### PR TITLE
Add API to release output buffer explicitly

### DIFF
--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -2105,6 +2105,16 @@ TRTSERVER2_InferenceRequestOutputShape(
 }
 
 TRTSERVER_Error*
+TRTSERVER2_InferenceRequestClearAllOutputs(
+    TRTSERVER2_InferenceRequest* inference_request)
+{
+  TrtInferenceRequest* lrequest =
+      reinterpret_cast<TrtInferenceRequest*>(inference_request);
+  lrequest->SetResponse(nullptr);
+  return nullptr;  // Success
+}
+
+TRTSERVER_Error*
 TRTSERVER2_ServerInferAsync(
     TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER2_InferenceRequest* inference_request,

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -1707,6 +1707,7 @@ TRTSERVER_ServerInferAsync(
   const auto& lrequest = ltrtrequest->Request();
   const auto& lbackend = ltrtrequest->Backend();
 
+  ltrtrequest->SetResponse(nullptr);
   RETURN_IF_STATUS_ERROR(lrequest->PrepareForInference(*lbackend));
 
 #ifdef TRTIS_ENABLE_STATS
@@ -2105,7 +2106,7 @@ TRTSERVER2_InferenceRequestOutputShape(
 }
 
 TRTSERVER_Error*
-TRTSERVER2_InferenceRequestClearAllOutputs(
+TRTSERVER2_InferenceRequestRemoveAllOutputs(
     TRTSERVER2_InferenceRequest* inference_request)
 {
   TrtInferenceRequest* lrequest =
@@ -2131,6 +2132,7 @@ TRTSERVER2_ServerInferAsync(
   const auto& lrequest = ltrtrequest->Request();
   const auto& lbackend = ltrtrequest->Backend();
 
+  ltrtrequest->SetResponse(nullptr);
   RETURN_IF_STATUS_ERROR(lrequest->PrepareForInference(*lbackend));
 
 #ifdef TRTIS_ENABLE_STATS

--- a/src/core/trtserver2.h
+++ b/src/core/trtserver2.h
@@ -297,11 +297,11 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER2_InferenceRequestOutputData(
     const void** base, size_t* byte_size, TRTSERVER_Memory_Type* memory_type,
     int64_t* memory_type_id);
 
-/// Clear all the output tensors. The meta data of the output tensors will
+/// Remove all the output tensors. The meta data of the output tensors will
 /// become unaccesible and the result data will be released.
 /// \param inference_request The request object.
 /// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER2_InferenceRequestClearAllOutputs(
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER2_InferenceRequestRemoveAllOutputs(
     TRTSERVER2_InferenceRequest* inference_request);
 
 /// Type for inference completion callback function. If non-nullptr,

--- a/src/core/trtserver2.h
+++ b/src/core/trtserver2.h
@@ -283,7 +283,7 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER2_InferenceRequestOutputShape(
 /// returned as the base pointer to the data and the size, in bytes,
 /// of the data. The caller does not own the returned data and must
 /// not modify or delete it. The lifetime of the returned data extends
-/// until 'inference_request' is or until 'inference_request' is
+/// until 'inference_request' is deleted or until 'inference_request' is
 /// reused in a call to TRTSERVER2_ServerInferAsync.
 /// \param inference_request The request object.
 /// \param name The name of the output.
@@ -296,6 +296,13 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER2_InferenceRequestOutputData(
     TRTSERVER2_InferenceRequest* inference_request, const char* name,
     const void** base, size_t* byte_size, TRTSERVER_Memory_Type* memory_type,
     int64_t* memory_type_id);
+
+/// Clear all the output tensors. The meta data of the output tensors will
+/// become unaccesible and the result data will be released.
+/// \param inference_request The request object.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER2_InferenceRequestClearAllOutputs(
+    TRTSERVER2_InferenceRequest* inference_request);
 
 /// Type for inference completion callback function. If non-nullptr,
 /// the 'trace_manager' object is the trace manager associated with


### PR DESCRIPTION
In the case of having pre-allocate buffer pool, we want to release the buffer back to the pool once it is done.