### PR TITLE
NGC Container Registry login not required.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,10 +38,7 @@ Installing Prebuilt Containers
 ------------------------------
 
 The inference server is provided as a pre-built container on the
-`NVIDIA GPU Cloud (NGC) <https://ngc.nvidia.com>`_.  Before pulling the
-container you must have access and be logged into the NGC container
-registry as explained in the `NGC Getting Started Guide
-<http://docs.nvidia.com/ngc/ngc-getting-started-guide/index.html>`_.
+`NVIDIA GPU Cloud (NGC) <https://ngc.nvidia.com>`_.
 
 Before you can pull a container from the NGC container registry, you
 must have Docker and nvidia-docker installed. For DGX users, this is

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -73,10 +73,6 @@ following prerequisite steps:
 If you are starting with a pre-built NGC container perform these
 additional steps:
 
-* Ensure you have access and are logged into NGC.  For step-by-step
-  instructions, see the `NGC Getting Started Guide
-  <http://docs.nvidia.com/ngc/ngc-getting-started-guide/index.html>`_.
-
 * Install Docker and nvidia-docker.  For DGX users, see `Preparing to
   use NVIDIA Containers
   <http://docs.nvidia.com/deeplearning/dgx/preparing-containers/index.html>`_.


### PR DESCRIPTION
I believe the NGC login requirement for pulling Triton was removed quite some time ago.  This step is definitely not needed now.

Signed-off-by: Niek Sanders <niek.sanders@gmail.com>