### PR TITLE
Update comment on ONNX Runtime OpenVINO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -383,10 +383,8 @@ COPY --chown=1000:1000 --from=trtserver_onnx /data/dldt/openvino_2019.3.376/tool
 ENV INTEL_CVSDK_DIR /opt/openvino_scripts/openvino_2019.3.376
 ENV PYTHONPATH /opt/openvino_scripts:$INTEL_CVSDK_DIR:$INTEL_CVSDK_DIR/deployment_tools/model_optimizer:$INTEL_CVSDK_DIR/tools:$PYTHONPATH
 
-# ONNX Runtime requires Python3 to convert ONNX models to OpenVINO models
-# in its OpenVINO execution accelerator.
-# [DLIS-1049] Needed to explicitly add test-generator==0.1.1 due to
-# OnnxRuntime 1.1.1 issue.
+# ONNX Runtime requires Python3 and additional packages to
+# convert ONNX models to OpenVINO models in its OpenVINO execution accelerator.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3-pip && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
test-generator is newly dependency added when ONNX Runtime uses a newer version of OpenVINO (2019 R3.1) https://github.com/microsoft/onnxruntime/blob/master/tools/ci_build/github/linux/docker/scripts/install_openvino.sh#L33