### PR TITLE
set_shape API for InferInput class

### DIFF
--- a/src/clients/python/experimental_api_v2/library/grpcclient.py
+++ b/src/clients/python/experimental_api_v2/library/grpcclient.py
@@ -1102,6 +1102,17 @@ class InferInput:
         """
         return self._input.shape
 
+    def set_shape(self, shape):
+        """Set the shape of input.
+
+        Parameters
+        ----------
+        shape : list
+            The shape of the associated input.
+        """
+        self._input.ClearField('shape')
+        self._input.shape.extend(shape)
+
     def set_data_from_numpy(self, input_tensor):
         """Set the tensor data from the specified numpy array for
         input associated with this object.

--- a/src/clients/python/experimental_api_v2/library/httpclient.py
+++ b/src/clients/python/experimental_api_v2/library/httpclient.py
@@ -1131,6 +1131,16 @@ class InferInput:
             The name of input
         """
         return self._name
+    
+    def datatype(self):
+        """Get the datatype of input associated with this object.
+
+        Returns
+        -------
+        str
+            The datatype of input
+        """
+        return self._datatype
 
     def shape(self):
         """Get the shape of input associated with this object.
@@ -1141,16 +1151,17 @@ class InferInput:
             The shape of input
         """
         return self._shape
+    
+    def set_shape(self, shape):
+        """Set the shape of input.
 
-    def datatype(self):
-        """Get the datatype of input associated with this object.
-
-        Returns
-        -------
-        str
-            The datatype of input
+        Parameters
+        ----------
+        shape : list
+            The shape of the associated input.
         """
-        return self._datatype
+        self._shape = shape
+
 
     def set_data_from_numpy(self, input_tensor, binary_data=True):
         """Set the tensor data from the specified numpy array for


### PR DESCRIPTION
This will be useful while dealing with dynamic shaped inputs. Users can use same InferInput object to send out requests with different shape and data.