### PR TITLE
Fix typo in ensemble and simple c++ clients

### DIFF
--- a/src/clients/c++/api_v1/examples/ensemble_image_client.cc
+++ b/src/clients/c++/api_v1/examples/ensemble_image_client.cc
@@ -106,7 +106,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "For -c, the <topk> classes will be returned, default is 1."
             << std::endl;
   std::cerr
-      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http."
+      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http'."
       << std::endl;
 
   exit(1);

--- a/src/clients/c++/api_v1/examples/simple_callback_client.cc
+++ b/src/clients/c++/api_v1/examples/simple_callback_client.cc
@@ -60,7 +60,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-u <URL for inference service>" << std::endl;
   std::cerr << std::endl;
   std::cerr
-      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http."
+      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http'."
       << std::endl;
 
   exit(1);

--- a/src/clients/c++/api_v1/examples/simple_client.cc.in
+++ b/src/clients/c++/api_v1/examples/simple_client.cc.in
@@ -66,7 +66,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-H <HTTP header>" << std::endl;
   std::cerr << std::endl;
   std::cerr
-      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http."
+      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http'."
       << std::endl;
   std::cerr
       << "For -H, header must be 'Header:Value'. May be given multiple times."

--- a/src/clients/c++/api_v1/examples/simple_perf_client.cc
+++ b/src/clients/c++/api_v1/examples/simple_perf_client.cc
@@ -464,7 +464,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-a" << std::endl;
   std::cerr << std::endl;
   std::cerr
-      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http."
+      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http'."
       << std::endl;
   std::cerr
       << "For -s, specify the input size in fp32 elements. So a value of 8 "

--- a/src/clients/c++/api_v1/examples/simple_string_client.cc
+++ b/src/clients/c++/api_v1/examples/simple_string_client.cc
@@ -58,7 +58,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-u <URL for inference service>" << std::endl;
   std::cerr << std::endl;
   std::cerr
-      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http."
+      << "For -i, available protocols are 'grpc' and 'http'. Default is 'http'."
       << std::endl;
 
   exit(1);


### PR DESCRIPTION
Corrected **available protocols are 'grpc' and 'http'. Default is 'http.** to **available protocols are 'grpc' and 'http'. Default is 'http'.**