### PR TITLE
Fix sequence batcher. Fix null request

### DIFF
--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -544,9 +544,13 @@ CustomBackend::Context::Run(
     if (custom_payloads[i].error_code == 0) {
       GetInputOutputContext* ocontext = static_cast<GetInputOutputContext*>(
           custom_payloads[i].output_context);
-      LOG_STATUS_ERROR(
-          InferenceResponse::Send(std::move(ocontext->response_)),
-          "failed to send custom backend response");
+      // response may not be created if the custom backend doesn't call
+      // GetOutput() on the output
+      if (ocontext->response_ != nullptr) {
+        LOG_STATUS_ERROR(
+            InferenceResponse::Send(std::move(ocontext->response_)),
+            "failed to send custom backend response");
+      }
       InferenceRequest::Release(std::move(requests[i]));
     } else {
       InferenceRequest::RespondWithError(

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -234,6 +234,8 @@ InferenceRequest::Release(std::unique_ptr<InferenceRequest>&& request)
        it != request->release_callbacks_.rend(); it++) {
     (*it)();
   }
+  request->release_callbacks_.clear();
+  
   void* userp = request->release_userp_;
   request->release_fn_(
       reinterpret_cast<TRITONSERVER_InferenceRequest*>(request.release()),

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -44,14 +44,12 @@ class PersistentBuffer {
   // Return a shared_ptr that is on heap so that it can be transferred as userp
   std::shared_ptr<char[]>* Buffer(size_t byte_size)
   {
-    {
-      std::lock_guard<std::mutex> lk(mtx_);
-      if (byte_size > byte_size_) {
-        byte_size_ = byte_size;
-        buffer_.reset(new char[byte_size]);
-      }
-      return new std::shared_ptr<char[]>(buffer_);
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (byte_size > byte_size_) {
+      byte_size_ = byte_size;
+      buffer_.reset(new char[byte_size]);
     }
+    return new std::shared_ptr<char[]>(buffer_);
   }
 
  private:

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -338,10 +338,10 @@ class InferenceRequest {
     return Status::Success;
   }
 
-  // Add a callback to be invoked on destruction. Multile callbacks
-  // can be added by calling this function in order, and they will be
-  // invoked in reversed order.
-  Status AddReleaseCallback(std::function<void()>&& callback)
+  // Add a callback to be invoked on releasing the request object from Triton.
+  // Multile callbacks can be added by calling this function in order,
+  // and they will be invoked in reversed order.
+  Status AddInternalReleaseCallback(std::function<void()>&& callback)
   {
     release_callbacks_.emplace_back(std::move(callback));
     return Status::Success;

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -183,14 +183,6 @@ class InferenceRequest {
   {
   }
 
-  ~InferenceRequest()
-  {
-    for (auto it = internal_callbacks_.rbegin();
-         it != internal_callbacks_.rend(); it++) {
-      (*it)();
-    }
-  }
-
   const std::string& ModelName() const;
   int64_t RequestedModelVersion() const { return requested_model_version_; }
   int64_t ActualModelVersion() const;
@@ -349,9 +341,9 @@ class InferenceRequest {
   // Add a callback to be invoked on destruction. Multile callbacks
   // can be added by calling this function in order, and they will be
   // invoked in reversed order.
-  Status AddInternalCallback(std::function<void()>&& callback)
+  Status AddReleaseCallback(std::function<void()>&& callback)
   {
-    internal_callbacks_.emplace_back(std::move(callback));
+    release_callbacks_.emplace_back(std::move(callback));
     return Status::Success;
   }
 
@@ -447,7 +439,7 @@ class InferenceRequest {
   // The response factory associated with this request.
   InferenceResponseFactory response_factory_;
 
-  std::vector<std::function<void()>> internal_callbacks_;
+  std::vector<std::function<void()>> release_callbacks_;
 };
 
 std::ostream& operator<<(std::ostream& out, const InferenceRequest& request);

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -1067,8 +1067,7 @@ DirectSequenceBatch::SchedulerThread(
             // Note that when the not-ready control input of the
             // request is "true" the model can't assume that any
             // other inputs are meaningful, including CORRID. So we
-            // just use zero for that and use whatever values the
-            // other inputs have in request_.
+            // just use zero for that.
             SetControlTensors(
                 ni, seq_slot, 0 /* corrid */, true /* not_ready */);
             requests.emplace_back(std::move(ni));
@@ -1282,7 +1281,7 @@ OldestSequenceBatch::CompleteAndNext(const uint32_t seq_slot)
                        << seq_slot;
         in_flight_[seq_slot] = true;
 
-        irequest->AddReleaseCallback(
+        irequest->AddInternalReleaseCallback(
             [this, seq_slot]() { CompleteAndNext(seq_slot); });
 
         dynamic_batcher_->Enqueue(irequest);

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -1081,14 +1081,14 @@ DirectSequenceBatch::SchedulerThread(
             SetControlTensors(
                 irequest, seq_slot, seq_slot_correlation_ids_[seq_slot]);
 
-            requests.emplace_back(std::move(irequest));
-
-            queue.pop_front();
-
             if ((irequest->Flags() & InferRequestHeader::FLAG_SEQUENCE_END) !=
                 0) {
               end_of_sequence = true;
             }
+
+            requests.emplace_back(std::move(irequest));
+
+            queue.pop_front();
           }
 
           // If the sequence has ended then attempt to refill the
@@ -1137,51 +1137,6 @@ DirectSequenceBatch::SchedulerThread(
     }
 
     if (!requests.empty()) {
-#if 0
-  // FIXME
-    auto OnCompleteQueuedPayloads = [payloads](const Status& rstatus) {
-        // Payloads that don't have a completion function don't have
-        // anywhere to report their errors. Those errors could have
-        // caused other payloads to have issues (due to mis-alignment
-        // within the batch, etc.). So if any such payload has an
-        // error we just fail all payloads.
-        Status status = rstatus;
-        if (status.IsOk()) {
-          for (auto& payload : *payloads) {
-            if (payload.complete_function_ == nullptr) {
-              if (!payload.status_.IsOk()) {
-                status = payload.status_;
-                break;
-              }
-            }
-          }
-        }
-
-        // Complete each payload by calling the competion function.
-#ifdef TRTIS_ENABLE_STATS
-        bool found_success = false;
-#endif  // TRTIS_ENABLE_STATS
-        for (auto& payload : *payloads) {
-          const Status& final_status = status.IsOk() ? payload.status_ : status;
-
-#ifdef TRTIS_ENABLE_STATS
-          // All the payloads executed together, so count 1 execution
-          // in the first successful payload. Other payloads stay at 0
-          // executions.
-          if (!found_success && final_status.IsOk() &&
-              (payload.stats_ != nullptr)) {
-            payload.stats_->SetModelExecutionCount(1);
-            found_success = true;
-          }
-#endif  // TRTIS_ENABLE_STATS
-
-          if (payload.complete_function_ != nullptr) {
-            payload.complete_function_(final_status);
-          }
-        }
-      };
-#endif
-
       // Run the backend...
       OnSchedule_(batcher_idx_, std::move(requests));
 
@@ -1274,18 +1229,9 @@ OldestSequenceBatch::OldestSequenceBatch(
 
 OldestSequenceBatch::~OldestSequenceBatch() {}
 
-#if 0  // FIXME
 void
-OldestSequenceBatch::CompleteAndNext(
-    const uint32_t seq_slot, std::function<void(const Status&)> OnComplete,
-    const Status& status)
+OldestSequenceBatch::CompleteAndNext(const uint32_t seq_slot)
 {
-  // If there is a completion function, call it to communicate the
-  // completion of the sequence's inference request.
-  if (OnComplete != nullptr) {
-    OnComplete(status);
-  }
-
   std::lock_guard<std::mutex> lock(mu_);
 
   // We may enqueue 1 or more pending inferences triggered by the
@@ -1296,7 +1242,7 @@ OldestSequenceBatch::CompleteAndNext(
   // being force-ended) then we try to fill the now-free sequence slot
   // from the backlog and then send the first inference from that
   // sequence to the dynamic batcher...
-  std::deque<Scheduler::Payload>& queue = queues_[seq_slot];
+  std::deque<std::unique_ptr<InferenceRequest>>& queue = queues_[seq_slot];
   bool retry = true;
   while (retry) {
     retry = false;
@@ -1307,8 +1253,7 @@ OldestSequenceBatch::CompleteAndNext(
     // If the next sequence inference is ready in the queue then enqueue
     // it in the dynamic batcher now.
     if (!queue.empty()) {
-      Scheduler::Payload& payload = queue.front();
-      const auto& irequest = payload.request_;
+      auto& irequest = queue.front();
 
       // If the request is null then this inference request is from
       // the reaper thread indicating a timed-out sequence. Mark that
@@ -1339,13 +1284,9 @@ OldestSequenceBatch::CompleteAndNext(
                        << seq_slot;
         in_flight_[seq_slot] = true;
 
-#if 0  // FIXME
-        auto on_complete_fn = std::bind(
-            &OldestSequenceBatch::CompleteAndNext, this, seq_slot,
-            payload.complete_function_, std::placeholders::_1);
-#endif
+        irequest->AddInternalCallback(
+            [this, seq_slot]() { CompleteAndNext(seq_slot); });
 
-        // FIXME handle error status.
         dynamic_batcher_->Enqueue(irequest);
       }
 
@@ -1384,7 +1325,6 @@ OldestSequenceBatch::CompleteAndNext(
     }
   }
 }
-#endif
 
 void
 OldestSequenceBatch::Enqueue(
@@ -1403,7 +1343,7 @@ OldestSequenceBatch::Enqueue(
   }
 
   if (!in_flight) {
-    //    CompleteAndNext(seq_slot, nullptr, Status::Success);
+    CompleteAndNext(seq_slot);
   }
 }
 

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -326,9 +326,7 @@ class OldestSequenceBatch : public SequenceBatch {
       std::unique_ptr<InferenceRequest>& request) override;
 
  private:
-  void CompleteAndNext(
-      const uint32_t seq_slot, std::function<void(const Status&)> OnComplete,
-      const Status& status);
+  void CompleteAndNext(const uint32_t seq_slot);
 
   // The dynamic batcher for this scheduler
   std::unique_ptr<Scheduler> dynamic_batcher_;


### PR DESCRIPTION
Manually tested using `simple_grpc_v2_sequence_sync_infer_client.py` and `simple_grpc_v2_sequence_stream_infer_client.py`. Also use sequence_sync_client with different length sequences to test null request.