### PR TITLE
Simplify shape tensor handling

### DIFF
--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -148,11 +148,7 @@ CustomBackend::CreateExecutionContexts(
           uint32_t runner_idx,
           std::vector<std::unique_ptr<InferenceRequest>>&& requests) {
         Run(runner_idx, std::move(requests));
-      },
-      [this](
-          uint32_t runner_idx, const InferenceRequest::Input& input,
-          const std::unique_ptr<InferenceRequest>& request,
-          std::vector<int64_t>* shape) -> Status { return Status::Success; }));
+      }));
 
   LOG_VERBOSE(1) << "custom backend for " << Name() << std::endl << *this;
   return Status::Success;

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -117,11 +117,7 @@ BaseBackend::CreateExecutionContexts(
           uint32_t runner_idx,
           std::vector<std::unique_ptr<InferenceRequest>>&& requests) {
         Run(runner_idx, std::move(requests));
-      },
-      [this](
-          uint32_t runner_idx, const InferenceRequest::Input& input,
-          const std::unique_ptr<InferenceRequest>& request,
-          std::vector<int64_t>* shape) -> Status { return Status::Success; }));
+      }));
 
   LOG_VERBOSE(1) << "backend for " << Name() << std::endl << *this;
 

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -68,10 +68,6 @@ class PlanBackend : public InferenceBackend {
   DISALLOW_COPY_AND_ASSIGN(PlanBackend);
   friend std::ostream& operator<<(std::ostream&, const PlanBackend&);
 
-  Status PeekShapeTensor(
-      uint32_t runner_idx, const InferenceRequest::Input& input,
-      const Scheduler::Payload& payload, std::vector<int64_t>* shape);
-
   // For each model instance there is a context.
   struct Context : BackendContext {
     Context(
@@ -118,11 +114,6 @@ class PlanBackend : public InferenceBackend {
 
     void ProcessResponse(
         size_t context_idx, std::shared_ptr<SyncQueue<size_t>> context_queue);
-
-    // See BackendContext::PeekShapeTensor()
-    Status PeekShapeTensor(
-        const InferenceRequest::Input& input, const Scheduler::Payload& payload,
-        std::vector<int64_t>* shape) override;
 
     // A struct to hold TensorRT execution context and its meta data, a backend
     // context can have multiple of this struct if multiple optimization

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -179,8 +179,7 @@ InferenceBackend::SetScheduler(std::unique_ptr<Scheduler> scheduler)
 Status
 InferenceBackend::SetConfiguredScheduler(
     const uint32_t runner_cnt, const Scheduler::StandardInitFunc& OnInit,
-    const Scheduler::StandardRunFunc& OnRun,
-    const Scheduler::StandardShapeTensorPeekFunc& OnPeek)
+    const Scheduler::StandardRunFunc& OnRun)
 {
   std::unique_ptr<Scheduler> scheduler;
 
@@ -239,7 +238,7 @@ InferenceBackend::SetConfiguredScheduler(
   if (config_.has_sequence_batching()) {
     // Sequence batcher
     RETURN_IF_ERROR(SequenceBatchScheduler::Create(
-        config_, runner_cnt, OnInit, OnWarmup, OnRun, OnPeek,
+        config_, runner_cnt, OnInit, OnWarmup, OnRun,
         enforce_equal_shape_tensors, &scheduler));
   } else if (config_.has_dynamic_batching()) {
     // Dynamic batcher
@@ -250,7 +249,7 @@ InferenceBackend::SetConfiguredScheduler(
 
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
         0 /* runner_id_start */, runner_cnt, GetCpuNiceLevel(config_), OnInit,
-        OnWarmup, OnRun, OnPeek, true /* dynamic_batching_enabled */,
+        OnWarmup, OnRun, true /* dynamic_batching_enabled */,
         enforce_equal_shape_tensors,
         config_.dynamic_batching().preserve_ordering(), preferred_batch_sizes,
         config_.dynamic_batching().max_queue_delay_microseconds(),
@@ -262,7 +261,7 @@ InferenceBackend::SetConfiguredScheduler(
     // disabled) as the default scheduler.
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
         0 /* runner_id_start */, runner_cnt, GetCpuNiceLevel(config_), OnInit,
-        OnWarmup, OnRun, OnPeek, false /* dynamic_batching_enabled */,
+        OnWarmup, OnRun, false /* dynamic_batching_enabled */,
         std::unordered_map<
             std::string, bool>() /* enforce_equal_shape_tensors */,
         false /* preserve_ordering */,

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -124,8 +124,7 @@ class InferenceBackend {
   // can only be set once for a backend.
   Status SetConfiguredScheduler(
       const uint32_t runner_cnt, const Scheduler::StandardInitFunc& OnInit,
-      const Scheduler::StandardRunFunc& OnRun,
-      const Scheduler::StandardShapeTensorPeekFunc& OnPeek);
+      const Scheduler::StandardRunFunc& OnRun);
 
   // Get the raw pointer to the scheduler of this backend.
   Scheduler* BackendScheduler() { return scheduler_.get(); }

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -62,7 +62,7 @@ GetContiguousInputContent(
   *cuda_copy = false;
   contiguous_buffer->reset();
 
-  // Peek input buffers to check if data copy is necessary
+  // Check input buffers to see if data copy is necessary
   MemoryReference input_buffers;
   size_t chunk_count = 0;
   bool type_mismatch = false;
@@ -400,16 +400,6 @@ BackendContext::CompareOutputDims(
   }
 
   return Status::Success;
-}
-
-Status
-BackendContext::PeekShapeTensor(
-    const InferenceRequest::Input& input,
-    const std::unique_ptr<InferenceRequest>& request,
-    std::vector<int64_t>* shape)
-{
-  // By default a backend doesn't support shape tensors.
-  return Status(Status::Code::INTERNAL, "shape tensors not supported");
 }
 
 //

--- a/src/core/backend_context.h
+++ b/src/core/backend_context.h
@@ -81,15 +81,6 @@ struct BackendContext {
       const InferenceBackend* base,
       std::vector<std::unique_ptr<InferenceRequest>>&& requests) = 0;
 
-  // Return the contents of a shape tensor. It is the caller's
-  // responsibility to call this only for shape tensors that are
-  // 1-dimensional, INT32 tensors. A non-OK status indicates that the
-  // contents of the tensor could not be peeked.
-  virtual Status PeekShapeTensor(
-      const InferenceRequest::Input& input,
-      const std::unique_ptr<InferenceRequest>& request,
-      std::vector<int64_t>* shape);
-
   // Helper function to populate the shape value of specified shape input
   // that corresponds with the batch size. The first shape value is asssumed
   // to be the batch size. Its the user's responsibility to ensure it is called

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -51,9 +51,7 @@ class DynamicBatchScheduler : public Scheduler {
   static Status Create(
       const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
       const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule,
-      const StandardShapeTensorPeekFunc& OnPeek,
-      const bool dynamic_batching_enabled,
+      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
@@ -66,9 +64,7 @@ class DynamicBatchScheduler : public Scheduler {
   static Status Create(
       const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
       const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule,
-      const StandardShapeTensorPeekFunc& OnPeek,
-      const bool dynamic_batching_enabled,
+      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
@@ -87,9 +83,7 @@ class DynamicBatchScheduler : public Scheduler {
   DynamicBatchScheduler(
       const uint32_t runner_id_start, const uint32_t runner_cnt,
       const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule,
-      const StandardShapeTensorPeekFunc& OnPeek,
-      const bool dynamic_batching_enabled,
+      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
@@ -116,9 +110,6 @@ class DynamicBatchScheduler : public Scheduler {
   // Function the scheduler will call to schedule a batch of requests.
   const StandardRunFunc OnSchedule_;
 
-  // Function the scheduler will call to peek at shape tensors.
-  const StandardShapeTensorPeekFunc OnPeek_;
-
   // True if dynamic batching is enabled.
   const bool dynamic_batching_enabled_;
 
@@ -144,7 +135,7 @@ class DynamicBatchScheduler : public Scheduler {
   std::set<int32_t> preferred_batch_sizes_;
   uint64_t pending_batch_delay_ns_;
   size_t pending_batch_size_;
-  PendingBatchShapes pending_batch_shapes_;
+  RequiredEqualInputs required_equal_inputs_;
 
   size_t queued_batch_size_;
   size_t next_preferred_batch_size_;

--- a/src/core/scheduler.h
+++ b/src/core/scheduler.h
@@ -65,16 +65,6 @@ class Scheduler {
       uint32_t runner_idx,
       std::vector<std::unique_ptr<InferenceRequest>>&& requests)>;
 
-  // The prototype for the shape-tensor peek function that can be
-  // called by the "standard" schedulers created based on a model's
-  // scheduling_choice settings. The peek function can be called to
-  // get the contents of a shape tensor. A non-OK error status
-  // indicates that the peek failed.
-  using StandardShapeTensorPeekFunc = std::function<Status(
-      uint32_t runner_idx, const InferenceRequest::Input& input,
-      const std::unique_ptr<InferenceRequest>& request,
-      std::vector<int64_t>* shape)>;
-
   // Enqueue a request with the scheduler. If Status::Success is returned
   // then the backend has taken ownership of the request object and so
   // 'request' will be nullptr. If non-success is returned then the

--- a/src/core/scheduler_utils.h
+++ b/src/core/scheduler_utils.h
@@ -33,20 +33,22 @@
 
 namespace nvidia { namespace inferenceserver {
 
-using PendingBatchShapes = std::unordered_map<
-    std::string, std::pair<std::vector<int64_t>, std::vector<int64_t>>>;
+using RequiredEqualInputs = std::unordered_map<
+    std::string,
+    std::pair<const InferenceRequest::Input*, bool /* compare contents */>>;
 
-Status InitPendingShape(
-    const int64_t runner_id, const std::unique_ptr<InferenceRequest>& request,
+Status InitRequiredEqualInputs(
+    const std::unique_ptr<InferenceRequest>& request,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
-    const Scheduler::StandardShapeTensorPeekFunc& OnPeek,
-    PendingBatchShapes* pending_batch_shapes);
+    RequiredEqualInputs* required_equal_inputs);
 
-bool CompareWithPendingShape(
-    const int64_t runner_id, const std::unique_ptr<InferenceRequest>& request,
-    const Scheduler::StandardShapeTensorPeekFunc& OnPeek,
-    const PendingBatchShapes& pending_batch_shapes);
+bool CompareWithRequiredEqualInputs(
+    const std::unique_ptr<InferenceRequest>& request,
+    const RequiredEqualInputs& required_equal_inputs);
 
+//
+// PriorityQueue
+//
 using ModelQueuePolicyMap =
     ::google::protobuf::Map<::google::protobuf::uint32, ModelQueuePolicy>;
 

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -59,7 +59,6 @@ class SequenceBatchScheduler : public Scheduler {
       const ModelConfig& config, const uint32_t runner_cnt,
       const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
       const StandardRunFunc& OnSchedule,
-      const StandardShapeTensorPeekFunc& OnPeek,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       std::unique_ptr<Scheduler>* scheduler);
 
@@ -236,7 +235,6 @@ class DirectSequenceBatch : public SequenceBatch {
       const Scheduler::StandardInitFunc& OnInit,
       const Scheduler::StandardWarmupFunc& OnWarmup,
       const Scheduler::StandardRunFunc& OnSchedule,
-      const Scheduler::StandardShapeTensorPeekFunc& OnPeek,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const std::shared_ptr<SequenceBatchScheduler::ControlInputs>&
           start_input_overrides,
@@ -266,9 +264,6 @@ class DirectSequenceBatch : public SequenceBatch {
 
   // Function to call to execute this batch of requests.
   const Scheduler::StandardRunFunc OnSchedule_;
-
-  // Function the scheduler will call to peek at shape tensors.
-  const Scheduler::StandardShapeTensorPeekFunc OnPeek_;
 
   // The thread scheduling requests that are queued in this batch.
   std::unique_ptr<std::thread> scheduler_thread_;
@@ -306,7 +301,6 @@ class OldestSequenceBatch : public SequenceBatch {
       const Scheduler::StandardInitFunc& OnInit,
       const Scheduler::StandardWarmupFunc& OnWarmup,
       const Scheduler::StandardRunFunc& OnSchedule,
-      const Scheduler::StandardShapeTensorPeekFunc& OnPeek,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const std::shared_ptr<SequenceBatchScheduler::ControlInputs>&
           start_input_overrides,


### PR DESCRIPTION
Require input shape tensors to be in contiguous CPU memory. This
removes the need for peek functionality and simplifies request
handling. If we need more functionality in the future we can promote
shape tensors to CPU memory early in request handling instead of where
we were doing it.