### PR TITLE
Skip shape manipulation for shape tensor

### DIFF
--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -535,6 +535,15 @@ InferenceRequest::NormalizeV2(const InferenceBackend& backend)
     batch_size_ = 0;
     for (auto& pr : original_inputs_) {
       auto& input = pr.second;
+
+      // Keep shape tensor's shape as it is
+      const ModelInput* input_config;
+      RETURN_IF_ERROR(backend.GetInput(pr.first, &input_config));
+      if (input_config->is_shape_tensor()) {
+        *input.MutableShape() = input.OriginalShape();
+        continue;
+      }
+
       if (input.OriginalShape().size() == 0) {
         return Status(
             Status::Code::INVALID_ARG,


### PR DESCRIPTION
@tanmayv25 I think we need modification like this on server side. The shape tensor value will not contain batch size.

In V2, for the config below, to send a request with batch size 4, the shapes of inputs will be:
`DUMMY_INPUT0 : [4, x, y]`; `INPUT0 : [2] (i.e. value: [32, 32])`. The output will be:
`DUMMY_OUTPUT0 : [4, 32, 32]`; `OUTPUT0 : [4, 2] (i.e. value: [[32, 32], [32, 32], [32, 32], [32, 32]])`. Then it is aligned with the V1 behavior.

```
# resize -> identity
...
max_batch_size: 8
input [
  {
    name: "DUMMY_INPUT0"
    data_type: TYPE_FP32
    dims: [ -1,-1 ]
  },
  {
    name: "INPUT0"
    data_type: TYPE_INT32
    dims: [ 2 ]
    is_shape_tensor: true
  }
]
output [
  {
    name: "DUMMY_OUTPUT0"
    data_type: TYPE_FP32
    dims: [ -1,-1 ]
  },
  {
    name: "OUTPUT0"
    data_type: TYPE_INT32
    dims: [ 2 ]
    is_shape_tensor: true
  }
]
```