### PR TITLE
Fixing Windows10 build for V2 client library (#1373)

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -144,7 +144,7 @@ management tool on Windows. The following shows how to install the dependencies
 using them, and you can also install the dependencies in other ways that you
 prefer::
 
-  > .\vcpkg.exe install openssl:x64-windows zlib:x64-windows
+  > .\vcpkg.exe install openssl:x64-windows zlib:x64-windows rapidjson:x64-windows
   > .\pip.exe install grpcio-tools wheel
 
 The vcpkg step above installs openssl and zlib, ":x64-windows" specifies the

--- a/qa/common/check_copyright.py
+++ b/qa/common/check_copyright.py
@@ -59,6 +59,8 @@ SKIP_PATHS = ('builddir',
               'qa/L0_perf_nomodel/baseline',
               'qa/L0_perf_nomodel/legacy_baseline',
               'qa/L0_warmup/raw_mug_data',
+              'src/clients/c++/experimental_api_v2/library/cencode.c',
+              'src/clients/c++/experimental_api_v2/library/cencode.h',
               'tools/patch',
               'VERSION')
 

--- a/src/clients/c++/experimental_api_v2/library/CMakeLists.txt
+++ b/src/clients/c++/experimental_api_v2/library/CMakeLists.txt
@@ -156,12 +156,12 @@ if(${TRTIS_ENABLE_HTTP_V2})
   # libhttpclient object build
   set(
     REQUEST_SRCS
-    http_client.cc common.cc
+    http_client.cc common.cc cencode.c
   )
 
   set(
     REQUEST_HDRS
-    http_client.h common.h
+    http_client.h common.h cencode.h
   )
 
   add_library(
@@ -197,7 +197,6 @@ if(${TRTIS_ENABLE_HTTP_V2})
   target_link_libraries(
     httpclient_static
     PRIVATE CURL::libcurl
-    PRIVATE -lb64
     PUBLIC Threads::Threads
   )
 
@@ -230,7 +229,6 @@ if(${TRTIS_ENABLE_HTTP_V2})
   target_link_libraries(
     httpclient
     PRIVATE CURL::libcurl
-    PRIVATE -lb64
     PUBLIC Threads::Threads
   )
 

--- a/src/clients/c++/experimental_api_v2/library/cencode.c
+++ b/src/clients/c++/experimental_api_v2/library/cencode.c
@@ -1,0 +1,109 @@
+/*
+cencoder.c - c source to a base64 encoding algorithm implementation
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#include <src/clients/c++/experimental_api_v2/library/cencode.h>
+
+const int CHARS_PER_LINE = 72;
+
+void base64_init_encodestate(base64_encodestate* state_in)
+{
+	state_in->step = step_A;
+	state_in->result = 0;
+	state_in->stepcount = 0;
+}
+
+char base64_encode_value(char value_in)
+{
+	static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	if (value_in > 63) return '=';
+	return encoding[(int)value_in];
+}
+
+int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in)
+{
+	const char* plainchar = plaintext_in;
+	const char* const plaintextend = plaintext_in + length_in;
+	char* codechar = code_out;
+	char result;
+	char fragment;
+	
+	result = state_in->result;
+	
+	switch (state_in->step)
+	{
+		while (1)
+		{
+	case step_A:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_A;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result = (fragment & 0x0fc) >> 2;
+			*codechar++ = base64_encode_value(result);
+			result = (fragment & 0x003) << 4;
+	case step_B:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_B;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result |= (fragment & 0x0f0) >> 4;
+			*codechar++ = base64_encode_value(result);
+			result = (fragment & 0x00f) << 2;
+	case step_C:
+			if (plainchar == plaintextend)
+			{
+				state_in->result = result;
+				state_in->step = step_C;
+				return codechar - code_out;
+			}
+			fragment = *plainchar++;
+			result |= (fragment & 0x0c0) >> 6;
+			*codechar++ = base64_encode_value(result);
+			result  = (fragment & 0x03f) >> 0;
+			*codechar++ = base64_encode_value(result);
+			
+			++(state_in->stepcount);
+			if (state_in->stepcount == CHARS_PER_LINE/4)
+			{
+				*codechar++ = '\n';
+				state_in->stepcount = 0;
+			}
+		}
+	}
+	/* control should not reach here */
+	return codechar - code_out;
+}
+
+int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
+{
+	char* codechar = code_out;
+	
+	switch (state_in->step)
+	{
+	case step_B:
+		*codechar++ = base64_encode_value(state_in->result);
+		*codechar++ = '=';
+		*codechar++ = '=';
+		break;
+	case step_C:
+		*codechar++ = base64_encode_value(state_in->result);
+		*codechar++ = '=';
+		break;
+	case step_A:
+		break;
+	}
+	*codechar++ = '\n';
+	
+	return codechar - code_out;
+}
+

--- a/src/clients/c++/experimental_api_v2/library/cencode.h
+++ b/src/clients/c++/experimental_api_v2/library/cencode.h
@@ -1,0 +1,29 @@
+/*
+cencode.h - c header for a base64 encoding algorithm
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#ifndef BASE64_CENCODE_H
+#define BASE64_CENCODE_H
+
+typedef enum { step_A, step_B, step_C } base64_encodestep;
+
+typedef struct {
+  base64_encodestep step;
+  char result;
+  int stepcount;
+} base64_encodestate;
+
+void base64_init_encodestate(base64_encodestate* state_in);
+
+char base64_encode_value(char value_in);
+
+int base64_encode_block(
+    const char* plaintext_in, int length_in, char* code_out,
+    base64_encodestate* state_in);
+
+int base64_encode_blockend(char* code_out, base64_encodestate* state_in);
+
+#endif /* BASE64_CENCODE_H */

--- a/src/clients/c++/experimental_api_v2/library/common.cc
+++ b/src/clients/c++/experimental_api_v2/library/common.cc
@@ -228,7 +228,7 @@ InferInput::GetNext(
 
   while ((bufs_idx_ < bufs_.size()) && (size > 0)) {
     const size_t buf_byte_size = buf_byte_sizes_[bufs_idx_];
-    const size_t csz = std::min(buf_byte_size - buf_pos_, size);
+    const size_t csz = (std::min)(buf_byte_size - buf_pos_, size);
     if (csz > 0) {
       const uint8_t* input_ptr = bufs_[bufs_idx_] + buf_pos_;
       std::copy(input_ptr, input_ptr + csz, buf);

--- a/src/clients/c++/experimental_api_v2/library/common.h
+++ b/src/clients/c++/experimental_api_v2/library/common.h
@@ -29,6 +29,7 @@
 
 #include "src/core/constants.h"
 
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <cstring>

--- a/src/clients/c++/experimental_api_v2/library/http_client.cc
+++ b/src/clients/c++/experimental_api_v2/library/http_client.cc
@@ -32,8 +32,12 @@
 #include <queue>
 
 extern "C" {
-#include <b64/cencode.h>
+#include <src/clients/c++/experimental_api_v2/library/cencode.h>
 }
+
+#ifdef _WIN32
+#define strncasecmp(x, y, z) _strnicmp(x, y, z)
+#endif  //_WIN32
 
 namespace nvidia { namespace inferenceserver { namespace client {
 
@@ -210,7 +214,7 @@ HttpInferRequest::GetNextInput(uint8_t* buf, size_t size, size_t* input_bytes)
   }
 
   while (!data_buffers_.empty() && size > 0) {
-    const size_t csz = std::min(data_buffers_.front().second, size);
+    const size_t csz = (std::min)(data_buffers_.front().second, size);
     if (csz > 0) {
       const uint8_t* input_ptr = data_buffers_.front().first;
       std::copy(input_ptr, input_ptr + csz, buf);


### PR DESCRIPTION
* Fixing Windows10 build for V2 client library

* Include algortihms.h unconditionally

* Removing unnecessary linker flags

* Format fixes