### PR TITLE
Fix L0_trt_shape_tensors

### DIFF
--- a/qa/L0_trt_shape_tensors/test.sh
+++ b/qa/L0_trt_shape_tensors/test.sh
@@ -132,73 +132,72 @@ for i in \
         wait $SERVER_PID
     done
 
-# FIXME skip sequence testing until the utils are fixed
-# for i in \
-#             test_sequence_different_shape_values \
-#             test_sequence_identical_shape_values ; do
-#         export TRTSERVER_BACKLOG_DELAY_SCHEDULER=0
-#         export TRTSERVER_DELAY_SCHEDULER=12
-#         SERVER_LOG="./$i.serverlog"
-#         run_server
-#         if [ "$SERVER_PID" == "0" ]; then
-#             echo -e "\n***\n*** Failed to start $SERVER\n***"
-#             cat $SERVER_LOG
-#             exit 1
-#         fi
+for i in \
+            test_sequence_different_shape_values \
+            test_sequence_identical_shape_values ; do
+        export TRTSERVER_BACKLOG_DELAY_SCHEDULER=0
+        export TRTSERVER_DELAY_SCHEDULER=12
+        SERVER_LOG="./$i.serverlog"
+        run_server
+        if [ "$SERVER_PID" == "0" ]; then
+            echo -e "\n***\n*** Failed to start $SERVER\n***"
+            cat $SERVER_LOG
+            exit 1
+        fi
 
-#         echo "Test: $i, $model_type" >>$CLIENT_LOG
+        echo "Test: $i, $model_type" >>$CLIENT_LOG
 
-#         set +e
-#         python $SHAPE_TENSOR_TEST SequenceBatcherShapeTensorTest.$i >>$CLIENT_LOG 2>&1
-#         if [ $? -ne 0 ]; then
-#             echo -e "\n***\n*** Test $i Failed\n***" >>$CLIENT_LOG
-#             echo -e "\n***\n*** Test Failed $i\n***"
-#             RET=1
-#         fi
-#         set -e
+        set +e
+        python $SHAPE_TENSOR_TEST SequenceBatcherShapeTensorTest.$i >>$CLIENT_LOG 2>&1
+        if [ $? -ne 0 ]; then
+            echo -e "\n***\n*** Test $i Failed\n***" >>$CLIENT_LOG
+            echo -e "\n***\n*** Test Failed $i\n***"
+            RET=1
+        fi
+        set -e
 
-#         unset TRTSERVER_DELAY_SCHEDULER
-#         unset TRTSERVER_BACKLOG_DELAY_SCHEDULER
-#         kill $SERVER_PID
-#         wait $SERVER_PID
-#     done
+        unset TRTSERVER_DELAY_SCHEDULER
+        unset TRTSERVER_BACKLOG_DELAY_SCHEDULER
+        kill $SERVER_PID
+        wait $SERVER_PID
+    done
 
-# # Prepare the config file for dynamic sequence batching tests
-# CONFIG_FILE="models/plan_dyna_sequence_float32/config.pbtxt"
-# sed -i "s/max_candidate_sequences:.*/max_candidate_sequences:4/" $CONFIG_FILE && \
-# sed -i "s/max_queue_delay_microseconds:.*/max_queue_delay_microseconds:5000000/" $CONFIG_FILE
+# Prepare the config file for dynamic sequence batching tests
+CONFIG_FILE="models/plan_dyna_sequence_float32/config.pbtxt"
+sed -i "s/max_candidate_sequences:.*/max_candidate_sequences:4/" $CONFIG_FILE && \
+sed -i "s/max_queue_delay_microseconds:.*/max_queue_delay_microseconds:5000000/" $CONFIG_FILE
 
-# export NO_BATCHING=0
+export NO_BATCHING=0
 
-# for i in \
-#     test_dynaseq_identical_shape_values_series \
-#     test_dynaseq_identical_shape_values_parallel \
-#     test_dynaseq_different_shape_values_series \
-#     test_dynaseq_different_shape_values_parallel \
-#     ;do
-#     SERVER_ARGS="--model-repository=`pwd`/models --api-version=2"
-#     SERVER_LOG="./$i.serverlog"
-#     run_server
-#     if [ "$SERVER_PID" == "0" ]; then
-#         echo -e "\n***\n*** Failed to start $SERVER\n***"
-#         cat $SERVER_LOG
-#         exit 1
-#     fi
+for i in \
+    test_dynaseq_identical_shape_values_series \
+    test_dynaseq_identical_shape_values_parallel \
+    test_dynaseq_different_shape_values_series \
+    test_dynaseq_different_shape_values_parallel \
+    ;do
+    SERVER_ARGS="--model-repository=`pwd`/models --api-version=2"
+    SERVER_LOG="./$i.serverlog"
+    run_server
+    if [ "$SERVER_PID" == "0" ]; then
+        echo -e "\n***\n*** Failed to start $SERVER\n***"
+        cat $SERVER_LOG
+        exit 1
+    fi
 
-#     echo "Test: $i" >>$CLIENT_LOG
+    echo "Test: $i" >>$CLIENT_LOG
 
-#     set +e
-#     python $SHAPE_TENSOR_TEST DynaSequenceBatcherTest.$i >>$CLIENT_LOG 2>&1
-#     if [ $? -ne 0 ]; then
-#         echo -e "\n***\n*** Test $i Failed\n***" >>$CLIENT_LOG
-#         echo -e "\n***\n*** Test $i Failed\n***"
-#         RET=1
-#     fi
-#     set -e
+    set +e
+    python $SHAPE_TENSOR_TEST DynaSequenceBatcherTest.$i >>$CLIENT_LOG 2>&1
+    if [ $? -ne 0 ]; then
+        echo -e "\n***\n*** Test $i Failed\n***" >>$CLIENT_LOG
+        echo -e "\n***\n*** Test $i Failed\n***"
+        RET=1
+    fi
+    set -e
 
-#     kill $SERVER_PID
-#     wait $SERVER_PID
-# done
+    kill $SERVER_PID
+    wait $SERVER_PID
+done
 
 grep -c "HTTPSocketPoolResponse status=200" $CLIENT_LOG
 if [ $? -ne 0 ]; then

--- a/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
+++ b/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
@@ -39,8 +39,6 @@ import test_util as tu
 import sequence_util as su
 
 import tritongrpcclient.core as grpcclient
-import tritongrpcclient.utils as grpcutils
-import tritonhttpclient.utils as httputils
 import os
 
 TEST_SYSTEM_SHARED_MEMORY = bool(int(os.environ.get('TEST_SYSTEM_SHARED_MEMORY', 0)))
@@ -317,8 +315,6 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
         dtype = np.float32
         try:
             model_name = tu.get_sequence_model_name("plan", dtype)
-            protocol = "streaming"
-
             self.check_setup(model_name)
 
             # Need scheduler to wait for queue to contain all
@@ -349,11 +345,9 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                         (("start", 2, 1, None), (None, 4, 2, None), ("end", 8,
                                                                      3, None)),
                         self.get_expected_result(6, 3, "end"),
-                        protocol,
                         precreated_shm0_handles),
                     kwargs={
-                        'sequence_name':
-                            "{}_{}".format(self._testMethodName, protocol)
+                        'sequence_name': "{}".format(self._testMethodName)
                     }))
             threads.append(
                 threading.Thread(
@@ -367,11 +361,9 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                         (("start", 2, 11, None), (None, 4, 12, None),
                          ("end", 8, 13, None)),
                         self.get_expected_result(36, 13, "end"),
-                        protocol,
                         precreated_shm1_handles),
                     kwargs={
-                        'sequence_name':
-                            "{}_{}".format(self._testMethodName, protocol)
+                        'sequence_name': "{}".format(self._testMethodName)
                     }))
             threads.append(
                 threading.Thread(
@@ -385,11 +377,9 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                         (("start", 2, 111, None), (None, 4, 112, None),
                          ("end", 8, 113, None)),
                         self.get_expected_result(336, 113, "end"),
-                        protocol,
                         precreated_shm2_handles),
                     kwargs={
-                        'sequence_name':
-                            "{}_{}".format(self._testMethodName, protocol)
+                        'sequence_name': "{}".format(self._testMethodName)
                     }))
             threads.append(
                 threading.Thread(
@@ -403,11 +393,9 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                         (("start", 2, 1111, None), (None, 4, 1112, None),
                          ("end", 8, 1113, None)),
                         self.get_expected_result(3336, 1113, "end"),
-                        protocol,
                         precreated_shm3_handles),
                     kwargs={
-                        'sequence_name':
-                            "{}_{}".format(self._testMethodName, protocol)
+                        'sequence_name': "{}".format(self._testMethodName)
                     }))
 
             for t in threads:
@@ -445,8 +433,6 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
             ((1, 1111), (1, 1112), (1, 1113)), dtype, 3)
         try:
             model_name = tu.get_sequence_model_name("plan", dtype)
-            protocol = "streaming"
-
             self.check_setup(model_name)
 
             # Need scheduler to wait for queue to contain all
@@ -470,11 +456,9 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                         (("start", 1, 1, None), (None, 1, 2, None), ("end", 1,
                                                                      3, None)),
                         self.get_expected_result(6, 3, "end"),
-                        protocol,
                         precreated_shm0_handles),
                     kwargs={
-                        'sequence_name':
-                            "{}_{}".format(self._testMethodName, protocol)
+                        'sequence_name': "{}".format(self._testMethodName)
                     }))
             threads.append(
                 threading.Thread(
@@ -488,11 +472,9 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                         (("start", 32, 11, None), (None, 32, 12, None),
                          ("end", 32, 13, None)),
                         self.get_expected_result(36, 13, "end"),
-                        protocol,
                         precreated_shm1_handles),
                     kwargs={
-                        'sequence_name':
-                            "{}_{}".format(self._testMethodName, protocol)
+                        'sequence_name': "{}".format(self._testMethodName)
                     }))
             threads.append(
                 threading.Thread(
@@ -506,11 +488,9 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                         (("start", 16, 111, None), (None, 16, 112, None),
                          ("end", 16, 113, None)),
                         self.get_expected_result(336, 113, "end"),
-                        protocol,
                         precreated_shm2_handles),
                     kwargs={
-                        'sequence_name':
-                            "{}_{}".format(self._testMethodName, protocol)
+                        'sequence_name': "{}".format(self._testMethodName)
                     }))
             threads.append(
                 threading.Thread(
@@ -524,11 +504,9 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                         (("start", 1, 1111, None), (None, 1, 1112, None),
                          ("end", 1, 1113, None)),
                         self.get_expected_result(3336, 1113, "end"),
-                        protocol,
                         precreated_shm3_handles),
                     kwargs={
-                        'sequence_name':
-                            "{}_{}".format(self._testMethodName, protocol)
+                        'sequence_name': "{}".format(self._testMethodName)
                     }))
 
             for t in threads:
@@ -575,8 +553,6 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
 
         try:
             model_name = tu.get_dyna_sequence_model_name("plan", dtype)
-            protocol = "streaming"
-
             self.check_setup(model_name)
             self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
             self.assertFalse("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
@@ -596,12 +572,10 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
                                                                       3, None)),
                         self.get_expected_result(4 + corrids[0], corrids[0], 3,
                                                  "end"),
-                        protocol,
                         precreated_shm0_handles),
                     kwargs={
                         'sequence_name':
-                            "{}_{}_{}".format(self._testMethodName, protocol,
-                                              corrids[0]),
+                            "{}_{}".format(self._testMethodName, corrids[0]),
                         'using_dynamic_batcher':
                             True
                     }))
@@ -618,12 +592,10 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
                          ("end", 5, 13, None)),
                         self.get_expected_result(36 + corrids[1], corrids[1],
                                                  13, "end"),
-                        protocol,
                         precreated_shm1_handles),
                     kwargs={
                         'sequence_name':
-                            "{}_{}_{}".format(self._testMethodName, protocol,
-                                              corrids[1]),
+                            "{}_{}".format(self._testMethodName, corrids[1]),
                         'using_dynamic_batcher':
                             True
                     }))
@@ -640,12 +612,10 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
                          ("end", 8, 113, None)),
                         self.get_expected_result(336 + corrids[2], corrids[2],
                                                  113, "end"),
-                        protocol,
                         precreated_shm2_handles),
                     kwargs={
                         'sequence_name':
-                            "{}_{}_{}".format(self._testMethodName, protocol,
-                                              corrids[2]),
+                            "{}_{}".format(self._testMethodName, corrids[2]),
                         'using_dynamic_batcher':
                             True
                     }))
@@ -662,12 +632,10 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
                          ("end", 11, 1113, None)),
                         self.get_expected_result(3336 + corrids[3], corrids[3],
                                                  1113, "end"),
-                        protocol,
                         precreated_shm3_handles),
                     kwargs={
                         'sequence_name':
-                            "{}_{}_{}".format(self._testMethodName, protocol,
-                                              corrids[3]),
+                            "{}_{}".format(self._testMethodName, corrids[3]),
                         'using_dynamic_batcher':
                             True
                     }))
@@ -704,7 +672,6 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
 
         try:
             model_name = tu.get_dyna_sequence_model_name("plan", dtype)
-            protocol = "streaming"
 
             self.check_setup(model_name)
             self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
@@ -725,12 +692,10 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
                                                                      3, None)),
                         self.get_expected_result(4 + corrids[0], corrids[0], 3,
                                                  "end"),
-                        protocol,
                         precreated_shm0_handles),
                     kwargs={
                         'sequence_name':
-                            "{}_{}_{}".format(self._testMethodName, protocol,
-                                              corrids[0]),
+                            "{}_{}".format(self._testMethodName, corrids[0]),
                         'using_dynamic_batcher':
                             True
                     }))
@@ -747,12 +712,10 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
                          ("end", 8, 13, None)),
                         self.get_expected_result(36 + corrids[1], corrids[1],
                                                  13, "end"),
-                        protocol,
                         precreated_shm1_handles),
                     kwargs={
                         'sequence_name':
-                            "{}_{}_{}".format(self._testMethodName, protocol,
-                                              corrids[1]),
+                            "{}_{}".format(self._testMethodName, corrids[1]),
                         'using_dynamic_batcher':
                             True
                     }))
@@ -769,12 +732,10 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
                          ("end", 8, 113, None)),
                         self.get_expected_result(336 + corrids[2], corrids[2],
                                                  113, "end"),
-                        protocol,
                         precreated_shm2_handles),
                     kwargs={
                         'sequence_name':
-                            "{}_{}_{}".format(self._testMethodName, protocol,
-                                              corrids[2]),
+                            "{}_{}".format(self._testMethodName, corrids[2]),
                         'using_dynamic_batcher':
                             True
                     }))
@@ -791,12 +752,10 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
                          ("end", 8, 1113, None)),
                         self.get_expected_result(3336 + corrids[3], corrids[3],
                                                  1113, "end"),
-                        protocol,
                         precreated_shm3_handles),
                     kwargs={
                         'sequence_name':
-                            "{}_{}_{}".format(self._testMethodName, protocol,
-                                              corrids[3]),
+                            "{}_{}".format(self._testMethodName, corrids[3]),
                         'using_dynamic_batcher':
                             True
                     }))

--- a/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
+++ b/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
@@ -139,7 +139,8 @@ class InferShapeTensorTest(unittest.TestCase):
                         "expected model-inference-count {}, got {}".format(
                                 infer_cnt, actual_infer_cnt))
 
-        # FIXME Uncomment below after syncing with 'response'.
+        # FIXME Uncomment below after updated V2 statistics schema from
+        # 'response' branch.
         # Before that, batch stats is not reported
 
         # batch_stats = stats.model_stats[0].batch_stats
@@ -254,7 +255,7 @@ class InferShapeTensorTest(unittest.TestCase):
             for t in threads:
                 t.join()
             self.check_deferred_exception()
-            self.check_status(model_name, {3: 2}, 2)
+            self.check_status(model_name, {3: 2}, 6)
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
 
@@ -291,7 +292,7 @@ class InferShapeTensorTest(unittest.TestCase):
             for t in threads:
                 t.join()
             self.check_deferred_exception()
-            self.check_status(model_name, {6: 1}, 2)
+            self.check_status(model_name, {6: 1}, 6)
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
 

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -456,3 +456,189 @@ def infer_exact(tester, pf, tensor_shape, batch_size,
                                       use_system_shared_memory, use_cuda_shared_memory)
 
     return results
+
+# Perform inference on a model that takes a shape and a dummy tensors as inputs,
+# resize the dummy tensor with the provided values in the shape tensor and finally
+# return the shape of the resized tensor.
+def infer_shape_tensor(tester, pf, tensor_dtype, input_shape_values, dummy_input_shapes,
+               use_http=True, use_grpc=True,
+               use_streaming=True, shm_suffix="", use_system_shared_memory=False,
+               use_cuda_shared_memory=False, priority=0, timeout_us=0,
+               batch_size=1):
+    tester.assertTrue(use_http or use_grpc or use_streaming)
+    tester.assertTrue(pf == "plan" or pf == "plan_nobatch")
+    tester.assertEqual(len(input_shape_values), len(dummy_input_shapes))
+    if use_system_shared_memory and use_cuda_shared_memory:
+        raise ValueError("Cannot set both System and CUDA shared memory flags to 1")
+
+    configs = []
+    if use_http:
+        configs.append(("localhost:8000", "http", False))
+    if use_grpc:
+        configs.append(("localhost:8001", "grpc", False))
+    if use_streaming:
+        configs.append(("localhost:8001", "grpc", True))
+
+    io_cnt = len(input_shape_values)
+
+    # FIXME wrap up shm handle cleanup
+    # For (cuda) shared memory, it's only set for shape tensor for simplicity.
+    # Regular tensor with (cuda) shared memory should be well-tested in other
+    # tests.
+    # item is (handle, byte_size, is_cuda)
+    input_shm_handle_list = []
+    output_shm_handle_list= []
+    dummy_input_list = []
+    input_list = []
+    expected_dict = dict()
+    # Prepare IO in advance
+    for io_num in range(io_cnt):
+        dummy_input_name = "DUMMY_INPUT{}".format(io_num)
+        input_name = "INPUT{}".format(io_num)
+        dummy_output_name = "DUMMY_OUTPUT{}".format(io_num)
+        output_name = "OUTPUT{}".format(io_num)
+
+        # Prepare the dummy tensor
+        rtensor_dtype = _range_repr_dtype(tensor_dtype)
+        if (rtensor_dtype != np.bool):
+            dummy_in0 = np.random.randint(low=np.iinfo(rtensor_dtype).min,
+                                    high=np.iinfo(rtensor_dtype).max,
+                                    size=dummy_input_shapes[io_num], dtype=rtensor_dtype)
+        else:
+            dummy_in0 = np.random.choice(a=[False, True], size=dummy_input_shapes[io_num])
+        if tensor_dtype != np.object:
+            dummy_in0 = dummy_in0.astype(tensor_dtype)
+        else:
+            dummy_in0 = np.array([str(x) for x in dummy_in0.flatten()],
+                            dtype=object).reshape(dummy_in0.shape)
+        dummy_input_list.append(dummy_in0)
+
+        # Prepare shape input tensor
+        in0 = np.asarray(input_shape_values[io_num], dtype=np.int32)
+        input_list.append(in0)
+
+        # Prepare the expected value for the output. Skip dummy output as we
+        # only care about its shape (== value of OUTPUT*)
+        expected_dict[output_name] = np.ndarray.copy(in0)
+
+        # Only need to create region once
+        input_byte_size = in0.size * np.dtype(np.int32).itemsize
+        output_byte_size = input_byte_size * batch_size
+        if use_system_shared_memory:
+            input_shm_handle_list.append((shm.create_shared_memory_region(input_name+shm_suffix,
+                                                            '/'+input_name+shm_suffix, input_byte_size), input_byte_size, False))
+            output_shm_handle_list.append((shm.create_shared_memory_region(output_name+shm_suffix,
+                                                            '/'+output_name+shm_suffix, output_byte_size), output_byte_size, False))
+            shm.set_shared_memory_region(input_shm_handle_list[-1][0], [in0,])
+        elif use_cuda_shared_memory:
+            input_shm_handle_list.append((cudashm.create_shared_memory_region(input_name+shm_suffix,
+                                                            input_byte_size, 0), input_byte_size, True))
+            output_shm_handle_list.append((cudashm.create_shared_memory_region(output_name+shm_suffix,
+                                                            output_byte_size, 0), output_byte_size, True))
+            cudashm.set_shared_memory_region(input_shm_handle_list[-1][0], [in0,])
+
+    model_name = tu.get_zero_model_name(pf, io_cnt, tensor_dtype)
+    # Run inference and check results for each config
+    for config in configs:
+        client_utils = grpcclient if config[1] == "grpc" else httpclient
+        triton_client = client_utils.InferenceServerClient(config[0], verbose=True)
+
+        inputs = []
+        outputs = []
+
+        # Set IOs
+        for io_num in range(io_cnt):
+            dummy_input_name = "DUMMY_INPUT{}".format(io_num)
+            input_name = "INPUT{}".format(io_num)
+            dummy_output_name = "DUMMY_OUTPUT{}".format(io_num)
+            output_name = "OUTPUT{}".format(io_num)
+
+            inputs.append(client_utils.InferInput(
+                dummy_input_name, dummy_input_shapes[io_num],
+                np_to_triton_dtype(tensor_dtype)))
+            inputs.append(client_utils.InferInput(
+                input_name, input_list[io_num].shape, "INT32"))
+            outputs.append(client_utils.InferRequestedOutput(
+                dummy_output_name))
+            outputs.append(client_utils.InferRequestedOutput(
+                output_name))
+
+            # -2: dummy; -1: input
+            inputs[-2].set_data_from_numpy(dummy_input_list[io_num])
+            if (not use_system_shared_memory) and (not use_cuda_shared_memory):
+                inputs[-1].set_data_from_numpy(input_list[io_num])
+            else:
+                input_byte_size = input_shm_handle_list[io_num][1]
+                output_byte_size = output_shm_handle_list[io_num][1]
+                if use_system_shared_memory:
+                    triton_client.register_system_shared_memory(input_name+shm_suffix, "/"+input_name+shm_suffix, input_byte_size)
+                    triton_client.register_system_shared_memory(output_name+shm_suffix, "/"+output_name+shm_suffix, output_byte_size)
+                else:
+                    triton_client.register_cuda_shared_memory(input_name+shm_suffix, cudashm.get_raw_handle(input_shm_handle_list[io_num][0]), 0, input_byte_size)
+                    triton_client.register_cuda_shared_memory(output_name+shm_suffix, cudashm.get_raw_handle(output_shm_handle_list[io_num][0]), 0, output_byte_size)
+                inputs[-1].set_shared_memory(input_name+shm_suffix, input_byte_size)
+                outputs[-1].set_shared_memory(output_name+shm_suffix, output_byte_size)
+            
+        # FIXME streaming needs async handling
+        results = triton_client.infer(model_name, inputs,
+                                      outputs=outputs,
+                                      priority=priority, timeout=timeout_us)
+
+        for io_num in range(io_cnt):
+            output_name = "OUTPUT{}".format(io_num)
+            dummy_output_name = "DUMMY_OUTPUT{}".format(io_num)
+            expected = expected_dict[output_name]
+
+            # get outputs as numpy array
+            dummy_out = results.as_numpy(dummy_output_name)
+            if (not use_system_shared_memory) and (not use_cuda_shared_memory):
+                out = results.as_numpy(output_name)
+            else:
+                output = results.get_output(output_name)
+                if config[1] == "grpc":
+                    output_shape = output.shape
+                else:
+                    output_shape = output["shape"]
+                if use_system_shared_memory:
+                    out = shm.get_contents_as_numpy(output_shm_handle_list[io_num][0], np.int32, output_shape)
+                else:
+                    out = cudashm.get_contents_as_numpy(output_shm_handle_list[io_num][0], np.int32, output_shape)
+
+            # if out shape is 2D, it is batched
+            if (len(out.shape) == 2):
+                # The shape of the dummy output should be equal to the shape values
+                # specified in the shape tensor
+                tester.assertTrue(np.array_equal(dummy_out.shape[1:], out[0]),
+                                  "{}, {} shape, expected: {}, got {}".format(
+                                      model_name, dummy_output_name, out[0], dummy_out.shape[1:]))
+                for b in range(1, out.shape[0]):
+                    tester.assertTrue(np.array_equal(out[b-1], out[b]),
+                                      "expect shape tensor has consistent value, "
+                                      "expected: {}, got {}".format(out[b-1], out[b]))
+                out = out[0]
+            else:
+                tester.assertTrue(np.array_equal(dummy_out.shape, out),
+                                  "{}, {} shape, expected: {}, got {}".format(
+                                      model_name, dummy_output_name, out, dummy_out.shape))
+            tester.assertTrue(np.array_equal(out, expected),
+                              "{}, {}, expected: {}, got {}".format(
+                              model_name, output_name, expected, out))
+
+            # unregister shared memory region for next config
+            if use_system_shared_memory:
+                triton_client.unregister_system_shared_memory(input_name+shm_suffix)
+                triton_client.unregister_system_shared_memory(output_name+shm_suffix)
+            elif use_cuda_shared_memory:
+                triton_client.unregister_cuda_shared_memory(input_name+shm_suffix)
+                triton_client.unregister_cuda_shared_memory(output_name+shm_suffix)
+
+    for handle in input_shm_handle_list:
+        if (handle[2]):
+            cudashm.destroy_shared_memory_region(handle[0])
+        else:
+            shm.destroy_shared_memory_region(handle[0])
+    for handle in output_shm_handle_list:
+        if (handle[2]):
+            cudashm.destroy_shared_memory_region(handle[0])
+        else:
+            shm.destroy_shared_memory_region(handle[0])

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -768,7 +768,8 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                         "expected model-inference-count {}, got {}".format(
                                 infer_cnt, actual_infer_cnt))
 
-        # FIXME Uncomment below after syncing with 'response'.
+        # FIXME Uncomment below after updated V2 statistics schema from
+        # 'response' branch.
         # Before that, batch stats is not reported
 
         # config = self.triton_client_.get_model_config(model_name).config


### PR DESCRIPTION
Manually tested regular, system shared memory, and cuda shared memory (w/o HTTP).
Note that the `check_status` is changed as infer stats is collected differently in V2:
- batch infer is reported based on total batch size of the execution instead of batch size of the request
- ~~infer count is incremented by 1 for each request, instead of by the batch size of the request.~~

@CoderHam Note that I touched some sequence utilities, please check if those changes make sense to you.