### PR TITLE
Relax check on tensor size to allow for empty string tensors

### DIFF
--- a/src/clients/python/experimental_api_v2/library/utils.py
+++ b/src/clients/python/experimental_api_v2/library/utils.py
@@ -186,7 +186,7 @@ def serialize_byte_tensor(input_tensor):
         """
 
     if input_tensor.size == 0:
-        raise_error("input cannot be empty")
+        return np.empty([0])
 
     # If the input is a tensor of string/bytes objects, then must flatten those into
     # a 1-dimensional array containing the 4-byte byte size followed by the

--- a/src/servers/http_server_v2.cc
+++ b/src/servers/http_server_v2.cc
@@ -712,12 +712,12 @@ void
 WriteDataToJsonHelper(
     rapidjson::Value* response_output_val,
     rapidjson::Document::AllocatorType& allocator,
-    const rapidjson::Value& shape, int shape_index, T* base, int* counter,
+    const rapidjson::Value& shape, size_t shape_index, T* base, int* counter,
     const DataType dtype)
 {
-  if (shape_index == (int)shape.Size()) {
+  if (shape_index == shape.Size()) {
     if (dtype != TYPE_STRING) {
-      rapidjson::Value data_val((T)(base[*counter]));
+      rapidjson::Value data_val(base[*counter]);
       response_output_val->PushBack(data_val, allocator);
       *counter += 1;
     } else {
@@ -729,7 +729,7 @@ WriteDataToJsonHelper(
     }
   } else {
     for (int i = 0; i < shape[shape_index].GetInt(); i++) {
-      if ((shape_index + 1) != (int)shape.Size()) {
+      if ((shape_index + 1) != shape.Size()) {
         rapidjson::Value response_output_array(rapidjson::kArrayType);
         WriteDataToJsonHelper(
             &response_output_array, allocator, shape, shape_index + 1, base,
@@ -737,7 +737,7 @@ WriteDataToJsonHelper(
         response_output_val->PushBack(response_output_array, allocator);
       } else {
         if (dtype != TYPE_STRING) {
-          rapidjson::Value data_val((T)(base[*counter]));
+          rapidjson::Value data_val(base[*counter]);
           response_output_val->PushBack(data_val, allocator);
           *counter += 1;
         } else {
@@ -764,7 +764,7 @@ WriteDataToJson(
 
   rapidjson::Value data_array(rapidjson::kArrayType);
   int counter = 0;
-  for (int i = 0; i < shape[0].GetInt(); i++) {
+  for (size_t i = 0; i < size_t(shape[0].GetInt()); i++) {
     rapidjson::Value data_val(rapidjson::kArrayType);
     switch (dtype) {
       case TYPE_BOOL: {


### PR DESCRIPTION
Needed to allow for client library to pass empty string tensors to the server. Follow up changes for #1396