### PR TITLE
Reorganizing triton client utilities

### DIFF
--- a/docs/experimental_grpc_python_api.rst
+++ b/docs/experimental_grpc_python_api.rst
@@ -35,7 +35,7 @@ This module contains most of the core functionality of the library
 including setting up a connection, sending requests and receiving
 response to/from an active Triton server.
 
-.. automodule:: tritongrpcclient.grpcclient
+.. automodule:: tritongrpcclient
    :members:
 
 Client Utils

--- a/docs/experimental_grpc_python_api.rst
+++ b/docs/experimental_grpc_python_api.rst
@@ -35,7 +35,7 @@ This module contains most of the core functionality of the library
 including setting up a connection, sending requests and receiving
 response to/from an active Triton server.
 
-.. automodule:: tritongrpcclient.core
+.. automodule:: tritongrpcclient.grpcclient
    :members:
 
 Client Utils
@@ -43,5 +43,5 @@ Client Utils
 
 This module exposes additional supporting utilities.
 
-.. automodule:: tritongrpcclient.utils
+.. automodule:: tritonclientutils.utils
    :members:

--- a/src/clients/python/experimental_api_v2/examples/grpc_v2_explicit_byte_content_client.py
+++ b/src/clients/python/experimental_api_v2/examples/grpc_v2_explicit_byte_content_client.py
@@ -32,7 +32,7 @@ import numpy as np
 import grpc
 from tritongrpcclient import grpc_service_v2_pb2
 from tritongrpcclient import grpc_service_v2_pb2_grpc
-from tritongrpcclient import utils
+from tritonclientutils import utils
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_async_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_async_infer_client.py
@@ -31,7 +31,7 @@ import numpy as np
 import time
 import sys
 
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = grpcclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))
@@ -62,8 +62,8 @@ if __name__ == '__main__':
     # Infer
     inputs = []
     outputs = []
-    inputs.append(grpcclient.InferInput('INPUT0', [1, 16], "INT32"))
-    inputs.append(grpcclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritongrpcclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritongrpcclient.InferInput('INPUT1', [1, 16], "INT32"))
 
     # Create the data for the two input tensors. Initialize the first
     # to unique integers and the second to all ones.
@@ -75,12 +75,12 @@ if __name__ == '__main__':
     inputs[0].set_data_from_numpy(input0_data)
     inputs[1].set_data_from_numpy(input1_data)
 
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT0'))
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT1'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT0'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT1'))
 
     # Define the callback function. Note the last two parameters should be
     # result and error. InferenceServerClient would povide the results of an
-    # inference as tritongrpcclient.grpcclient.InferResult in result. For successful
+    # inference as tritongrpcclient.InferResult in result. For successful
     # inference, error will be None, otherwise it will be an object of
     # tritonclientutils.utils.InferenceServerException holding the error details
     def callback(user_data, result, error):

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_async_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_async_infer_client.py
@@ -31,8 +31,8 @@ import numpy as np
 import time
 import sys
 
-import tritongrpcclient.core as grpcclient
-from tritongrpcclient.utils import InferenceServerException
+import tritongrpcclient.grpcclient as grpcclient
+from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -80,9 +80,9 @@ if __name__ == '__main__':
 
     # Define the callback function. Note the last two parameters should be
     # result and error. InferenceServerClient would povide the results of an
-    # inference as tritongrpcclient.core.InferResult in result. For successful
+    # inference as tritongrpcclient.grpcclient.InferResult in result. For successful
     # inference, error will be None, otherwise it will be an object of
-    # tritongrpcclient.utils.InferenceServerException holding the error details
+    # tritonclientutils.utils.InferenceServerException holding the error details
     def callback(user_data, result, error):
         if error:
             user_data.append(error)

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_cudashm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_cudashm_client.py
@@ -30,7 +30,7 @@ import numpy as np
 import os
 import sys
 from builtins import range
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 import tritonclientutils.cuda_shared_memory as cudashm
 import tritonclientutils.utils as utils
 from ctypes import *
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
 
     try:
-        triton_client = grpcclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("channel creation failed: " + str(e))
@@ -115,17 +115,17 @@ if __name__ == '__main__':
 
     # Set the parameters to use data from shared memory
     inputs = []
-    inputs.append(grpcclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritongrpcclient.InferInput('INPUT0', [1, 16], "INT32"))
     inputs[-1].set_shared_memory("input0_data", input_byte_size)
 
-    inputs.append(grpcclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritongrpcclient.InferInput('INPUT1', [1, 16], "INT32"))
     inputs[-1].set_shared_memory("input1_data", input_byte_size)
 
     outputs = []
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT0'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT0'))
     outputs[-1].set_shared_memory("output0_data", output_byte_size)
 
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT1'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT1'))
     outputs[-1].set_shared_memory("output1_data", output_byte_size)
 
     results = triton_client.infer(model_name=model_name,

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_cudashm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_cudashm_client.py
@@ -30,9 +30,9 @@ import numpy as np
 import os
 import sys
 from builtins import range
-import tritongrpcclient.core as grpcclient
-import tritonsharedmemoryutils.cuda_shared_memory as cudashm
-import tritongrpcclient.utils as utils
+import tritongrpcclient.grpcclient as grpcclient
+import tritonclientutils.cuda_shared_memory as cudashm
+import tritonclientutils.utils as utils
 from ctypes import *
 
 FLAGS = None

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_health_metadata.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_health_metadata.py
@@ -27,7 +27,7 @@
 
 import argparse
 
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
@@ -47,7 +47,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = grpcclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_health_metadata.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_health_metadata.py
@@ -27,8 +27,8 @@
 
 import argparse
 
-import tritongrpcclient.core as grpcclient
-from tritongrpcclient.utils import InferenceServerException
+import tritongrpcclient.grpcclient as grpcclient
+from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_infer_client.py
@@ -29,7 +29,7 @@ import argparse
 import numpy as np
 import sys
 
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -48,7 +48,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = grpcclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("channel creation failed: " + str(e))
@@ -59,8 +59,8 @@ if __name__ == '__main__':
     # Infer
     inputs = []
     outputs = []
-    inputs.append(grpcclient.InferInput('INPUT0', [1, 16], "INT32"))
-    inputs.append(grpcclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritongrpcclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritongrpcclient.InferInput('INPUT1', [1, 16], "INT32"))
 
     # Create the data for the two input tensors. Initialize the first
     # to unique integers and the second to all ones.
@@ -72,8 +72,8 @@ if __name__ == '__main__':
     inputs[0].set_data_from_numpy(input0_data)
     inputs[1].set_data_from_numpy(input1_data)
 
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT0'))
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT1'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT0'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT1'))
 
     # Test with outputs
     results = triton_client.infer(model_name=model_name,

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_infer_client.py
@@ -29,7 +29,7 @@ import argparse
 import numpy as np
 import sys
 
-import tritongrpcclient.core as grpcclient
+import tritongrpcclient.grpcclient as grpcclient
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_model_control.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_model_control.py
@@ -29,8 +29,8 @@ import argparse
 import time
 import sys
 
-import tritongrpcclient.core as grpcclient
-from tritongrpcclient.utils import InferenceServerException
+import tritongrpcclient.grpcclient as grpcclient
+from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_model_control.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_model_control.py
@@ -29,7 +29,7 @@ import argparse
 import time
 import sys
 
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
@@ -49,7 +49,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = grpcclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_sequence_stream_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_sequence_stream_infer_client.py
@@ -31,7 +31,7 @@ import numpy as np
 import sys
 import queue
 
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 from tritonclientutils.utils import InferenceServerException
 
 FLAGS = None
@@ -45,7 +45,7 @@ class UserData:
 
 # Define the callback function. Note the last two parameters should be
 # result and error. InferenceServerClient would povide the results of an
-# inference as tritongrpcclient.grpcclient.InferResult in result. For successful
+# inference as tritongrpcclient.InferResult in result. For successful
 # inference, error will be None, otherwise it will be an object of
 # tritonclientutils.utils.InferenceServerException holding the error details
 def callback(user_data, result, error):
@@ -65,11 +65,11 @@ def async_stream_send(triton_client, values, batch_size, sequence_id,
                              fill_value=value,
                              dtype=np.int32)
         inputs = []
-        inputs.append(grpcclient.InferInput('INPUT', value_data.shape, "INT32"))
+        inputs.append(tritongrpcclient.InferInput('INPUT', value_data.shape, "INT32"))
         # Initialize the data
         inputs[0].set_data_from_numpy(value_data)
         outputs = []
-        outputs.append(grpcclient.InferRequestedOutput('OUTPUT'))
+        outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT'))
         # Issue the asynchronous sequence inference.
         triton_client.async_stream_infer(model_name=model_name,
                                          inputs=inputs,
@@ -136,7 +136,7 @@ if __name__ == '__main__':
     # It is advisable to use client object within with..as clause
     # when sending streaming requests. This ensures the client
     # is closed when the block inside with exits.
-    with grpcclient.InferenceServerClient(
+    with tritongrpcclient.InferenceServerClient(
             url=FLAGS.url, verbose=FLAGS.verbose) as triton_client:
         try:
             # Establish stream

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_sequence_stream_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_sequence_stream_infer_client.py
@@ -31,8 +31,8 @@ import numpy as np
 import sys
 import queue
 
-import tritongrpcclient.core as grpcclient
-from tritongrpcclient.utils import InferenceServerException
+import tritongrpcclient.grpcclient as grpcclient
+from tritonclientutils.utils import InferenceServerException
 
 FLAGS = None
 
@@ -45,9 +45,9 @@ class UserData:
 
 # Define the callback function. Note the last two parameters should be
 # result and error. InferenceServerClient would povide the results of an
-# inference as tritongrpcclient.core.InferResult in result. For successful
+# inference as tritongrpcclient.grpcclient.InferResult in result. For successful
 # inference, error will be None, otherwise it will be an object of
-# tritongrpcclient.utils.InferenceServerException holding the error details
+# tritonclientutils.utils.InferenceServerException holding the error details
 def callback(user_data, result, error):
     if error:
         user_data._completed_requests.put(error)

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_sequence_sync_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_sequence_sync_infer_client.py
@@ -30,8 +30,8 @@ import numpy as np
 import sys
 import queue
 
-import tritongrpcclient.core as grpcclient
-from tritongrpcclient.utils import InferenceServerException
+import tritongrpcclient.grpcclient as grpcclient
+from tritonclientutils.utils import InferenceServerException
 
 FLAGS = None
 

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_sequence_sync_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_sequence_sync_infer_client.py
@@ -30,7 +30,7 @@ import numpy as np
 import sys
 import queue
 
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 from tritonclientutils.utils import InferenceServerException
 
 FLAGS = None
@@ -52,11 +52,11 @@ def sync_send(triton_client, result_list, values, batch_size, sequence_id,
                              fill_value=value,
                              dtype=np.int32)
         inputs = []
-        inputs.append(grpcclient.InferInput('INPUT', value_data.shape, "INT32"))
+        inputs.append(tritongrpcclient.InferInput('INPUT', value_data.shape, "INT32"))
         # Initialize the data
         inputs[0].set_data_from_numpy(value_data)
         outputs = []
-        outputs.append(grpcclient.InferRequestedOutput('OUTPUT'))
+        outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT'))
         # Issue the synchronous sequence inference.
         result = triton_client.infer(model_name=model_name,
                                      inputs=inputs,
@@ -100,7 +100,7 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
 
     try:
-        triton_client = grpcclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_shm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_shm_client.py
@@ -30,9 +30,9 @@ import numpy as np
 import os
 import sys
 from builtins import range
-import tritongrpcclient.core as grpcclient
-import tritonsharedmemoryutils.shared_memory as shm
-import tritongrpcclient.utils as utils
+import tritongrpcclient.grpcclient as grpcclient
+import tritonclientutils.shared_memory as shm
+import tritonclientutils.utils as utils
 from ctypes import *
 
 FLAGS = None

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_shm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_shm_client.py
@@ -30,7 +30,7 @@ import numpy as np
 import os
 import sys
 from builtins import range
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 import tritonclientutils.shared_memory as shm
 import tritonclientutils.utils as utils
 from ctypes import *
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
 
     try:
-        triton_client = grpcclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("channel creation failed: " + str(e))
@@ -117,17 +117,17 @@ if __name__ == '__main__':
 
     # Set the parameters to use data from shared memory
     inputs = []
-    inputs.append(grpcclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritongrpcclient.InferInput('INPUT0', [1, 16], "INT32"))
     inputs[-1].set_shared_memory("input0_data", input_byte_size)
 
-    inputs.append(grpcclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritongrpcclient.InferInput('INPUT1', [1, 16], "INT32"))
     inputs[-1].set_shared_memory("input1_data", input_byte_size)
 
     outputs = []
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT0'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT0'))
     outputs[-1].set_shared_memory("output0_data", output_byte_size)
 
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT1'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT1'))
     outputs[-1].set_shared_memory("output1_data", output_byte_size)
 
     results = triton_client.infer(model_name=model_name,

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_string_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_string_infer_client.py
@@ -28,7 +28,7 @@
 import argparse
 import numpy as np
 
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -47,7 +47,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = grpcclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))
@@ -57,8 +57,8 @@ if __name__ == '__main__':
 
     inputs = []
     outputs = []
-    inputs.append(grpcclient.InferInput('INPUT0', [1, 16], "BYTES"))
-    inputs.append(grpcclient.InferInput('INPUT1', [1, 16], "BYTES"))
+    inputs.append(tritongrpcclient.InferInput('INPUT0', [1, 16], "BYTES"))
+    inputs.append(tritongrpcclient.InferInput('INPUT1', [1, 16], "BYTES"))
 
     # Create the data for the two input tensors. Initialize the first
     # to unique integers and the second to all ones.
@@ -77,8 +77,8 @@ if __name__ == '__main__':
     inputs[0].set_data_from_numpy(input0_data)
     inputs[1].set_data_from_numpy(input1_data)
 
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT0'))
-    outputs.append(grpcclient.InferRequestedOutput('OUTPUT1'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT0'))
+    outputs.append(tritongrpcclient.InferRequestedOutput('OUTPUT1'))
 
     results = triton_client.infer(model_name=model_name,
                                   inputs=inputs,

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_string_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_string_infer_client.py
@@ -28,7 +28,7 @@
 import argparse
 import numpy as np
 
-import tritongrpcclient.core as grpcclient
+import tritongrpcclient.grpcclient as grpcclient
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_async_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_async_infer_client.py
@@ -31,8 +31,8 @@ import numpy as np
 import sys
 import gevent
 
-import tritonhttpclient.core as httpclient
-from tritonhttpclient.utils import InferenceServerException
+import tritonhttpclient.httpclient as httpclient
+from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -83,9 +83,9 @@ if __name__ == '__main__':
 
     # Define the callback function. Note the last two parameters should be
     # result and error. InferenceServerClient would povide the results of an
-    # inference as tritongrpcclient.core.InferResult in result. For successful
+    # inference as tritongrpcclient.grpcclient.InferResult in result. For successful
     # inference, error will be None, otherwise it will be an object of
-    # tritongrpcclient.utils.InferenceServerException holding the error details.
+    # tritonclientutils.utils.InferenceServerException holding the error details.
     def callback(user_data, result, error):
         if not error:
             user_data.append(result)

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_async_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_async_infer_client.py
@@ -31,7 +31,7 @@ import numpy as np
 import sys
 import gevent
 
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = httpclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritonhttpclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))
@@ -62,8 +62,8 @@ if __name__ == '__main__':
     # Infer
     inputs = []
     outputs = []
-    inputs.append(httpclient.InferInput('INPUT0', [1, 16], "INT32"))
-    inputs.append(httpclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT1', [1, 16], "INT32"))
 
     # Create the data for the two input tensors. Initialize the first
     # to unique integers and the second to all ones.
@@ -76,14 +76,14 @@ if __name__ == '__main__':
     inputs[0].set_data_from_numpy(input0_data, binary_data=False)
     inputs[1].set_data_from_numpy(input1_data, binary_data=False)
 
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT0',
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT0',
                                                    binary_data=False))
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT1',
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT1',
                                                    binary_data=False))
 
     # Define the callback function. Note the last two parameters should be
     # result and error. InferenceServerClient would povide the results of an
-    # inference as tritongrpcclient.grpcclient.InferResult in result. For successful
+    # inference as tritongrpcclient.InferResult in result. For successful
     # inference, error will be None, otherwise it will be an object of
     # tritonclientutils.utils.InferenceServerException holding the error details.
     def callback(user_data, result, error):

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_cudashm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_cudashm_client.py
@@ -29,7 +29,7 @@ import argparse
 import numpy as np
 import sys
 from builtins import range
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 import tritonclientutils.cuda_shared_memory as cudashm
 import tritonclientutils.utils as utils
 
@@ -53,7 +53,7 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
 
     try:
-        triton_client = httpclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritonhttpclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("channel creation failed: " + str(e))
@@ -113,18 +113,18 @@ if __name__ == '__main__':
 
     # Set the parameters to use data from shared memory
     inputs = []
-    inputs.append(httpclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT0', [1, 16], "INT32"))
     inputs[-1].set_shared_memory("input0_data", input_byte_size)
 
-    inputs.append(httpclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT1', [1, 16], "INT32"))
     inputs[-1].set_shared_memory("input1_data", input_byte_size)
 
     outputs = []
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT0',
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT0',
                                                    binary_data=False))
     outputs[-1].set_shared_memory("output0_data", output_byte_size)
 
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT1',
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT1',
                                                    binary_data=False))
     outputs[-1].set_shared_memory("output1_data", output_byte_size)
 

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_cudashm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_cudashm_client.py
@@ -29,9 +29,9 @@ import argparse
 import numpy as np
 import sys
 from builtins import range
-import tritonhttpclient.core as httpclient
-import tritonsharedmemoryutils.cuda_shared_memory as cudashm
-import tritonhttpclient.utils as utils
+import tritonhttpclient.httpclient as httpclient
+import tritonclientutils.cuda_shared_memory as cudashm
+import tritonclientutils.utils as utils
 
 FLAGS = None
 

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_health_metadata.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_health_metadata.py
@@ -28,7 +28,7 @@
 import argparse
 import sys
 
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
@@ -48,7 +48,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = httpclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritonhttpclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_health_metadata.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_health_metadata.py
@@ -28,8 +28,8 @@
 import argparse
 import sys
 
-import tritonhttpclient.core as httpclient
-from tritonhttpclient.utils import InferenceServerException
+import tritonhttpclient.httpclient as httpclient
+from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_infer_client.py
@@ -29,8 +29,8 @@ import argparse
 import numpy as np
 import sys
 
-import tritonhttpclient.core as httpclient
-from tritonhttpclient.utils import InferenceServerException
+import tritonhttpclient.httpclient as httpclient
+from tritonclientutils.utils import InferenceServerException
 
 def test_infer(model_name, input0_data, input1_data):
     inputs = []

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_infer_client.py
@@ -29,21 +29,21 @@ import argparse
 import numpy as np
 import sys
 
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 from tritonclientutils.utils import InferenceServerException
 
 def test_infer(model_name, input0_data, input1_data):
     inputs = []
     outputs = []
-    inputs.append(httpclient.InferInput('INPUT0', [1, 16], "INT32"))
-    inputs.append(httpclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT1', [1, 16], "INT32"))
 
     # Initialize the data
     inputs[0].set_data_from_numpy(input0_data, binary_data=False)
     inputs[1].set_data_from_numpy(input1_data, binary_data=True)
 
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT0', binary_data=True))
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT1',
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT0', binary_data=True))
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT1',
                                                    binary_data=False))
     query_params = {'test_1': 1, 'test_2': 2}
     results = triton_client.infer(model_name,
@@ -56,8 +56,8 @@ def test_infer(model_name, input0_data, input1_data):
 
 def test_infer_no_outputs(model_name, input0_data, input1_data):
     inputs = []
-    inputs.append(httpclient.InferInput('INPUT0', [1, 16], "INT32"))
-    inputs.append(httpclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT1', [1, 16], "INT32"))
 
     # Initialize the data
     inputs[0].set_data_from_numpy(input0_data, binary_data=False)
@@ -89,7 +89,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = httpclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritonhttpclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("channel creation failed: " + str(e))

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_model_control.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_model_control.py
@@ -28,7 +28,7 @@
 import argparse
 import sys
 
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
@@ -48,7 +48,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = httpclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritonhttpclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_model_control.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_model_control.py
@@ -28,8 +28,8 @@
 import argparse
 import sys
 
-import tritonhttpclient.core as httpclient
-from tritonhttpclient.utils import InferenceServerException
+import tritonhttpclient.httpclient as httpclient
+from tritonclientutils.utils import InferenceServerException
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_sequence_sync_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_sequence_sync_infer_client.py
@@ -30,8 +30,8 @@ import numpy as np
 import sys
 import queue
 
-import tritonhttpclient.core as httpclient
-from tritonhttpclient.utils import InferenceServerException
+import tritonhttpclient.httpclient as httpclient
+from tritonclientutils.utils import InferenceServerException
 
 FLAGS = None
 

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_sequence_sync_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_sequence_sync_infer_client.py
@@ -30,7 +30,7 @@ import numpy as np
 import sys
 import queue
 
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 from tritonclientutils.utils import InferenceServerException
 
 FLAGS = None
@@ -52,13 +52,13 @@ def sync_send(triton_client, result_list, values, batch_size, sequence_id,
                              fill_value=value,
                              dtype=np.int32)
         inputs = []
-        inputs.append(httpclient.InferInput('INPUT', value_data.shape, "INT32"))
+        inputs.append(tritonhttpclient.InferInput('INPUT', value_data.shape, "INT32"))
         # Initialize the data
         # FIXME, negative value in binary form can't be handled properly,
         # which causes the library to raise decode exception.
         inputs[0].set_data_from_numpy(value_data, binary_data=False)
         outputs = []
-        outputs.append(httpclient.InferRequestedOutput('OUTPUT'))
+        outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT'))
         # Issue the synchronous sequence inference.
         result = triton_client.infer(model_name=model_name,
                                      inputs=inputs,
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
 
     try:
-        triton_client = httpclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritonhttpclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_shm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_shm_client.py
@@ -29,9 +29,9 @@ import argparse
 import numpy as np
 import sys
 from builtins import range
-import tritonhttpclient.core as httpclient
-import tritonsharedmemoryutils.shared_memory as shm
-import tritonhttpclient.utils as utils
+import tritonhttpclient.httpclient as httpclient
+import tritonclientutils.shared_memory as shm
+import tritonclientutils.utils as utils
 
 FLAGS = None
 

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_shm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_shm_client.py
@@ -29,7 +29,7 @@ import argparse
 import numpy as np
 import sys
 from builtins import range
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 import tritonclientutils.shared_memory as shm
 import tritonclientutils.utils as utils
 
@@ -53,7 +53,7 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
 
     try:
-        triton_client = httpclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritonhttpclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("channel creation failed: " + str(e))
@@ -115,18 +115,18 @@ if __name__ == '__main__':
 
     # Set the parameters to use data from shared memory
     inputs = []
-    inputs.append(httpclient.InferInput('INPUT0', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT0', [1, 16], "INT32"))
     inputs[-1].set_shared_memory("input0_data", input_byte_size)
 
-    inputs.append(httpclient.InferInput('INPUT1', [1, 16], "INT32"))
+    inputs.append(tritonhttpclient.InferInput('INPUT1', [1, 16], "INT32"))
     inputs[-1].set_shared_memory("input1_data", input_byte_size)
 
     outputs = []
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT0',
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT0',
                                                    binary_data=False))
     outputs[-1].set_shared_memory("output0_data", output_byte_size)
 
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT1',
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT1',
                                                    binary_data=False))
     outputs[-1].set_shared_memory("output1_data", output_byte_size)
 

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_string_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_string_infer_client.py
@@ -29,7 +29,7 @@ import argparse
 import numpy as np
 import sys
 
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 
 
 def TestIdentityInference(np_array, binary_data):
@@ -37,11 +37,11 @@ def TestIdentityInference(np_array, binary_data):
     inputs = []
     outputs = []
 
-    inputs.append(httpclient.InferInput('INPUT0', np_array.shape, "BYTES"))
+    inputs.append(tritonhttpclient.InferInput('INPUT0', np_array.shape, "BYTES"))
     inputs[0].set_data_from_numpy(np_array, binary_data=binary_data)
 
     outputs.append(
-        httpclient.InferRequestedOutput('OUTPUT0', binary_data=binary_data))
+        tritonhttpclient.InferRequestedOutput('OUTPUT0', binary_data=binary_data))
 
     results = triton_client.infer(model_name=model_name,
                                   inputs=inputs,
@@ -74,7 +74,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        triton_client = httpclient.InferenceServerClient(url=FLAGS.url,
+        triton_client = tritonhttpclient.InferenceServerClient(url=FLAGS.url,
                                                          verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))
@@ -84,8 +84,8 @@ if __name__ == '__main__':
 
     inputs = []
     outputs = []
-    inputs.append(httpclient.InferInput('INPUT0', [1, 16], "BYTES"))
-    inputs.append(httpclient.InferInput('INPUT1', [1, 16], "BYTES"))
+    inputs.append(tritonhttpclient.InferInput('INPUT0', [1, 16], "BYTES"))
+    inputs.append(tritonhttpclient.InferInput('INPUT1', [1, 16], "BYTES"))
 
     # Create the data for the two input tensors. Initialize the first
     # to unique integers and the second to all ones.
@@ -104,8 +104,8 @@ if __name__ == '__main__':
     inputs[0].set_data_from_numpy(input0_data, binary_data=True)
     inputs[1].set_data_from_numpy(input1_data, binary_data=False)
 
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT0', binary_data=True))
-    outputs.append(httpclient.InferRequestedOutput('OUTPUT1',
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT0', binary_data=True))
+    outputs.append(tritonhttpclient.InferRequestedOutput('OUTPUT1',
                                                    binary_data=False))
 
     results = triton_client.infer(model_name=model_name,

--- a/src/clients/python/experimental_api_v2/examples/simple_http_v2_string_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_http_v2_string_infer_client.py
@@ -29,7 +29,7 @@ import argparse
 import numpy as np
 import sys
 
-import tritonhttpclient.core as httpclient
+import tritonhttpclient.httpclient as httpclient
 
 
 def TestIdentityInference(np_array, binary_data):

--- a/src/clients/python/experimental_api_v2/examples/v2_image_client.py
+++ b/src/clients/python/experimental_api_v2/examples/v2_image_client.py
@@ -30,11 +30,11 @@ import numpy as np
 from PIL import Image
 import sys
 
-import tritongrpcclient.core as grpcclient
+import tritongrpcclient.grpcclient as grpcclient
 import tritongrpcclient.model_config_pb2 as mc
-import tritonhttpclient.core as httpclient
-from tritonhttpclient.utils import triton_to_np_dtype
-from tritonhttpclient.utils import InferenceServerException
+import tritonhttpclient.httpclient as httpclient
+from tritonclientutils.utils import triton_to_np_dtype
+from tritonclientutils.utils import InferenceServerException
 
 FLAGS = None
 

--- a/src/clients/python/experimental_api_v2/examples/v2_image_client.py
+++ b/src/clients/python/experimental_api_v2/examples/v2_image_client.py
@@ -30,9 +30,9 @@ import numpy as np
 from PIL import Image
 import sys
 
-import tritongrpcclient.grpcclient as grpcclient
+import tritongrpcclient
 import tritongrpcclient.model_config_pb2 as mc
-import tritonhttpclient.httpclient as httpclient
+import tritonhttpclient
 from tritonclientutils.utils import triton_to_np_dtype
 from tritonclientutils.utils import InferenceServerException
 
@@ -245,21 +245,21 @@ def requestGenerator(input_name, output_name, c, h, w, format, dtype, FLAGS):
     inputs = []
     if FLAGS.protocol.lower() == "grpc":
         inputs.append(
-            grpcclient.InferInput(input_name, batched_image_data.shape, dtype))
+            tritongrpcclient.InferInput(input_name, batched_image_data.shape, dtype))
         inputs[0].set_data_from_numpy(batched_image_data)
     else:
         inputs.append(
-            httpclient.InferInput(input_name, batched_image_data.shape, dtype))
+            tritonhttpclient.InferInput(input_name, batched_image_data.shape, dtype))
         inputs[0].set_data_from_numpy(batched_image_data, binary_data=False)
 
     outputs = []
     if FLAGS.protocol.lower() == "grpc":
         outputs.append(
-            grpcclient.InferRequestedOutput(output_name,
+            tritongrpcclient.InferRequestedOutput(output_name,
                                             class_count=FLAGS.classes))
     else:
         outputs.append(
-            httpclient.InferRequestedOutput(output_name,
+            tritonhttpclient.InferRequestedOutput(output_name,
                                             binary_data=False,
                                             class_count=FLAGS.classes))
 
@@ -325,11 +325,11 @@ if __name__ == '__main__':
     try:
         if FLAGS.protocol.lower() == "grpc":
             # Create gRPC client for communicating with the server
-            triton_client = grpcclient.InferenceServerClient(
+            triton_client = tritongrpcclient.InferenceServerClient(
                 url=FLAGS.url, verbose=FLAGS.verbose)
         else:
             # Create HTTP client for communicating with the server
-            triton_client = httpclient.InferenceServerClient(
+            triton_client = tritonhttpclient.InferenceServerClient(
                 url=FLAGS.url, verbose=FLAGS.verbose)
     except Exception as e:
         print("context creation failed: " + str(e))

--- a/src/clients/python/experimental_api_v2/library/CMakeLists.txt
+++ b/src/clients/python/experimental_api_v2/library/CMakeLists.txt
@@ -143,32 +143,32 @@ if(${TRTIS_ENABLE_GRPC_V2})
 endif() # TRTIS_ENABLE_GRPC_V2
 
 #
-# shared memory utils wheel file
+# triton client utils wheel file
 #
 if(${TRTIS_ENABLE_HTTP_V2} OR ${TRTIS_ENABLE_GRPC_V2})
   if(NOT WIN32)
-    set(shared_memory_wheel_stamp_file "shared_memory_stamp.whl")
-    configure_file(shared_memory_setup.py shared_memory_setup.py COPYONLY)
+    set(utils_wheel_stamp_file "utils_stamp.whl")
+    configure_file(utils_setup.py utils_setup.py COPYONLY)
 
     if(${TRTIS_ENABLE_GPU})
       add_custom_command(
-        OUTPUT "${shared_memory_wheel_stamp_file}"
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/shared_memory_build_wheel.sh"
-        ARGS "${CMAKE_CURRENT_BINARY_DIR}/shared_memory/"
+        OUTPUT "${utils_wheel_stamp_file}"
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/utils_build_wheel.sh"
+        ARGS "${CMAKE_CURRENT_BINARY_DIR}/utils/"
         DEPENDS
           ${CMAKE_CURRENT_BINARY_DIR}/VERSION
-          ${CMAKE_CURRENT_BINARY_DIR}/shared_memory_setup.py
+          ${CMAKE_CURRENT_BINARY_DIR}/utils_setup.py
           cshmv2
           ccudashmv2
       )
     else()
       add_custom_command(
-        OUTPUT "${shared_memory_wheel_stamp_file}"
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/shared_memory_build_wheel.sh"
-        ARGS "${CMAKE_CURRENT_BINARY_DIR}/shared_memory/"
+        OUTPUT "${utils_wheel_stamp_file}"
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/utils_build_wheel.sh"
+        ARGS "${CMAKE_CURRENT_BINARY_DIR}/utils/"
         DEPENDS
           ${CMAKE_CURRENT_BINARY_DIR}/VERSION
-          ${CMAKE_CURRENT_BINARY_DIR}/shared_memory_setup.py
+          ${CMAKE_CURRENT_BINARY_DIR}/utils_setup.py
           cshmv2
       )
 
@@ -176,13 +176,13 @@ if(${TRTIS_ENABLE_HTTP_V2} OR ${TRTIS_ENABLE_GRPC_V2})
 
 
     add_custom_target(
-      client-wheel-shared-memory ALL
+      client-wheel-utils ALL
       DEPENDS
-        "${shared_memory_wheel_stamp_file}"
+        "${utils_wheel_stamp_file}"
     )
 
     install(
-      CODE "file(GLOB _Wheel \"${CMAKE_CURRENT_BINARY_DIR}/shared_memory/tritonsharedmemoryutils-*.whl\")"
+      CODE "file(GLOB _Wheel \"${CMAKE_CURRENT_BINARY_DIR}/utils/tritonclientutils-*.whl\")"
       CODE "file(INSTALL \${_Wheel} DESTINATION \"${CMAKE_INSTALL_PREFIX}/python\")"
     )
   endif() # NOT WIN32

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/__init__.py
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/__init__.py
@@ -50,7 +50,7 @@ class _utf8(object):
 import os
 _ccudashm_lib = "ccudashmv2" if os.name == 'nt' else 'libccudashmv2.so'
 _ccudashm_path = pkg_resources.resource_filename(
-    'tritonsharedmemoryutils.cuda_shared_memory', _ccudashm_lib)
+    'tritonclientutils.cuda_shared_memory', _ccudashm_lib)
 _ccudashm = cdll.LoadLibrary(_ccudashm_path)
 
 _ccudashm_shared_memory_region_create = _ccudashm.CudaSharedMemoryRegionCreate

--- a/src/clients/python/experimental_api_v2/library/grpc_build_wheel.sh
+++ b/src/clients/python/experimental_api_v2/library/grpc_build_wheel.sh
@@ -53,10 +53,9 @@ function main() {
     "${WHLDIR}/tritongrpcclient/."
   
   cp grpcclient.py \
-    "${WHLDIR}/tritongrpcclient/grpcclient.py"
+    "${WHLDIR}/tritongrpcclient/__init__.py"
 
   cp grpc_setup.py "${WHLDIR}"
-  touch ${WHLDIR}/tritongrpcclient/__init__.py
 
   # Use 'sed' command to fix protoc compiled imports (see
   # https://github.com/google/protobuf/issues/1491).

--- a/src/clients/python/experimental_api_v2/library/grpc_build_wheel.sh
+++ b/src/clients/python/experimental_api_v2/library/grpc_build_wheel.sh
@@ -53,10 +53,7 @@ function main() {
     "${WHLDIR}/tritongrpcclient/."
   
   cp grpcclient.py \
-    "${WHLDIR}/tritongrpcclient/core.py"
-
-  cp utils.py \
-    "${WHLDIR}/tritongrpcclient/."
+    "${WHLDIR}/tritongrpcclient/grpcclient.py"
 
   cp grpc_setup.py "${WHLDIR}"
   touch ${WHLDIR}/tritongrpcclient/__init__.py

--- a/src/clients/python/experimental_api_v2/library/grpc_setup.py
+++ b/src/clients/python/experimental_api_v2/library/grpc_setup.py
@@ -33,7 +33,10 @@ if 'VERSION' not in os.environ:
 
 VERSION = os.environ['VERSION']
 
-REQUIRED = ['numpy', 'python-rapidjson', 'protobuf>=3.5.0', 'grpcio']
+REQUIRED = [
+    'numpy', 'python-rapidjson', 'protobuf>=3.5.0', 'grpcio',
+    'tritonclientutils'
+]
 
 try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel

--- a/src/clients/python/experimental_api_v2/library/grpcclient.py
+++ b/src/clients/python/experimental_api_v2/library/grpcclient.py
@@ -35,7 +35,7 @@ from google.protobuf.json_format import MessageToJson
 
 from tritongrpcclient import grpc_service_v2_pb2
 from tritongrpcclient import grpc_service_v2_pb2_grpc
-from tritongrpcclient.utils import *
+from tritonclientutils.utils import *
 
 
 def get_error_grpc(rpc_error):

--- a/src/clients/python/experimental_api_v2/library/http_build_wheel.sh
+++ b/src/clients/python/experimental_api_v2/library/http_build_wheel.sh
@@ -46,10 +46,9 @@ function main() {
   mkdir -p ${WHLDIR}/tritonhttpclient/
 
   cp httpclient.py \
-    "${WHLDIR}/tritonhttpclient/httpclient.py"
+    "${WHLDIR}/tritonhttpclient/__init__.py"
 
   cp http_setup.py "${WHLDIR}"
-  touch ${WHLDIR}/tritonhttpclient/__init__.py
 
   pushd "${WHLDIR}"
   echo $(date) : "=== Building wheel"

--- a/src/clients/python/experimental_api_v2/library/http_build_wheel.sh
+++ b/src/clients/python/experimental_api_v2/library/http_build_wheel.sh
@@ -46,10 +46,7 @@ function main() {
   mkdir -p ${WHLDIR}/tritonhttpclient/
 
   cp httpclient.py \
-    "${WHLDIR}/tritonhttpclient/core.py"
-
-  cp utils.py \
-    "${WHLDIR}/tritonhttpclient/."
+    "${WHLDIR}/tritonhttpclient/httpclient.py"
 
   cp http_setup.py "${WHLDIR}"
   touch ${WHLDIR}/tritonhttpclient/__init__.py

--- a/src/clients/python/experimental_api_v2/library/http_setup.py
+++ b/src/clients/python/experimental_api_v2/library/http_setup.py
@@ -33,7 +33,9 @@ if 'VERSION' not in os.environ:
 
 VERSION = os.environ['VERSION']
 
-REQUIRED = ['numpy', 'geventhttpclient', 'python-rapidjson']
+REQUIRED = [
+    'numpy', 'geventhttpclient', 'python-rapidjson', 'tritonclientutils'
+]
 
 try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel

--- a/src/clients/python/experimental_api_v2/library/httpclient.py
+++ b/src/clients/python/experimental_api_v2/library/httpclient.py
@@ -33,7 +33,7 @@ import numpy as np
 import gevent.pool
 import struct
 
-from tritonhttpclient.utils import *
+from tritonclientutils.utils import *
 
 
 def _get_error(response):

--- a/src/clients/python/experimental_api_v2/library/shared_memory/__init__.py
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/__init__.py
@@ -50,7 +50,7 @@ class _utf8(object):
 import os
 _cshm_lib = "cshmv2" if os.name == 'nt' else 'libcshmv2.so'
 _cshm_path = pkg_resources.resource_filename(
-    'tritonsharedmemoryutils.shared_memory', _cshm_lib)
+    'tritonclientutils.shared_memory', _cshm_lib)
 _cshm = cdll.LoadLibrary(_cshm_path)
 
 _cshm_shared_memory_region_create = _cshm.SharedMemoryRegionCreate

--- a/src/clients/python/experimental_api_v2/library/utils_build_wheel.sh
+++ b/src/clients/python/experimental_api_v2/library/utils_build_wheel.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -24,54 +25,57 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-from setuptools import find_packages
-from setuptools import setup
+set -e
 
-if 'VERSION' not in os.environ:
-    raise Exception('envvar VERSION must be specified')
+function main() {
+  if [[ $# -lt 1 ]] ; then
+    echo "usage: $0 <destination dir>"
+    exit 1
+  fi
 
-VERSION = os.environ['VERSION']
+  if [[ ! -f "VERSION" ]]; then
+    echo "Could not find VERSION"
+    exit 1
+  fi
 
-REQUIRED = ['numpy']
+  VERSION=`cat VERSION`
+  DEST="$1"
+  WHLDIR="$DEST/wheel"
 
-try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+  echo $(date) : "=== Using builddir: ${WHLDIR}"
+  mkdir -p ${WHLDIR}/tritonclientutils/
 
-    class bdist_wheel(_bdist_wheel):
+  if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    mkdir -p ${WHLDIR}/tritonclientutils/shared_memory
+    cp libcshmv2.so \
+      "${WHLDIR}/tritonclientutils/shared_memory/."
+    cp shared_memory/__init__.py \
+      "${WHLDIR}/tritonclientutils/shared_memory/."
 
-        def finalize_options(self):
-            _bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
+    if [ -f libccudashmv2.so ] && [ -f cuda_shared_memory/__init__.py ]; then
+      mkdir -p ${WHLDIR}/tritonclientutils/cuda_shared_memory
+      cp libccudashmv2.so \
+        "${WHLDIR}/tritonclientutils/cuda_shared_memory/."
+      cp cuda_shared_memory/__init__.py \
+        "${WHLDIR}/tritonclientutils/cuda_shared_memory/."
+    fi
+  fi
 
-        def get_tag(self):
-            pyver, abi, plat = _bdist_wheel.get_tag(self)
-            pyver, abi = 'py3', 'none'
-            return pyver, abi, plat
-except ImportError:
-    bdist_wheel = None
+  cp utils.py \
+    "${WHLDIR}/tritonclientutils/."
 
-if not os.name == 'nt':
-    platform_package_data = ['libcshmv2.so']
-    if bool(os.environ.get('CUDA_VERSION', 0)):
-        platform_package_data += ['libccudashmv2.so']
+  cp utils_setup.py "${WHLDIR}"
+  touch ${WHLDIR}/tritonclientutils/__init__.py
 
-    setup(
-        name='tritonsharedmemoryutils',
-        version=VERSION,
-        author='NVIDIA Inc.',
-        author_email='tanmayv@nvidia.com',
-        description=
-        'Python utils library for creating and managing system and cuda shared memory regions',
-        license='BSD',
-        url='http://nvidia.com',
-        keywords=
-        'triton tensorrt inference server system memory cuda system client',
-        packages=find_packages(),
-        install_requires=REQUIRED,
-        package_data={
-            '': platform_package_data,
-        },
-        zip_safe=False,
-        cmdclass={'bdist_wheel': bdist_wheel},
-    )
+  pushd "${WHLDIR}"
+  echo $(date) : "=== Building wheel"
+  VERSION=$VERSION python${PYVER} utils_setup.py bdist_wheel
+  mkdir -p "${DEST}"
+  cp dist/* "${DEST}"
+  popd
+  echo $(date) : "=== Output wheel file is in: ${DEST}"
+
+  touch ${DEST}/stamp.whl
+}
+
+main "$@"

--- a/src/clients/python/experimental_api_v2/library/utils_setup.py
+++ b/src/clients/python/experimental_api_v2/library/utils_setup.py
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,54 +24,54 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set -e
+import os
+from setuptools import find_packages
+from setuptools import setup
 
-function main() {
-  if [[ $# -lt 1 ]] ; then
-    echo "usage: $0 <destination dir>"
-    exit 1
-  fi
+if 'VERSION' not in os.environ:
+    raise Exception('envvar VERSION must be specified')
 
-  if [[ ! -f "VERSION" ]]; then
-    echo "Could not find VERSION"
-    exit 1
-  fi
+VERSION = os.environ['VERSION']
 
-  VERSION=`cat VERSION`
-  DEST="$1"
-  WHLDIR="$DEST/wheel"
+REQUIRED = ['numpy']
 
-  echo $(date) : "=== Using builddir: ${WHLDIR}"
-  mkdir -p ${WHLDIR}/tritonsharedmemoryutils/
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
-  if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    mkdir -p ${WHLDIR}/tritonsharedmemoryutils/shared_memory
-    cp libcshmv2.so \
-      "${WHLDIR}/tritonsharedmemoryutils/shared_memory/."
-    cp shared_memory/__init__.py \
-      "${WHLDIR}/tritonsharedmemoryutils/shared_memory/."
+    class bdist_wheel(_bdist_wheel):
 
-    if [ -f libccudashmv2.so ] && [ -f cuda_shared_memory/__init__.py ]; then
-      mkdir -p ${WHLDIR}/tritonsharedmemoryutils/cuda_shared_memory
-      cp libccudashmv2.so \
-        "${WHLDIR}/tritonsharedmemoryutils/cuda_shared_memory/."
-      cp cuda_shared_memory/__init__.py \
-        "${WHLDIR}/tritonsharedmemoryutils/cuda_shared_memory/."
-    fi
-  fi
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
 
-  cp shared_memory_setup.py "${WHLDIR}"
-  touch ${WHLDIR}/tritonsharedmemoryutils/__init__.py
+        def get_tag(self):
+            pyver, abi, plat = _bdist_wheel.get_tag(self)
+            pyver, abi = 'py3', 'none'
+            return pyver, abi, plat
+except ImportError:
+    bdist_wheel = None
 
-  pushd "${WHLDIR}"
-  echo $(date) : "=== Building wheel"
-  VERSION=$VERSION python${PYVER} shared_memory_setup.py bdist_wheel
-  mkdir -p "${DEST}"
-  cp dist/* "${DEST}"
-  popd
-  echo $(date) : "=== Output wheel file is in: ${DEST}"
+if not os.name == 'nt':
+    platform_package_data = ['libcshmv2.so']
+    if bool(os.environ.get('CUDA_VERSION', 0)):
+        platform_package_data += ['libccudashmv2.so']
 
-  touch ${DEST}/stamp.whl
-}
-
-main "$@"
+    setup(
+        name='tritonclientutils',
+        version=VERSION,
+        author='NVIDIA Inc.',
+        author_email='tanmayv@nvidia.com',
+        description=
+        'Python utils library for creating and managing system and cuda shared memory regions',
+        license='BSD',
+        url='http://nvidia.com',
+        keywords=
+        'triton tensorrt inference server system memory cuda system client',
+        packages=find_packages(),
+        install_requires=REQUIRED,
+        package_data={
+            '': platform_package_data,
+        },
+        zip_safe=False,
+        cmdclass={'bdist_wheel': bdist_wheel},
+    )


### PR DESCRIPTION
We will have three packages:
1. tritongrpcclient : [grpcclient]
2. tritonhttpclient: [httpclient]
3. tritonclientutils: [utils, shared_memory and cuda_shared_memory]