### PR TITLE
Fix for error reporting in HTTP server

### DIFF
--- a/src/servers/http_server_v2.cc
+++ b/src/servers/http_server_v2.cc
@@ -2012,6 +2012,7 @@ HTTPAPIServerV2::HandleInfer(
     LOG_VERBOSE(1) << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
     EVBufferAddErrorJson(req->buffer_out, err);
     evhtp_send_reply(req, EVHTP_RES_BADREQ);
+    evhtp_request_resume(req);
     TRITONSERVER_ErrorDelete(err);
 
     LOG_TRITONSERVER_ERROR(


### PR DESCRIPTION
We pause the connection in InferRequestClass constructor, which is resumed in the callback. If TRITONSERVER_ServerInferAsync itself failed then we must explicitly resume the connection so that error message gets delivered. 

### Before:
root@81251697a639:/opt/tritonserver/qa/L0_http_v2# /tmp/host/install/bin/perf_client_v2 -m simple -b 10
*** Measurement Settings ***
  Batch size: 10
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
Failed to maintain requested inference load. Worker thread(s) failed to generate concurrent requests.
Thread [0] had error: inference request batch-size must be <= 8 for 'simple'
root@81251697a639:/opt/tritonserver/qa/L0_http_v2# /tmp/host/install/bin/perf_client_v2 -m simple -b 10
*** Measurement Settings ***
  Batch size: 10
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
perf_client_v2: /usr/include/rapidjson/document.h:1154: rapidjson::GenericValue<Encoding, Allocator>::MemberIterator rapidjson::GenericValue<Encoding, Allocator>::FindMember(const rapidjson::GenericValue<Encoding, SourceAllocator>&) [with SourceAllocator = rapidjson::MemoryPoolAllocator<>; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>; rapidjson::GenericValue<Encoding, Allocator>::MemberIterator = rapidjson::GenericMemberIterator<false, rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<> >]: Assertion `IsObject()' failed.

### After:
root@81251697a639:/opt/tritonserver/qa/L0_http_v2# /tmp/host/install/bin/perf_client_v2 -m simple -b 10
*** Measurement Settings ***
  Batch size: 10
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
Failed to maintain requested inference load. Worker thread(s) failed to generate concurrent requests.
Thread [0] had error: inference request batch-size must be <= 8 for 'simple'