### PR TITLE
Fix base64 encoding to null terminate the string

### DIFF
--- a/src/clients/c++/experimental_api_v2/examples/CMakeLists.txt
+++ b/src/clients/c++/experimental_api_v2/examples/CMakeLists.txt
@@ -188,7 +188,6 @@ else()
         simple_grpc_v2_cudashm_client
         PRIVATE TRTIS::grpcclient_static
         PRIVATE ${CUDA_LIBRARIES}
-        PRIVATE -lb64
       )
       install(
         TARGETS simple_grpc_v2_cudashm_client
@@ -317,7 +316,6 @@ else()
         simple_http_v2_cudashm_client
         PRIVATE TRTIS::httpclient_static
         PRIVATE ${CUDA_LIBRARIES}
-        PRIVATE -lb64
       )
       install(
         TARGETS simple_http_v2_cudashm_client

--- a/src/clients/c++/experimental_api_v2/library/cencode.c
+++ b/src/clients/c++/experimental_api_v2/library/cencode.c
@@ -102,7 +102,7 @@ int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 	case step_A:
 		break;
 	}
-	*codechar++ = '\0';
+	*codechar++ = '\n';
 	
 	return codechar - code_out;
 }

--- a/src/clients/c++/experimental_api_v2/library/cencode.c
+++ b/src/clients/c++/experimental_api_v2/library/cencode.c
@@ -102,7 +102,7 @@ int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 	case step_A:
 		break;
 	}
-	*codechar++ = '\n';
+	*codechar++ = '\0';
 	
 	return codechar - code_out;
 }

--- a/src/clients/c++/experimental_api_v2/library/http_client.cc
+++ b/src/clients/c++/experimental_api_v2/library/http_client.cc
@@ -95,14 +95,14 @@ GetQueryString(const Headers& query_params)
 // encoded size to get the right contents.
 void
 Base64Encode(
-    char* raw_ptr, size_t raw_size, char** encoded_ptr, size_t* encoded_size)
+    char* raw_ptr, size_t raw_size, char** encoded_ptr, int* encoded_size)
 {
   // Encode the handle object to base64
   base64_encodestate es;
   base64_init_encodestate(&es);
   *encoded_ptr = (char*)malloc(raw_size * 2); /* ~4/3 x raw_size */
   *encoded_size = base64_encode_block(raw_ptr, raw_size, *encoded_ptr, &es);
-  size_t padding_size =
+  int padding_size =
       base64_encode_blockend(*encoded_ptr + *encoded_size, &es);
   *encoded_size += padding_size;
 }
@@ -842,7 +842,7 @@ InferenceServerHttpClient::RegisterCudaSharedMemory(
     rapidjson::Value raw_handle_json(rapidjson::kObjectType);
     {
       char* encoded_handle = nullptr;
-      size_t encoded_size;
+      int encoded_size;
       Base64Encode(
           (char*)((void*)&raw_handle), sizeof(cudaIpcMemHandle_t),
           &encoded_handle, &encoded_size);

--- a/src/clients/c++/experimental_api_v2/library/http_client.cc
+++ b/src/clients/c++/experimental_api_v2/library/http_client.cc
@@ -90,6 +90,9 @@ GetQueryString(const Headers& query_params)
   return query_string;
 }
 
+// Encodes the contents of the provided buffer into base64 string. Note the
+// string is not guaranteed to be null-terminated. Must rely on the returned
+// encoded size to get the right contents.
 void
 Base64Encode(
     char* raw_ptr, size_t raw_size, char** encoded_ptr, size_t* encoded_size)

--- a/src/clients/c++/experimental_api_v2/library/http_client.cc
+++ b/src/clients/c++/experimental_api_v2/library/http_client.cc
@@ -91,14 +91,17 @@ GetQueryString(const Headers& query_params)
 }
 
 void
-Base64Encode(char* raw_ptr, size_t raw_size, char** encoded_ptr)
+Base64Encode(
+    char* raw_ptr, size_t raw_size, char** encoded_ptr, size_t* encoded_size)
 {
   // Encode the handle object to base64
   base64_encodestate es;
   base64_init_encodestate(&es);
   *encoded_ptr = (char*)malloc(raw_size * 2); /* ~4/3 x raw_size */
-  int offset = base64_encode_block(raw_ptr, raw_size, *encoded_ptr, &es);
-  base64_encode_blockend(*encoded_ptr + offset, &es);
+  *encoded_size = base64_encode_block(raw_ptr, raw_size, *encoded_ptr, &es);
+  size_t padding_size =
+      base64_encode_blockend(*encoded_ptr + *encoded_size, &es);
+  *encoded_size += padding_size;
 }
 
 }  // namespace
@@ -836,13 +839,16 @@ InferenceServerHttpClient::RegisterCudaSharedMemory(
     rapidjson::Value raw_handle_json(rapidjson::kObjectType);
     {
       char* encoded_handle = nullptr;
+      size_t encoded_size;
       Base64Encode(
           (char*)((void*)&raw_handle), sizeof(cudaIpcMemHandle_t),
-          &encoded_handle);
+          &encoded_handle, &encoded_size);
       if (encoded_handle == nullptr) {
         return Error("Failed to base64 encode the cudaIpcMemHandle_t");
       }
-      rapidjson::Value b64_json(encoded_handle, allocator);
+      const auto encoded_handle_str = std::string(encoded_handle, encoded_size);
+      rapidjson::Value b64_json(
+          rapidjson::StringRef(encoded_handle_str.c_str()), allocator);
       delete encoded_handle;
       raw_handle_json.AddMember("b64", b64_json, allocator);
     }

--- a/src/clients/python/experimental_api_v2/library/CMakeLists.txt
+++ b/src/clients/python/experimental_api_v2/library/CMakeLists.txt
@@ -41,11 +41,13 @@ if(${TRTIS_ENABLE_HTTP_V2} OR ${TRTIS_ENABLE_GRPC_V2})
     # libccudashmv2.so
     #
     if(${TRTIS_ENABLE_GPU})
-      add_library(ccudashmv2 SHARED cuda_shared_memory/cuda_shared_memory.cc)
+      add_library(ccudashmv2 SHARED
+        cuda_shared_memory/cuda_shared_memory.cc
+        ../../../c++/experimental_api_v2/library/cencode.c
+        ../../../c++/experimental_api_v2/library/cencode.h)
       target_include_directories(ccudashmv2 PUBLIC ${CUDA_INCLUDE_DIRS})
       target_link_libraries(ccudashmv2
-        PRIVATE ${CUDA_LIBRARIES}
-        PRIVATE -lb64)
+        PRIVATE ${CUDA_LIBRARIES})
     endif() # TRTIS_ENABLE_GPU
   endif() # NOT WIN32
 

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
@@ -27,7 +27,7 @@
 #include "src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.h"
 
 extern "C" {
-#include <b64/cencode.h>
+#include <src/clients/c++/experimental_api_v2/library/cencode.h>
 }
 #include <cuda_runtime_api.h>
 #include <cstring>

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
@@ -110,11 +110,11 @@ CudaSharedMemoryGetRawHandle(
   base64_init_encodestate(&es);
   size_t handle_size = sizeof(cudaIpcMemHandle_t);
   *serialized_raw_handle = (char*)malloc(handle_size * 2); /* ~4/3 x input */
-  size_t offset = base64_encode_block(
+  int offset = base64_encode_block(
       (char*)((void*)&handle->cuda_shm_handle_), handle_size,
       *serialized_raw_handle, &es);
   base64_encode_blockend(*serialized_raw_handle + offset, &es);
-  size_t padding_size =
+  int padding_size =
       base64_encode_blockend(*serialized_raw_handle + offset, &es);
   offset += (padding_size - 1);
   // The base64_encode_blockend does not null-terminate the string but adds

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
@@ -110,10 +110,17 @@ CudaSharedMemoryGetRawHandle(
   base64_init_encodestate(&es);
   size_t handle_size = sizeof(cudaIpcMemHandle_t);
   *serialized_raw_handle = (char*)malloc(handle_size * 2); /* ~4/3 x input */
-  int offset = base64_encode_block(
+  size_t offset = base64_encode_block(
       (char*)((void*)&handle->cuda_shm_handle_), handle_size,
       *serialized_raw_handle, &es);
   base64_encode_blockend(*serialized_raw_handle + offset, &es);
+  size_t padding_size =
+      base64_encode_blockend(*serialized_raw_handle + offset, &es);
+  offset += (padding_size - 1);
+  // The base64_encode_blockend does not null-terminate the string but adds
+  // the new line character. Adding the null character here for proper
+  // termination of ctypes.
+  *serialized_raw_handle[offset] = '\0';
 
   return 0;
 }

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
@@ -120,7 +120,7 @@ CudaSharedMemoryGetRawHandle(
   // The base64_encode_blockend does not null-terminate the string but adds
   // the new line character. Adding the null character here for proper
   // termination of ctypes.
-  *serialized_raw_handle[offset] = '\0';
+  (*serialized_raw_handle)[offset] = '\0';
 
   return 0;
 }


### PR DESCRIPTION
The encoded base64 string was not getting null terminated. Fixed the termination to let the libraries detect the end.
I tested with the perf_client and it worked fine,
@CoderHam Can you try this fix with L0_* cuda shared memory tests?