### PR TITLE
Allow HTTP server to report complex error messages

### DIFF
--- a/src/servers/http_server_v2.cc
+++ b/src/servers/http_server_v2.cc
@@ -868,9 +868,16 @@ WriteDataToJson(
 void
 EVBufferAddErrorJson(evbuffer* buffer, TRITONSERVER_Error* err)
 {
+  rapidjson::Document response;
+  response.SetObject();
   std::string message = std::string(TRITONSERVER_ErrorMessage(err));
-  std::string message_json = "{ \"error\" : \"" + message + "\" }";
-  evbuffer_add(buffer, message_json.c_str(), message_json.size());
+  rapidjson::Value message_json(
+      rapidjson::StringRef(message.c_str(), message.size()),
+      response.GetAllocator());
+  rapidjson::StringBuffer buffer_json;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer_json);
+  response.Accept(writer);
+  evbuffer_add(buffer, buffer_json.GetString(), buffer_json.GetSize());
 }
 
 void

--- a/src/servers/http_server_v2.cc
+++ b/src/servers/http_server_v2.cc
@@ -874,6 +874,7 @@ EVBufferAddErrorJson(evbuffer* buffer, TRITONSERVER_Error* err)
   rapidjson::Value message_json(
       rapidjson::StringRef(message.c_str(), message.size()),
       response.GetAllocator());
+  response.AddMember("error", message_json, response.GetAllocator());
   rapidjson::StringBuffer buffer_json;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer_json);
   response.Accept(writer);


### PR DESCRIPTION
The error messages can be complex sometimes. Relying on the rapidjson to do correct encoding, 


### After this fix :
root@27ab6cfd09e0:/opt/tritonserver/qa/clients# ../clients/perf_client_v2 -v -i http -m graphdef_sequence_float32 --shape INPUT:2 --input-data=/opt/tritonserver/qa/L0_perf_client/json_input_data_files/float_data_with_shape.json --input-data=/opt/tritonserver/qa/L0_perf_client/json_input_data_files/float_data_with_shape.json -p2000 --shared-memory=none
 Successfully read data for 6 stream/streams.
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 2000 msec
  Using asynchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Pass [1] throughput: 0.5 infer/sec. Avg latency: 9353 usec (std 0 usec)
**Failed to retrieve results from inference request.
Thread [0] had error: 2 root error(s) found.
  (0) Invalid argument: Inputs to operation Select of type Select must have the same size and shape.  Input 0: [1,1] != input 1: [1,2]
         [[{{node Select}}]]
         [[OUTPUT/_7]]
  (1) Invalid argument: Inputs to operation Select of type Select must have the same size and shape.  Input 0: [1,1] != input 1: [1,2]
         [[{{node Select}}]]
0 successful operations.
0 derived errors ignored.**