### PR TITLE
Fix model repository error message for incorrect version

### DIFF
--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -196,7 +196,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model: 'graphdef_float32_float32_float32' is not found"))
+                    "Request for unknown model: 'graphdef_float32_float32_float32' has no available versions"))
 
         # And other models should be loaded successfully
         try:
@@ -466,7 +466,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model: 'savedmodel_float32_float32_float32' is not found"))
+                    "Request for unknown model: 'savedmodel_float32_float32_float32' has no available versions"))
 
         # Add back the same model. The status/stats should be reset.
         try:
@@ -521,7 +521,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model: 'netdef_float32_float32_float32' is not found"))
+                    "Request for unknown model: 'netdef_float32_float32_float32' has no available versions"))
 
     def test_dynamic_model_load_unload_disabled(self):
         input_size = 16
@@ -694,7 +694,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model: 'graphdef_int32_int32_int32' version 1 is not found"))
+                    "Request for unknown model: 'graphdef_int32_int32_int32' version 1 is not at ready state"))
 
         # Add back the same version. The status/stats should be
         # retained for versions (note that this is different behavior

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -196,7 +196,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model 'graphdef_float32_float32_float32'"))
+                    "Request for unknown model: 'graphdef_float32_float32_float32' is not found"))
 
         # And other models should be loaded successfully
         try:
@@ -322,7 +322,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model 'graphdef_float32_float32_float32'"))
+                    "Request for unknown model: 'graphdef_float32_float32_float32' is not found"))
 
     def test_parse_ignore_zero_prefixed_version(self):
         input_size = 16
@@ -466,7 +466,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model 'savedmodel_float32_float32_float32'"))
+                    "Request for unknown model: 'savedmodel_float32_float32_float32' is not found"))
 
         # Add back the same model. The status/stats should be reset.
         try:
@@ -521,7 +521,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model 'netdef_float32_float32_float32'"))
+                    "Request for unknown model: 'netdef_float32_float32_float32' is not found"))
 
     def test_dynamic_model_load_unload_disabled(self):
         input_size = 16
@@ -694,7 +694,7 @@ class LifeCycleTest(unittest.TestCase):
             self.assertEqual("inference:0", ex.server_id())
             self.assertTrue(
                 ex.message().startswith(
-                    "Request for unknown model 'graphdef_int32_int32_int32'"))
+                    "Request for unknown model: 'graphdef_int32_int32_int32' version 1 is not found"))
 
         # Add back the same version. The status/stats should be
         # retained for versions (note that this is different behavior

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -552,8 +552,7 @@ ModelRepositoryManager::BackendLifeCycle::GetInferenceBackend(
   std::lock_guard<std::mutex> map_lock(map_mtx_);
   auto mit = map_.find(model_name);
   if (mit == map_.end()) {
-    return Status(
-        Status::Code::NOT_FOUND, "model '" + model_name + "' is not found");
+    return Status(Status::Code::NOT_FOUND, "'" + model_name + "' is not found");
   }
 
   auto vit = mit->second.find(version);
@@ -578,7 +577,7 @@ ModelRepositoryManager::BackendLifeCycle::GetInferenceBackend(
     }
     if (latest == -1) {
       return Status(
-          Status::Code::NOT_FOUND, "model '" + model_name + "' version " +
+          Status::Code::NOT_FOUND, "'" + model_name + "' version " +
                                        std::to_string(version) +
                                        " is not found");
     }
@@ -588,7 +587,7 @@ ModelRepositoryManager::BackendLifeCycle::GetInferenceBackend(
       *backend = vit->second->backend_;
     } else {
       return Status(
-          Status::Code::UNAVAILABLE, "model '" + model_name + "' version " +
+          Status::Code::UNAVAILABLE, "'" + model_name + "' version " +
                                          std::to_string(version) +
                                          " is not at ready state");
     }

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -1408,7 +1408,7 @@ ModelRepositoryManager::GetInferenceBackend(
     backend->reset();
     status = Status(
         Status::Code::UNAVAILABLE,
-        "Request for unknown model '" + model_name + "'");
+        "Request for unknown model: " + status.Message());
   }
   return status;
 }

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -574,8 +574,12 @@ ModelRepositoryManager::BackendLifeCycle::GetInferenceBackend(
           }
         }
       }
-    }
-    if (latest == -1) {
+      if (latest == -1) {
+        return Status(
+            Status::Code::NOT_FOUND,
+            "'" + model_name + "' has no available versions");
+      }
+    } else {
       return Status(
           Status::Code::NOT_FOUND, "'" + model_name + "' version " +
                                        std::to_string(version) +


### PR DESCRIPTION
**Old Error Message:**
Missing/Incorrect model_name/model_version: `"Request for unknown model 'graphdef_float32_float32_float32'"`

**New Error Message:**
Missing/Incorrect model_name: `"Request for unknown model: 'graphdef_float32_float32_float32' is not found"`
Model name correct but version=-1 and no version is available anymore: `"Request for unknown model: 'graphdef_float32_float32_float32' has no available versions"`
Missing/Incorrect model_version: `"Request for unknown model: 'graphdef_float32_float32_float32' version 1 is not found"`