### PR TITLE
Fix syntax error in Dockerfile.centos_client

### DIFF
--- a/Dockerfile.centos_client
+++ b/Dockerfile.centos_client
@@ -63,7 +63,7 @@ COPY src/core src/core
 
 RUN cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_INSTALL_PREFIX:PATH=/workspace/install
+          -DCMAKE_INSTALL_PREFIX:PATH=/workspace/install \
           -DTRTIS_ENABLE_GRPC_V2=ON \
           -DTRTIS_ENABLE_HTTP_V2=ON \
           . && \


### PR DESCRIPTION
There should be a trailing backslash.