### PR TITLE
Include inference and execution count in grpc stat response

### DIFF
--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -1047,6 +1047,10 @@ CommonHandler::SetUpAllRequests()
         statistics->set_version(model_stat["version"].GetString());
         statistics->set_last_inference(
             model_stat["last_inference"].GetUint64());
+        statistics->set_inference_count(
+            model_stat["inference_count"].GetUint64());
+        statistics->set_execution_count(
+            model_stat["execution_count"].GetUint64());
         statistics->mutable_inference_stats()->mutable_success()->set_count(
             infer_stats_json["success"]["count"].GetUint64());
         statistics->mutable_inference_stats()->mutable_success()->set_ns(


### PR DESCRIPTION
### HTTP Statistics Response

> {
>     "model_stats": [
>         {
>             "name": "simple",
>             "version": "1",
>             "last_inference": 1590094368740,
>             "inference_count": 4,
>             "execution_count": 4,
>             "inference_stats": {
>                 "success": {
>                     "count": 4,
>                     "ns": 41781417847706535
>                 },
>                 "fail": {
>                     "count": 0,
>                     "ns": 0
>                 },
>                 "queue": {
>                     "count": 4,
>                     "ns": 539764
>                 },
>                 "compute_input": {
>                     "count": 4,
>                     "ns": 579680
>                 },
>                 "compute_infer": {
>                     "count": 4,
>                     "ns": 13285528
>                 },
>                 "compute_output": {
>                     "count": 4,
>                     "ns": 749337
>                 }
>             },
>             "batch_stats": [
>                 {
>                     "batch_size": 1,
>                     "compute_input": {
>                         "count": 4,
>                         "ns": 579680
>                     },
>                     "compute_infer": {
>                         "count": 4,
>                         "ns": 13285528
>                     },
>                     "compute_output": {
>                         "count": 4,
>                         "ns": 749337
>                     }
>                 }
>             ]
>         }
>     ]
> }

### gRPC Statistics response

> model_stats {
>   name: "simple"
>   version: "1"
>   last_inference: 1590094496568
>   inference_count: 5
>   execution_count: 5
>   inference_stats {
>     success {
>       count: 5
>       ns: 52227077085272955
>     }
>     fail {
>     }
>     queue {
>       count: 5
>       ns: 677663
>     }
>     compute_input {
>       count: 5
>       ns: 695883
>     }
>     compute_infer {
>       count: 5
>       ns: 13764110
>     }
>     compute_output {
>       count: 5
>       ns: 950397
>     }
>   }
>   batch_stats {
>     batch_size: 1
>     compute_input {
>       count: 5
>       ns: 695883
>     }
>     compute_infer {
>       count: 5
>       ns: 13764110
>     }
>     compute_output {
>       count: 5
>       ns: 950397
>     }
>   }
> }