### PR TITLE
Fixing FAIL_ALL_AND_RETURN_IF_ERROR macro

### DIFF
--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -43,7 +43,7 @@ namespace nvidia { namespace inferenceserver {
         if (response != nullptr) {                                        \
           LOG_STATUS_ERROR(                                               \
               InferenceResponse::SendWithStatus(                          \
-                  std::move(response), status__),                         \
+                  std::move(response), (S)),                              \
               (LOG_MSG));                                                 \
         }                                                                 \
       }                                                                   \

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -35,43 +35,41 @@
 namespace nvidia { namespace inferenceserver {
 
 #ifdef TRITON_ENABLE_STATS
-#define FAIL_ALL_AND_RETURN_IF_ERROR(REQUESTS, RESPONSES, MR, S, LOG_MSG) \
-  do {                                                                    \
-    const auto& status__ = (S);                                           \
-    if (!status__.IsOk()) {                                               \
-      for (auto& response : (RESPONSES)) {                                \
-        if (response != nullptr) {                                        \
-          LOG_STATUS_ERROR(                                               \
-              InferenceResponse::SendWithStatus(                          \
-                  std::move(response), (S)),                              \
-              (LOG_MSG));                                                 \
-        }                                                                 \
-      }                                                                   \
-      for (auto& request : (REQUESTS)) {                                  \
-        request->ReportStatistics(MR, false /* success */, 0, 0, 0, 0);   \
-        InferenceRequest::Release(std::move(request));                    \
-      }                                                                   \
-      return;                                                             \
-    }                                                                     \
+#define FAIL_ALL_AND_RETURN_IF_ERROR(REQUESTS, RESPONSES, MR, S, LOG_MSG)    \
+  do {                                                                       \
+    const auto& status__ = (S);                                              \
+    if (!status__.IsOk()) {                                                  \
+      for (auto& response : (RESPONSES)) {                                   \
+        if (response != nullptr) {                                           \
+          const auto& response_status__ = InferenceResponse::SendWithStatus( \
+              std::move(response), status__);                                \
+          LOG_STATUS_ERROR(response_status__, (LOG_MSG));                    \
+        }                                                                    \
+      }                                                                      \
+      for (auto& request : (REQUESTS)) {                                     \
+        request->ReportStatistics(MR, false /* success */, 0, 0, 0, 0);      \
+        InferenceRequest::Release(std::move(request));                       \
+      }                                                                      \
+      return;                                                                \
+    }                                                                        \
   } while (false)
 #else
-#define FAIL_ALL_AND_RETURN_IF_ERROR(REQUESTS, RESPONSES, MR, S, LOG_MSG) \
-  do {                                                                    \
-    const auto& status__ = (S);                                           \
-    if (!status__.IsOk()) {                                               \
-      for (auto& response : (RESPONSES)) {                                \
-        if (response != nullptr) {                                        \
-          LOG_STATUS_ERROR(                                               \
-              InferenceResponse::SendWithStatus(                          \
-                  std::move(response), status__),                         \
-              (LOG_MSG));                                                 \
-        }                                                                 \
-      }                                                                   \
-      for (auto& request : (REQUESTS)) {                                  \
-        InferenceRequest::Release(std::move(request));                    \
-      }                                                                   \
-      return;                                                             \
-    }                                                                     \
+#define FAIL_ALL_AND_RETURN_IF_ERROR(REQUESTS, RESPONSES, MR, S, LOG_MSG)    \
+  do {                                                                       \
+    const auto& status__ = (S);                                              \
+    if (!status__.IsOk()) {                                                  \
+      for (auto& response : (RESPONSES)) {                                   \
+        if (response != nullptr) {                                           \
+          const auto& response_status__ = InferenceResponse::SendWithStatus( \
+              std::move(response), status__);                                \
+          LOG_STATUS_ERROR(response_status__, (LOG_MSG));                    \
+        }                                                                    \
+      }                                                                      \
+      for (auto& request : (REQUESTS)) {                                     \
+        InferenceRequest::Release(std::move(request));                       \
+      }                                                                      \
+      return;                                                                \
+    }                                                                        \
   } while (false)
 #endif  // TRITON_ENABLE_STATS
 


### PR DESCRIPTION
### Before
The server segfaults when the status is not ok

### After
../clients/perf_client -m plan_float32_float32_float32-4-32 --shape INPUT0:16 --shape INPUT1:16 -b 10*** Measurement Settings ***  Batch size: 10  Measurement window: 5000 msec  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
Failed to maintain requested inference load. Worker thread(s) failed to generate concurrent requests.
Thread [0] had error: inference request batch-size must be <= 8 for 'plan_float32_float32_float32-4-32'