### PR TITLE
Fixing L0_server_status

### DIFF
--- a/qa/L0_server_status/server_status_test.py
+++ b/qa/L0_server_status/server_status_test.py
@@ -186,7 +186,7 @@ class ServerMetadataTest(unittest.TestCase):
                             input_name = model_input.name
                         self.assertTrue(input_name in ["INPUT0", "INPUT1"])
                         self.assertEqual(input_dtype, "INT32")
-                        self.assertEqual(input_shape, [16])
+                        self.assertEqual(input_shape, [-1, 16])
 
                     for model_output in model_outputs:
                         if pair[1] == "http":
@@ -199,7 +199,7 @@ class ServerMetadataTest(unittest.TestCase):
                             output_name = model_output.name
                         self.assertTrue(output_name in ["OUTPUT0", "OUTPUT1"])
                         self.assertEqual(output_dtype, "INT32")
-                        self.assertEqual(output_shape, [16])
+                        self.assertEqual(output_shape, [-1, 16])
 
             except InferenceServerException as ex:
                 self.assertTrue(False, "unexpected error {}".format(ex))
@@ -350,7 +350,7 @@ class ModelMetadataTest(unittest.TestCase):
         # Originally There were 3 versions of *_int32_int32_int32 and
         # version 3 was executed once. Version 2 and 3 models were
         # deleted from the model repository so now only expect version 1 to
-        # be ready and version 3 to show stats but not be ready.
+        # be ready and show stats.
         for platform in ('graphdef', 'netdef'):
             model_name = platform + "_int32_int32_int32"
 
@@ -377,43 +377,34 @@ class ModelMetadataTest(unittest.TestCase):
 
                     # Only version 3 should have infer stats, only 1 is ready
                     for v in (1, 2, 3):
-                        infer_stats = triton_client.get_inference_statistics(model_name, model_version=str(v))
                         if v == 1:
                             self.assertTrue(triton_client.is_model_ready(model_name, model_version=str(v)))
-                        else:
-                            self.assertFalse(triton_client.is_model_ready(model_name, model_version=str(v)))
-
-                        if v != 3:
-                            if pair[1] == "http":
-                                stats = infer_stats['model_stats'][0]['inference_stats']
-                                self.assertEqual(stats['success']['count'], 0,
-                                                 "unexpected infer stats for version " + str(v) +
-                                                 " of model " + model_name)
-                            else:
-                                stats = infer_stats.model_stats[0].inference_stats
-                                self.assertEqual(stats.success.count, 0,
-                                                 "unexpected infer stats for version " + str(v) +
-                                                 " of model " + model_name)
-                        else:
+                            infer_stats = triton_client.get_inference_statistics(model_name,
+                                                                        model_version=str(v))
                             if pair[1] == "http":
                                 self.assertEqual(len(infer_stats['model_stats']), 1,
                                                  "expected 1 infer stats for version " + str(v) +
                                                  " of model " + model_name)
                                 stats = infer_stats['model_stats'][0]['inference_stats']
-                                self.assertTrue(stats['success']['count'], 3)
+                                self.assertEqual(stats['success']['count'], 0)
                             else:
                                 self.assertEqual(len(infer_stats.model_stats), 1,
                                                  "expected 1 infer stats for version " + str(v) +
                                                  " of model " + model_name)
                                 stats = infer_stats.model_stats[0].inference_stats
-                                self.assertTrue(stats.success.count, 3)
+                                self.assertEqual(stats.success.count, 0)
+
+                        else:
+                            self.assertFalse(triton_client.is_model_ready(model_name, model_version=str(v)))
+                            
 
             except InferenceServerException as ex:
                 self.assertTrue(False, "unexpected error {}".format(ex))
 
     def test_model_versions_added(self):
         # Originally There was version 1 of *_float16_float32_float32.
-        # Version 7 was added so now expect just version 7 to be ready.
+        # Version 7 was added so now expect just version 7 to be ready
+        # and provide infer stats.
         for platform in ('graphdef',):
             model_name = platform + "_float16_float32_float32"
 
@@ -435,32 +426,38 @@ class ModelMetadataTest(unittest.TestCase):
                             model_name, model_metadata['name'], "expected status for model " + model_name)
                         self.assertEqual(len(model_metadata['versions']), 1,
                             "expected status for 1 versions for model " + model_name)
-                        self.assertEqual("7", model_metadata['versions'][0])
+                        self.assertEqual("7", model_metadata['versions'][0])                 
                     else:
                         self.assertEqual(
                             model_name, model_metadata.name, "expected status for model " + model_name)
                         self.assertEqual(len(model_metadata.versions), 1,
                             "expected status for 1 versions for model " + model_name)
                         self.assertEqual("7", model_metadata.versions[0])
-
-                    # Only version 7 should be ready. Neither should have infer stats
+                        
+                    # Only version 7 should be ready and show infer stat.
                     for v in (1, 7):
-                        infer_stats = triton_client.get_inference_statistics(model_name, model_version=str(v))
                         if v == 7:
                             self.assertTrue(triton_client.is_model_ready(model_name, model_version=str(v)))
+                            infer_stats = triton_client.get_inference_statistics(model_name, model_version=str(v))
+                            if pair[1] == "http":
+                                stats = infer_stats['model_stats'][0]['inference_stats']
+                                self.assertEqual(stats['success']['count'], 0,
+                                                    "unexpected infer stats for version " + str(v) +
+                                                    " of model " + model_name)
+                            else:
+                                stats = infer_stats.model_stats[0].inference_stats
+                                self.assertEqual(stats.success.count, 0,
+                                                    "unexpected infer stats for version " + str(v) +
+                                                    " of model " + model_name)
+
                         else:
                             self.assertFalse(triton_client.is_model_ready(model_name, model_version=str(v)))
+                            try:
+                                infer_stats = triton_client.get_inference_statistics(model_name, model_version=str(v))
+                                self.assertTrue(False, "unexpected infer stats for the model that is not ready")
+                            except InferenceServerException as ex:
+                                self.assertTrue("requested model version is not available for model" in str(ex))
 
-                        if pair[1] == "http":
-                            stats = infer_stats['model_stats'][0]['inference_stats']
-                            self.assertEqual(stats['success']['count'], 0,
-                                                "unexpected infer stats for version " + str(v) +
-                                                " of model " + model_name)
-                        else:
-                            stats = infer_stats.model_stats[0].inference_stats
-                            self.assertEqual(stats.success.count, 0,
-                                                "unexpected infer stats for version " + str(v) +
-                                                " of model " + model_name)
 
             except InferenceServerException as ex:
                 self.assertTrue(False, "unexpected error {}".format(ex))
@@ -469,7 +466,7 @@ class ModelMetadataTest(unittest.TestCase):
         # Originally There were 3 versions of *_int32_int32_int32 and
         # version 3 was executed once. Version 2 and 3 models were
         # deleted from the model repository so now only expect version 1 to
-        # be ready and version 3 to show stats but not be ready.
+        # be ready and show infer stats.
         for platform in ('graphdef', 'netdef'):
             model_name = platform + "_int32_int32_int32"
 
@@ -509,31 +506,28 @@ class ModelMetadataTest(unittest.TestCase):
                         stats = infer_stats['model_stats']
                     else:
                         stats = infer_stats.model_stats
-                    self.assertEqual(len(stats), 3,
-                                        "expected 3 infer stats for model " + model_name)
+                    self.assertEqual(len(stats), 1,
+                                        "expected 1 infer stats for model " + model_name)
 
-                    for s in stats:
+                    
+                    if pair[1] == "http":
+                        version = stats[0]['version']
+                        stat = stats[0]['inference_stats']
+                    else:
+                        version = stats[0].version
+                        stat = stats[0].inference_stats
+
+                    if version != "1":
+                        self.assertTrue(False, "expected version 1 for infer stat, got " + version)
+                    else:
                         if pair[1] == "http":
-                            version = s['version']
-                            stat = s['inference_stats']
+                            self.assertEqual(stat['success']['count'], 0,
+                                                "unexpected infer stats for version " + str(version) +
+                                                " of model " + model_name)
                         else:
-                            version = s.version
-                            stat = s.inference_stats
-
-                        if version != "3":
-                            if pair[1] == "http":
-                                self.assertEqual(stat['success']['count'], 0,
-                                                    "unexpected infer stats for version " + str(v) +
-                                                    " of model " + model_name)
-                            else:
-                                self.assertEqual(stat.success.count, 0,
-                                                    "unexpected infer stats for version " + str(v) +
-                                                    " of model " + model_name)
-                        else:
-                            if pair[1] == "http":
-                                self.assertTrue(stat['success']['count'], 3)
-                            else:
-                                self.assertTrue(stat.success.count, 3)
+                            self.assertEqual(stat.success.count, 0,
+                                                "unexpected infer stats for version " + str(version) +
+                                                " of model " + model_name)
 
             except InferenceServerException as ex:
                 self.assertTrue(False, "unexpected error {}".format(ex))
@@ -552,14 +546,14 @@ class ModelMetadataTest(unittest.TestCase):
                 self.assertTrue(triton_client.is_server_live())
                 self.assertTrue(triton_client.is_server_ready())
 
-                # Returns infer stats for ALL models + versions
+                # Returns infer stats for ALL models + ready versions
                 infer_stats = triton_client.get_inference_statistics()
                 if pair[1] == "http":
                     stats = infer_stats['model_stats']
                 else:
                     stats = infer_stats.model_stats
-                self.assertEqual(len(stats), 205,
-                                    "expected 205 infer stats for all versions of all model")
+                self.assertEqual(len(stats), 200,
+                                    "expected 200 infer stats for all ready versions of all model")
 
         except InferenceServerException as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))

--- a/qa/L0_server_status/server_status_test.py
+++ b/qa/L0_server_status/server_status_test.py
@@ -426,14 +426,14 @@ class ModelMetadataTest(unittest.TestCase):
                             model_name, model_metadata['name'], "expected status for model " + model_name)
                         self.assertEqual(len(model_metadata['versions']), 1,
                             "expected status for 1 versions for model " + model_name)
-                        self.assertEqual("7", model_metadata['versions'][0])                 
+                        self.assertEqual("7", model_metadata['versions'][0])
                     else:
                         self.assertEqual(
                             model_name, model_metadata.name, "expected status for model " + model_name)
                         self.assertEqual(len(model_metadata.versions), 1,
                             "expected status for 1 versions for model " + model_name)
                         self.assertEqual("7", model_metadata.versions[0])
-                        
+
                     # Only version 7 should be ready and show infer stat.
                     for v in (1, 7):
                         if v == 7:

--- a/qa/L0_server_status/test.sh
+++ b/qa/L0_server_status/test.sh
@@ -43,7 +43,7 @@ SERVER_STATUS_TEST=server_status_test.py
 DATADIR=/data/inferenceserver/${REPO_VERSION}
 
 SERVER=/opt/tritonserver/bin/tritonserver
-SERVER_ARGS="--repository-poll-secs=1 --model-repository=`pwd`/models"
+SERVER_ARGS="--repository-poll-secs=1 --model-control-mode=poll --model-repository=`pwd`/models"
 SERVER_LOG="./inference_server.log"
 source ../common/util.sh
 

--- a/src/clients/python/examples/grpc_explicit_byte_content_client.py
+++ b/src/clients/python/examples/grpc_explicit_byte_content_client.py
@@ -32,7 +32,7 @@ import numpy as np
 import grpc
 from tritongrpcclient import grpc_service_pb2
 from tritongrpcclient import grpc_service_pb2_grpc
-from tritonclientutils import utils
+import tritonclientutils as utils
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Note that now server returns only the infer_stats for models that are ready. This PR tunes the test to the new behavior.