### PR TITLE
Update C++ client libraries to use TritonJson

### DIFF
--- a/Dockerfile.centos_client
+++ b/Dockerfile.centos_client
@@ -41,7 +41,8 @@ RUN yum install -y \
         libtool \
         make \
         python3 \
-        python3-pip && \
+        python3-pip \
+        rapidjson-devel && \
     yum clean all && \
     pip3 install --upgrade wheel setuptools && \
     pip3 install --upgrade grpcio-tools

--- a/Dockerfile.custombackend
+++ b/Dockerfile.custombackend
@@ -42,7 +42,8 @@ RUN apt-get update && \
             libopencv-core-dev \
             libssl-dev \
             libtool \
-            pkg-config
+            pkg-config \
+            rapidjson-dev
 
 # Build the custom backend library and example custom backends
 WORKDIR /workspace

--- a/src/clients/c++/examples/CMakeLists.txt
+++ b/src/clients/c++/examples/CMakeLists.txt
@@ -45,6 +45,10 @@ else()
       json-utils-library EXCLUDE_FROM_ALL OBJECT
       json_utils.h json_utils.cc
   )
+  target_include_directories(
+    json-utils-library
+    PUBLIC ${RapidJSON_INCLUDE_DIRS}
+  )
 
   #
   # image_client
@@ -58,7 +62,6 @@ else()
   target_include_directories(
     image_client
     PRIVATE ${OpenCV_INCLUDE_DIRS}
-    PUBLIC ${RapidJSON_INCLUDE_DIRS}
   )
   target_link_libraries(
     image_client
@@ -78,10 +81,6 @@ else()
     ensemble_image_client
     ensemble_image_client.cc
     $<TARGET_OBJECTS:json-utils-library>
-  )
-  target_include_directories(
-    image_client
-    PUBLIC ${RapidJSON_INCLUDE_DIRS}
   )
   target_link_libraries(
     ensemble_image_client
@@ -238,10 +237,6 @@ else()
     simple_http_health_metadata.cc
     $<TARGET_OBJECTS:json-utils-library>
   )
-  target_include_directories(
-      simple_http_health_metadata
-      PUBLIC ${RapidJSON_INCLUDE_DIRS}
-  )
   target_link_libraries(
     simple_http_health_metadata
     PRIVATE TRITON::httpclient_static
@@ -258,10 +253,6 @@ else()
     simple_http_model_control
     simple_http_model_control.cc
     $<TARGET_OBJECTS:json-utils-library>
-  )
-  target_include_directories(
-      simple_http_model_control
-      PUBLIC ${RapidJSON_INCLUDE_DIRS}
   )
   target_link_libraries(
     simple_http_model_control

--- a/src/clients/c++/examples/CMakeLists.txt
+++ b/src/clients/c++/examples/CMakeLists.txt
@@ -38,11 +38,28 @@ else()
   )
 
   #
+  # json_utils
+  #
+  find_package(RapidJSON CONFIG REQUIRED)
+  add_library(
+      json-utils-library EXCLUDE_FROM_ALL OBJECT
+      json_utils.h json_utils.cc
+  )
+
+  #
   # image_client
   #
   find_package(OpenCV REQUIRED)
-  add_executable(image_client image_client.cc)
-  target_include_directories(image_client PRIVATE ${OpenCV_INCLUDE_DIRS})
+  add_executable(
+    image_client
+    image_client.cc
+    $<TARGET_OBJECTS:json-utils-library>
+  )
+  target_include_directories(
+    image_client
+    PRIVATE ${OpenCV_INCLUDE_DIRS}
+    PUBLIC ${RapidJSON_INCLUDE_DIRS}
+  )
   target_link_libraries(
     image_client
     PRIVATE TRITON::grpcclient_static
@@ -57,7 +74,15 @@ else()
   #
   # ensemble_image_client
   #
-  add_executable(ensemble_image_client ensemble_image_client.cc)
+  add_executable(
+    ensemble_image_client
+    ensemble_image_client.cc
+    $<TARGET_OBJECTS:json-utils-library>
+  )
+  target_include_directories(
+    image_client
+    PUBLIC ${RapidJSON_INCLUDE_DIRS}
+  )
   target_link_libraries(
     ensemble_image_client
     PRIVATE TRITON::grpcclient_static
@@ -208,7 +233,15 @@ else()
   #
   # simple_http_health_metadata
   #
-  add_executable(simple_http_health_metadata simple_http_health_metadata.cc)
+  add_executable(
+    simple_http_health_metadata
+    simple_http_health_metadata.cc
+    $<TARGET_OBJECTS:json-utils-library>
+  )
+  target_include_directories(
+      simple_http_health_metadata
+      PUBLIC ${RapidJSON_INCLUDE_DIRS}
+  )
   target_link_libraries(
     simple_http_health_metadata
     PRIVATE TRITON::httpclient_static
@@ -221,7 +254,15 @@ else()
   #
   # simple_http_model_control
   #
-  add_executable(simple_http_model_control simple_http_model_control.cc)
+  add_executable(
+    simple_http_model_control
+    simple_http_model_control.cc
+    $<TARGET_OBJECTS:json-utils-library>
+  )
+  target_include_directories(
+      simple_http_model_control
+      PUBLIC ${RapidJSON_INCLUDE_DIRS}
+  )
   target_link_libraries(
     simple_http_model_control
     PRIVATE TRITON::httpclient_static

--- a/src/clients/c++/examples/ensemble_image_client.cc
+++ b/src/clients/c++/examples/ensemble_image_client.cc
@@ -32,6 +32,7 @@
 #include <iterator>
 #include <sstream>
 #include <string>
+#include "src/clients/c++/examples/json_utils.h"
 #include "src/clients/c++/library/grpc_client.h"
 #include "src/clients/c++/library/http_client.h"
 
@@ -280,14 +281,20 @@ main(int argc, char** argv)
   // of the images to be processed is limited by the maximum batch size
   size_t batch_size = 0;
   if (protocol == "http") {
-    rapidjson::Document model_config;
+    std::string model_config;
     err = triton_client.http_client_->ModelConfig(&model_config, model_name);
     if (!err.IsOk()) {
       std::cerr << "error: failed to get model config: " << err << std::endl;
     }
 
-    const auto bs_itr = model_config.FindMember("max_batch_size");
-    if (bs_itr != model_config.MemberEnd()) {
+    rapidjson::Document model_config_json;
+    err = nic::ParseJson(&model_config_json, model_config);
+    if (!err.IsOk()) {
+      std::cerr << "error: failed to parse model config: " << err << std::endl;
+    }
+
+    const auto bs_itr = model_config_json.FindMember("max_batch_size");
+    if (bs_itr != model_config_json.MemberEnd()) {
       batch_size = bs_itr->value.GetInt();
     }
   } else {

--- a/src/clients/c++/examples/json_utils.cc
+++ b/src/clients/c++/examples/json_utils.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/c++/examples/json_utils.h"
+
+#include <rapidjson/error/en.h>
+
+namespace nvidia { namespace inferenceserver { namespace client {
+
+Error
+ParseJson(rapidjson::Document* document, const std::string& json_str)
+{
+  document->Parse(json_str.c_str(), json_str.size());
+  if (document->HasParseError()) {
+    return Error(
+        "failed to parse JSON at" + std::to_string(document->GetErrorOffset()) +
+        ": " + std::string(GetParseError_En(document->GetParseError())));
+  }
+
+  return Error::Success;
+}
+
+}}}  // namespace nvidia::inferenceserver::client

--- a/src/clients/c++/examples/json_utils.h
+++ b/src/clients/c++/examples/json_utils.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <rapidjson/document.h>
+#include <rapidjson/rapidjson.h>
+#include <string>
+#include "src/clients/c++/library/common.h"
+
+namespace nvidia { namespace inferenceserver { namespace client {
+
+Error ParseJson(rapidjson::Document* document, const std::string& json_str);
+
+}}}  // namespace nvidia::inferenceserver::client

--- a/src/clients/c++/examples/simple_http_cudashm_client.cc
+++ b/src/clients/c++/examples/simple_http_cudashm_client.cc
@@ -299,12 +299,12 @@ main(int argc, char** argv)
     }
   }
 
-  // Get shared memory regions  active/registered within triton
-  rapidjson::Document status;
+  // Get shared memory regions active/registered within triton
+  std::string shm_status;
   FAIL_IF_ERR(
-      client->CudaSharedMemoryStatus(&status),
+      client->CudaSharedMemoryStatus(&shm_status),
       "failed to get shared memory status");
-  std::cout << "Shared Memory Status:\n" << nic::GetJsonText(status) << "\n";
+  std::cout << "Shared Memory Status:\n" << shm_status << "\n";
 
   // Unregister shared memory
   FAIL_IF_ERR(

--- a/src/clients/c++/examples/simple_http_infer_client.cc
+++ b/src/clients/c++/examples/simple_http_infer_client.cc
@@ -264,10 +264,12 @@ main(int argc, char** argv)
   std::cout << "cumulative_receive_time_ns "
             << infer_stat.cumulative_receive_time_ns << std::endl;
 
-  rapidjson::Document model_stat;
-  client->ModelInferenceStatistics(&model_stat, model_name);
+  std::string model_stat;
+  FAIL_IF_ERR(
+      client->ModelInferenceStatistics(&model_stat, model_name),
+      "unable to get model statistics");
   std::cout << "======Model Statistics======" << std::endl;
-  std::cout << nic::GetJsonText(model_stat) << std::endl;
+  std::cout << model_stat << std::endl;
 
   std::cout << "PASS : Infer" << std::endl;
 

--- a/src/clients/c++/examples/simple_http_model_control.cc
+++ b/src/clients/c++/examples/simple_http_model_control.cc
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <string>
+#include "src/clients/c++/examples/json_utils.h"
 #include "src/clients/c++/library/http_client.h"
 
 namespace ni = nvidia::inferenceserver;
@@ -102,14 +103,20 @@ main(int argc, char** argv)
       nic::InferenceServerHttpClient::Create(&client, url, verbose),
       "unable to create http client");
 
-  rapidjson::Document repository_index;
-  FAIL_IF_ERR(
-      client->ModelRepositoryIndex(&repository_index, http_headers),
-      "Failed to get repository index");
-  if (repository_index.Size() != 9) {
-    std::cerr << "expected number of models 9, got " << repository_index.Size()
-              << std::endl;
-    exit(1);
+  {
+    std::string repository_index;
+    FAIL_IF_ERR(
+        client->ModelRepositoryIndex(&repository_index, http_headers),
+        "Failed to get repository index");
+    rapidjson::Document repository_index_json;
+    FAIL_IF_ERR(
+        nic::ParseJson(&repository_index_json, repository_index),
+        "failed to parse model config");
+    if (repository_index_json.Size() != 9) {
+      std::cerr << "expected number of models 9, got "
+                << repository_index_json.Size() << std::endl;
+      exit(1);
+    }
   }
 
 

--- a/src/clients/c++/examples/simple_http_shm_client.cc
+++ b/src/clients/c++/examples/simple_http_shm_client.cc
@@ -275,11 +275,11 @@ main(int argc, char** argv)
   }
 
   // Get shared memory regions active/registered within triton
-  rapidjson::Document status;
+  std::string shm_status;
   FAIL_IF_ERR(
-      client->SystemSharedMemoryStatus(&status),
+      client->SystemSharedMemoryStatus(&shm_status),
       "failed to get shared memory status");
-  std::cout << "Shared Memory Status:\n" << nic::GetJsonText(status) << "\n";
+  std::cout << "Shared Memory Status:\n" << shm_status << "\n";
 
   // Unregister shared memory
   FAIL_IF_ERR(

--- a/src/clients/c++/library/CMakeLists.txt
+++ b/src/clients/c++/library/CMakeLists.txt
@@ -64,6 +64,7 @@ if(${TRITON_ENABLE_GRPC})
       $<TARGET_OBJECTS:model-config-library>
       $<TARGET_OBJECTS:proto-library>
       $<TARGET_OBJECTS:grpc-client-library>
+      $<TARGET_OBJECTS:triton-json-library>
   )
   add_library(
       TRITON::grpcclient_static ALIAS grpcclient_static
@@ -93,6 +94,7 @@ if(${TRITON_ENABLE_GRPC})
       $<TARGET_OBJECTS:model-config-library>
       $<TARGET_OBJECTS:proto-library>
       $<TARGET_OBJECTS:grpc-client-library>
+      $<TARGET_OBJECTS:triton-json-library>
   )
   add_library(
       TRITON::grpcclient ALIAS grpcclient
@@ -144,9 +146,6 @@ if(${TRITON_ENABLE_HTTP})
   #
   # libhttpclient.so and libhttpclient_static.a
   #
-
-  find_package(RapidJSON CONFIG REQUIRED)
-
   find_package(CURL CONFIG REQUIRED)
   message(STATUS "Using curl ${CURL_VERSION}")
   add_definitions(-DCURL_STATICLIB)
@@ -172,7 +171,6 @@ if(${TRITON_ENABLE_HTTP})
   target_include_directories(
       http-client-library
       PRIVATE $<TARGET_PROPERTY:CURL::libcurl,INTERFACE_INCLUDE_DIRECTORIES>
-      PUBLIC ${RapidJSON_INCLUDE_DIRS}
   )
   if(${TRITON_ENABLE_GPU})
     target_include_directories(http-client-library PUBLIC ${CUDA_INCLUDE_DIRS})
@@ -182,6 +180,7 @@ if(${TRITON_ENABLE_HTTP})
   add_library(
       httpclient_static STATIC
       $<TARGET_OBJECTS:http-client-library>
+      $<TARGET_OBJECTS:triton-json-library>
   )
   add_library(
       TRITON::httpclient_static ALIAS httpclient_static
@@ -206,6 +205,7 @@ if(${TRITON_ENABLE_HTTP})
   add_library(
       httpclient SHARED
       $<TARGET_OBJECTS:http-client-library>
+      $<TARGET_OBJECTS:triton-json-library>
   )
   add_library(
       TRITON::httpclient ALIAS httpclient

--- a/src/clients/c++/library/common.cc
+++ b/src/clients/c++/library/common.cc
@@ -314,9 +314,10 @@ InferRequestedOutput::SharedMemoryInfo(
   if (io_type_ != SHARED_MEMORY) {
     return Error("The input has not been set with the shared memory.");
   }
+
   *name = shm_name_;
-  *offset = shm_offset_;
   *byte_size = shm_byte_size_;
+  *offset = shm_offset_;
 
   return Error::Success;
 }

--- a/src/clients/c++/library/grpc_client.cc
+++ b/src/clients/c++/library/grpc_client.cc
@@ -1051,7 +1051,7 @@ InferenceServerGrpcClient::PreRunProcessing(
   for (const auto routput : outputs) {
     auto grpc_output = infer_request_.add_outputs();
     grpc_output->set_name(routput->Name());
-    size_t class_count = routput->ClassCount();
+    size_t class_count = routput->ClassificationCount();
     if (class_count != 0) {
       (*grpc_output->mutable_parameters())["classification"].set_int64_param(
           class_count);

--- a/src/clients/c++/library/grpc_client.h
+++ b/src/clients/c++/library/grpc_client.h
@@ -28,11 +28,18 @@
 /// \file
 
 #include <queue>
-
 #include "src/clients/c++/library/common.h"
 #include "src/core/constants.h"
 #include "src/core/grpc_service.grpc.pb.h"
 #include "src/core/model_config.pb.h"
+
+#ifdef TRITON_ENABLE_GPU
+#include <cuda_runtime_api.h>
+#else
+struct cudaIpcMemHandle_t {
+};
+#endif  // TRITON_ENABLE_GPU
+
 
 namespace nvidia { namespace inferenceserver { namespace client {
 

--- a/src/clients/c++/perf_client/CMakeLists.txt
+++ b/src/clients/c++/perf_client/CMakeLists.txt
@@ -31,8 +31,6 @@ if(WIN32)
 		      "are UNIX specific.")
 else()
 
-find_package(RapidJSON CONFIG REQUIRED)
-
 set(
   PERF_CLIENT_SRCS
   perf_client.cc
@@ -67,10 +65,6 @@ add_executable(
   ${PERF_CLIENT_SRCS}
   ${PERF_CLIENT_HDRS}
   $<TARGET_OBJECTS:json-utils-library>
-)
-target_include_directories(
-  perf_client
-  PRIVATE ${RapidJSON_INCLUDE_DIRS}
 )
 target_link_libraries(
   perf_client

--- a/src/clients/c++/perf_client/CMakeLists.txt
+++ b/src/clients/c++/perf_client/CMakeLists.txt
@@ -62,11 +62,16 @@ set(
  ../examples/shm_utils.h
 )
 
-add_executable(perf_client
-  ${PERF_CLIENT_SRCS} ${PERF_CLIENT_HDRS})
+add_executable(
+  perf_client
+  ${PERF_CLIENT_SRCS}
+  ${PERF_CLIENT_HDRS}
+  $<TARGET_OBJECTS:json-utils-library>
+)
 target_include_directories(
   perf_client
-  PRIVATE ${RapidJSON_INCLUDE_DIRS})
+  PRIVATE ${RapidJSON_INCLUDE_DIRS}
+)
 target_link_libraries(
   perf_client
   PRIVATE TRITON::grpcclient_static

--- a/src/clients/c++/perf_client/perf_utils.h
+++ b/src/clients/c++/perf_client/perf_utils.h
@@ -32,8 +32,8 @@
 #include <random>
 
 #include <rapidjson/document.h>
+#include <rapidjson/rapidjson.h>
 #include <sys/stat.h>
-#include "rapidjson/rapidjson.h"
 #include "src/clients/c++/library/grpc_client.h"
 #include "src/clients/c++/library/http_client.h"
 #include "src/core/constants.h"

--- a/src/clients/c++/perf_client/triton_client_wrapper.cc
+++ b/src/clients/c++/perf_client/triton_client_wrapper.cc
@@ -24,9 +24,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 #include "src/clients/c++/perf_client/triton_client_wrapper.h"
 
+#include "src/clients/c++/examples/json_utils.h"
 
 //==============================================================================
 
@@ -74,8 +74,10 @@ TritonClientWrapper::ModelMetadata(
     const std::string& model_version)
 {
   if (protocol_ == ProtocolType::HTTP) {
+    std::string metadata;
     RETURN_IF_ERROR(client_.http_client_->ModelMetadata(
-        model_metadata, model_name, model_version, *http_headers_));
+        &metadata, model_name, model_version, *http_headers_));
+    RETURN_IF_ERROR(nic::ParseJson(model_metadata, metadata));
   } else {
     return nic::Error("gRPC can not return model metadata as json");
   }
@@ -105,8 +107,10 @@ TritonClientWrapper::ModelConfig(
     const std::string& model_version)
 {
   if (protocol_ == ProtocolType::HTTP) {
+    std::string config;
     RETURN_IF_ERROR(client_.http_client_->ModelConfig(
-        model_config, model_name, model_version, *http_headers_));
+        &config, model_name, model_version, *http_headers_));
+    RETURN_IF_ERROR(nic::ParseJson(model_config, config));
   } else {
     return nic::Error("gRPC can not return model config as json");
   }
@@ -214,10 +218,12 @@ TritonClientWrapper::ModelInferenceStatistics(
         &infer_stat, model_name, model_version, *http_headers_));
     ParseStatistics(infer_stat, model_stats);
   } else {
-    rapidjson::Document infer_stat;
+    std::string infer_stat;
     RETURN_IF_ERROR(client_.http_client_->ModelInferenceStatistics(
         &infer_stat, model_name, model_version, *http_headers_));
-    ParseStatistics(infer_stat, model_stats);
+    rapidjson::Document infer_stat_json;
+    RETURN_IF_ERROR(nic::ParseJson(&infer_stat_json, infer_stat));
+    ParseStatistics(infer_stat_json, model_stats);
   }
 
   return nic::Error::Success;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -104,6 +104,19 @@ if(${TRITON_ENABLE_GPU})
 endif() # TRITON_ENABLE_GPU
 
 #
+# JSON utilities used by both clients and server
+#
+find_package(RapidJSON CONFIG REQUIRED)
+add_library(
+    triton-json-library EXCLUDE_FROM_ALL OBJECT
+    json.h
+)
+target_include_directories(
+  triton-json-library
+  PUBLIC ${RapidJSON_INCLUDE_DIRS}
+)
+
+#
 # Inference server core
 #
 if(${TRITON_ENABLE_GCS})
@@ -159,7 +172,6 @@ set(
   filesystem.h
   infer_request.h
   infer_response.h
-  json.h
   label_provider.h
   logging.h
   memory.h

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -43,7 +43,9 @@
 #include "src/core/server.h"
 #include "src/core/status.h"
 
-#define TRITONJSON_INTERNAL_STATUS
+#define TRITONJSON_STATUSTYPE Status
+#define TRITONJSON_STATUSRETURN(M) return Status(Status::Code::INTERNAL, (M))
+#define TRITONJSON_STATUSSUCCESS Status::Success
 #include "src/core/json.h"
 
 namespace ni = nvidia::inferenceserver;

--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -347,6 +347,7 @@ add_library(
   $<TARGET_OBJECTS:server-library>
   $<TARGET_OBJECTS:model-config-library>
   $<TARGET_OBJECTS:proto-library>
+  $<TARGET_OBJECTS:triton-json-library>
   ${CUDA_OBJS}
   ${BACKEND_OBJS}
 )

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -46,7 +46,10 @@
 #include "src/servers/classification.h"
 #include "src/servers/common.h"
 
-#define TRITONJSON_TRITONSERVER_STATUS
+#define TRITONJSON_STATUSTYPE TRITONSERVER_Error*
+#define TRITONJSON_STATUSRETURN(M) \
+  return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, (M).c_str())
+#define TRITONJSON_STATUSSUCCESS nullptr
 #include "src/core/json.h"
 
 #ifdef TRITON_ENABLE_TRACING

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -40,7 +40,10 @@
 #include "src/servers/classification.h"
 #include "src/servers/common.h"
 
-#define TRITONJSON_TRITONSERVER_STATUS
+#define TRITONJSON_STATUSTYPE TRITONSERVER_Error*
+#define TRITONJSON_STATUSRETURN(M) \
+  return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, (M).c_str())
+#define TRITONJSON_STATUSSUCCESS nullptr
 #include "src/core/json.h"
 
 #ifdef TRITON_ENABLE_GPU

--- a/src/servers/shared_memory_manager.h
+++ b/src/servers/shared_memory_manager.h
@@ -31,7 +31,10 @@
 #include "src/core/server_status.pb.h"
 #include "src/core/tritonserver.h"
 
-#define TRITONJSON_TRITONSERVER_STATUS
+#define TRITONJSON_STATUSTYPE TRITONSERVER_Error*
+#define TRITONJSON_STATUSRETURN(M) \
+  return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, (M).c_str())
+#define TRITONJSON_STATUSSUCCESS nullptr
 #include "src/core/json.h"
 
 #ifdef TRITON_ENABLE_GRPC


### PR DESCRIPTION
The C++ API is changes to return JSON as a string, not as a rapidjson object model.  The examples themselves continue to use radpijson to parse that json when necessary (but any json library could be used).