### PR TITLE
Fix TRT backend to handle dynamically batched requests

### DIFF
--- a/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
+++ b/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
@@ -127,39 +127,40 @@ class InferShapeTensorTest(unittest.TestCase):
         self.assertTrue(6 in bconfig.preferred_batch_size)
         self.assertEqual(bconfig.max_queue_delay_microseconds, _max_queue_delay_ms * 1000) # 10 secs
 
-    def check_status(self, model_name, batch_exec, request_cnt, infer_cnt):
+    def check_status(self, model_name, batch_exec, exec_cnt, infer_cnt):
         stats = self.triton_client_.get_inference_statistics(model_name, "1")
         self.assertEqual(len(stats.model_stats), 1, "expect 1 model stats")
         self.assertEqual(stats.model_stats[0].name, model_name,
                          "expect model stats for model {}".format(model_name))
         self.assertEqual(stats.model_stats[0].version, "1",
                          "expect model stats for model {} version 1".format(model_name))
-        
-        
-        batch_stats = stats.model_stats[0].batch_stats
-        self.assertEqual(len(batch_stats), len(batch_exec),
-                          "expected {} different batch-sizes, got {}".format(
-                                 len(batch_exec), len(batch_stats)))
 
-        for batch_stat in batch_stats:
-             bs = batch_stat.batch_size
-             bc = batch_stat.compute_infer.count
-             self.assertTrue(bs in batch_exec,
-                             "unexpected batch-size {}".format(bs))
-             # Get count from one of the stats
-             self.assertEqual(bc, batch_exec[bs],
-                             "expected model-execution-count {} for batch size {}, got {}".format(
-                                     batch_exec[bs], bs, bc))
+        if batch_exec is not None:
+            batch_stats = stats.model_stats[0].batch_stats
+            print(batch_stats)
+            self.assertEqual(len(batch_stats), len(batch_exec),
+                             "expected {} different batch-sizes, got {}".format(
+                               len(batch_exec), len(batch_stats)))
 
-        actual_request_cnt = stats.model_stats[0].inference_stats.success.count
-        self.assertEqual(actual_request_cnt, request_cnt,
-                        "expected model-request-count {}, got {}".format(
-                                request_cnt, actual_request_cnt))
+            for batch_stat in batch_stats:
+                bs = batch_stat.batch_size
+                bc = batch_stat.compute_infer.count
+                self.assertTrue(bs in batch_exec,
+                                "did not find expected batch-size {}".format(bs))
+                # Get count from one of the stats
+                self.assertEqual(bc, batch_exec[bs],
+                                 "expected model-execution-count {} for batch size {}, got {}".format(
+                                   batch_exec[bs], bs, bc))
 
         actual_exec_cnt = stats.model_stats[0].execution_count
-        self.assertEqual(actual_request_cnt, request_cnt,
+        self.assertEqual(actual_exec_cnt, exec_cnt,
                         "expected model-exec-count {}, got {}".format(
-                                request_cnt, actual_exec_cnt))
+                                exec_cnt, actual_exec_cnt))
+
+        actual_infer_cnt = stats.model_stats[0].inference_count
+        self.assertEqual(actual_infer_cnt, infer_cnt,
+                         "expected model-inference-count {}, got {}".format(
+                                 infer_cnt, actual_infer_cnt))
         
         actual_infer_cnt = stats.model_stats[0].inference_count
         self.assertEqual(actual_infer_cnt, infer_cnt,
@@ -301,7 +302,7 @@ class InferShapeTensorTest(unittest.TestCase):
             for t in threads:
                 t.join()
             self.check_deferred_exception()
-            self.check_status(model_name, {6: 1}, 2, 6)
+            self.check_status(model_name, {6: 1}, 1, 6)
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
 
@@ -413,7 +414,7 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
             for t in threads:
                 t.join()
             self.check_deferred_exception()
-            self.check_status(model_name, {4: 3}, 12, 12)
+            self.check_status(model_name, {4: 3}, 3, 12)
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
         finally:
@@ -525,7 +526,7 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
                 t.join()
 
             self.check_deferred_exception()
-            self.check_status(model_name, {2: 3, 1: 6}, 12, 12)
+            self.check_status(model_name, {2: 3, 1: 6}, 9, 12)
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
         finally:
@@ -777,7 +778,7 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
             for t in threads:
                 t.join()
             self.check_deferred_exception()
-            self.check_status(model_name, {4: 3}, 12, 12)
+            self.check_status(model_name, {4: 3}, 3, 12)
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
         finally:

--- a/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
+++ b/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
@@ -42,7 +42,6 @@ import sequence_util as su
 import tritongrpcclient as grpcclient
 
 TEST_SYSTEM_SHARED_MEMORY = bool(int(os.environ.get('TEST_SYSTEM_SHARED_MEMORY', 0)))
-TEST_CUDA_SHARED_MEMORY = bool(int(os.environ.get('TEST_CUDA_SHARED_MEMORY',0)))
 
 _model_instances = 1
 _max_queue_delay_ms = 10000
@@ -99,7 +98,6 @@ class InferShapeTensorTest(unittest.TestCase):
                 use_streaming=False,
                 shm_suffix=shm_suffix,
                 use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-                use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
                 batch_size=bs)
 
             end_ms = int(round(time.time() * 1000))
@@ -174,21 +172,18 @@ class InferShapeTensorTest(unittest.TestCase):
             'plan',
             np.float32, [[32, 32]], [[8, 4, 4]],
             use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-            use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
             batch_size=8)
         iu.infer_shape_tensor(
             self,
             'plan',
             np.float32, [[4, 4]], [[8, 32, 32]],
             use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-            use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
             batch_size=8)
         iu.infer_shape_tensor(
             self,
             'plan',
             np.float32, [[4, 4]], [[8, 4, 4]],
             use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-            use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
             batch_size=8)
 
     def test_nobatch(self):
@@ -196,20 +191,17 @@ class InferShapeTensorTest(unittest.TestCase):
             self,
             'plan_nobatch',
             np.float32, [[32, 32]], [[4, 4]],
-            use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-            use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY)
+            use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY)
         iu.infer_shape_tensor(
             self,
             'plan_nobatch',
             np.float32, [[4, 4]], [[32, 32]],
-            use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-            use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY)
+            use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY)
         iu.infer_shape_tensor(
             self,
             'plan_nobatch',
             np.float32, [[4, 4]], [[4, 4]],
-            use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-            use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY)
+            use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY)
 
     def test_wrong_shape_values(self):
         over_shape_values = [[32, 33]]
@@ -220,7 +212,6 @@ class InferShapeTensorTest(unittest.TestCase):
                 np.float32,
                 over_shape_values, [[8, 4, 4]],
                 use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-                use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
                 batch_size=8)
         # InferenceServerException will be raised from different namespace,
         # use dynamic type characteristic to catch both ex
@@ -418,7 +409,7 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
         finally:
-            if TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY:
+            if TEST_SYSTEM_SHARED_MEMORY:
                 self.cleanup_shm_regions(precreated_shm0_handles)
                 self.cleanup_shm_regions(precreated_shm1_handles)
                 self.cleanup_shm_regions(precreated_shm2_handles)
@@ -530,7 +521,7 @@ class SequenceBatcherShapeTensorTest(su.SequenceBatcherTestUtil):
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
         finally:
-            if TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY:
+            if TEST_SYSTEM_SHARED_MEMORY:
                 self.cleanup_shm_regions(precreated_shm0_handles)
                 self.cleanup_shm_regions(precreated_shm1_handles)
                 self.cleanup_shm_regions(precreated_shm2_handles)
@@ -662,7 +653,7 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
         finally:
-            if TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY:
+            if TEST_SYSTEM_SHARED_MEMORY:
                 self.cleanup_shm_regions(precreated_shm0_handles)
                 self.cleanup_shm_regions(precreated_shm1_handles)
                 self.cleanup_shm_regions(precreated_shm2_handles)
@@ -782,7 +773,7 @@ class DynaSequenceBatcherTest(su.SequenceBatcherTestUtil):
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
         finally:
-            if TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY:
+            if TEST_SYSTEM_SHARED_MEMORY:
                 self.cleanup_shm_regions(precreated_shm0_handles)
                 self.cleanup_shm_regions(precreated_shm1_handles)
                 self.cleanup_shm_regions(precreated_shm2_handles)

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -150,7 +150,9 @@ class SequenceBatcherTestUtil(unittest.TestCase):
     # Returns (name, byte size, shm_handle)
     def precreate_register_shape_tensor_regions(self, value_list, dtype, i,
                                             batch_size=1, tensor_shape=(1,)):
-        if _test_system_shared_memory or _test_cuda_shared_memory:
+        self.assertFalse(_test_cuda_shared_memory,
+                        "Shape tensors does not support CUDA shared memory")
+        if _test_system_shared_memory:
             shm_region_handles = []
             for j, (shape_value, value) in enumerate(value_list):
                 input_list = list()
@@ -181,42 +183,25 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                 shape_op_name = 'shape_op{}{}'.format(i,j)
                 op_name = 'op{}{}'.format(i,j)
                 resized_op_name = 'resized_op{}{}'.format(i,j)
-                if _test_system_shared_memory:
-                    shm_ip_handle = shm.create_shared_memory_region(
-                        ip_name, '/'+ip_name, input_byte_size)
-                    shm_shape_ip_handle = shm.create_shared_memory_region(
-                        shape_ip_name, '/'+shape_ip_name, shape_input_byte_size)
-                    shm_shape_op_handle = shm.create_shared_memory_region(
-                        shape_op_name, '/'+shape_op_name, shape_output_byte_size)
-                    shm_op_handle = shm.create_shared_memory_region(
-                        op_name, '/'+op_name, output_byte_size)
-                    shm_resized_op_handle = shm.create_shared_memory_region(
-                        resized_op_name, '/'+resized_op_name, resized_output_byte_size)
-                    shm.set_shared_memory_region(shm_ip_handle, input_list_tmp)
-                    shm.set_shared_memory_region(shm_shape_ip_handle, shape_input_list)
-                    self.triton_client_.register_system_shared_memory(ip_name, '/'+ip_name, input_byte_size)
-                    self.triton_client_.register_system_shared_memory(shape_ip_name, '/'+shape_ip_name, shape_input_byte_size)
-                    self.triton_client_.register_system_shared_memory(shape_op_name, '/'+shape_op_name, shape_output_byte_size)
-                    self.triton_client_.register_system_shared_memory(op_name, '/'+op_name, output_byte_size)
-                    self.triton_client_.register_system_shared_memory(resized_op_name, '/'+resized_op_name, resized_output_byte_size)
-                elif _test_cuda_shared_memory:
-                    shm_ip_handle = cudashm.create_shared_memory_region(
-                        ip_name, input_byte_size, 0)
-                    shm_shape_ip_handle = cudashm.create_shared_memory_region(
-                        shape_ip_name, shape_input_byte_size, 0)
-                    shm_shape_op_handle = cudashm.create_shared_memory_region(
-                        shape_op_name, shape_output_byte_size, 0)
-                    shm_op_handle = cudashm.create_shared_memory_region(
-                        op_name, output_byte_size, 0)
-                    shm_resized_op_handle = cudashm.create_shared_memory_region(
-                        resized_op_name, resized_output_byte_size, 0)
-                    cudashm.set_shared_memory_region(shm_ip_handle, input_list_tmp)
-                    cudashm.set_shared_memory_region(shm_shape_ip_handle, shape_input_list)
-                    self.triton_client_.register_cuda_shared_memory(ip_name, cudashm.get_raw_handle(shm_ip_handle), 0, input_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(shape_ip_name, cudashm.get_raw_handle(shm_shape_ip_handle), 0, shape_input_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(shape_op_name, cudashm.get_raw_handle(shm_shape_op_handle), 0, shape_output_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(op_name, cudashm.get_raw_handle(shm_op_handle), 0, output_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(resized_op_name, cudashm.get_raw_handle(shm_resized_op_handle), 0, resized_output_byte_size)
+                
+                shm_ip_handle = shm.create_shared_memory_region(
+                    ip_name, '/'+ip_name, input_byte_size)
+                shm_shape_ip_handle = shm.create_shared_memory_region(
+                    shape_ip_name, '/'+shape_ip_name, shape_input_byte_size)
+                shm_shape_op_handle = shm.create_shared_memory_region(
+                    shape_op_name, '/'+shape_op_name, shape_output_byte_size)
+                shm_op_handle = shm.create_shared_memory_region(
+                    op_name, '/'+op_name, output_byte_size)
+                shm_resized_op_handle = shm.create_shared_memory_region(
+                    resized_op_name, '/'+resized_op_name, resized_output_byte_size)
+                shm.set_shared_memory_region(shm_ip_handle, input_list_tmp)
+                shm.set_shared_memory_region(shm_shape_ip_handle, shape_input_list)
+                self.triton_client_.register_system_shared_memory(ip_name, '/'+ip_name, input_byte_size)
+                self.triton_client_.register_system_shared_memory(shape_ip_name, '/'+shape_ip_name, shape_input_byte_size)
+                self.triton_client_.register_system_shared_memory(shape_op_name, '/'+shape_op_name, shape_output_byte_size)
+                self.triton_client_.register_system_shared_memory(op_name, '/'+op_name, output_byte_size)
+                self.triton_client_.register_system_shared_memory(resized_op_name, '/'+resized_op_name, resized_output_byte_size)
+                
                 shm_region_handles.append((ip_name, input_byte_size, shm_ip_handle))
                 shm_region_handles.append((shape_ip_name, shape_input_byte_size, shm_shape_ip_handle))
                 shm_region_handles.append((shape_op_name, shape_output_byte_size, shm_shape_op_handle))
@@ -229,7 +214,9 @@ class SequenceBatcherTestUtil(unittest.TestCase):
     # Returns (name, byte size, shm_handle)
     def precreate_register_dynaseq_shape_tensor_regions(self, value_list, dtype, i,
                                             batch_size=1, tensor_shape=(1,)):
-        if _test_system_shared_memory or _test_cuda_shared_memory:
+        self.assertFalse(_test_cuda_shared_memory,
+                        "Shape tensors does not support CUDA shared memory")
+        if _test_system_shared_memory:
             shm_region_handles = []
             for j, (shape_value, value) in enumerate(value_list):
                 input_list = list()
@@ -265,50 +252,29 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                 shape_op_name = 'shape_op{}{}'.format(i,j)
                 op_name = 'op{}{}'.format(i,j)
                 resized_op_name = 'resized_op{}{}'.format(i,j)
-                if _test_system_shared_memory:
-                    shm_ip_handle = shm.create_shared_memory_region(
-                        ip_name, '/'+ip_name, input_byte_size)
-                    shm_shape_ip_handle = shm.create_shared_memory_region(
-                        shape_ip_name, '/'+shape_ip_name, shape_input_byte_size)
-                    shm_dummy_ip_handle = shm.create_shared_memory_region(
-                        dummy_ip_name, '/'+dummy_ip_name, dummy_input_byte_size)
-                    shm_shape_op_handle = shm.create_shared_memory_region(
-                        shape_op_name, '/'+shape_op_name, shape_output_byte_size)
-                    shm_op_handle = shm.create_shared_memory_region(
-                        op_name, '/'+op_name, output_byte_size)
-                    shm_resized_op_handle = shm.create_shared_memory_region(
-                        resized_op_name, '/'+resized_op_name, resized_output_byte_size)
-                    shm.set_shared_memory_region(shm_ip_handle, input_list_tmp)
-                    shm.set_shared_memory_region(shm_shape_ip_handle, shape_input_list)
-                    shm.set_shared_memory_region(shm_dummy_ip_handle, dummy_input_list)
-                    self.triton_client_.register_system_shared_memory(ip_name, '/'+ip_name, input_byte_size)
-                    self.triton_client_.register_system_shared_memory(shape_ip_name, '/'+shape_ip_name, shape_input_byte_size)
-                    self.triton_client_.register_system_shared_memory(dummy_ip_name, '/'+dummy_ip_name, dummy_input_byte_size)
-                    self.triton_client_.register_system_shared_memory(shape_op_name, '/'+shape_op_name, shape_output_byte_size)
-                    self.triton_client_.register_system_shared_memory(op_name, '/'+op_name, output_byte_size)
-                    self.triton_client_.register_system_shared_memory(resized_op_name, '/'+resized_op_name, resized_output_byte_size)
-                elif _test_cuda_shared_memory:
-                    shm_ip_handle = cudashm.create_shared_memory_region(
-                        ip_name, input_byte_size, 0)
-                    shm_shape_ip_handle = cudashm.create_shared_memory_region(
-                        shape_ip_name, shape_input_byte_size, 0)
-                    shm_dummy_ip_handle = cudashm.create_shared_memory_region(
-                        dummy_ip_name, dummy_input_byte_size, 0)
-                    shm_shape_op_handle = cudashm.create_shared_memory_region(
-                        shape_op_name, shape_output_byte_size, 0)
-                    shm_op_handle = cudashm.create_shared_memory_region(
-                        op_name, output_byte_size, 0)
-                    shm_resized_op_handle = cudashm.create_shared_memory_region(
-                        resized_op_name, resized_output_byte_size, 0)
-                    cudashm.set_shared_memory_region(shm_ip_handle, input_list_tmp)
-                    cudashm.set_shared_memory_region(shm_shape_ip_handle, shape_input_list)
-                    cudashm.set_shared_memory_region(shm_dummy_ip_handle, dummy_input_list)
-                    self.triton_client_.register_cuda_shared_memory(ip_name, cudashm.get_raw_handle(shm_ip_handle), 0, input_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(shape_ip_name, cudashm.get_raw_handle(shm_shape_ip_handle), 0, shape_input_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(dummy_ip_name, cudashm.get_raw_handle(shm_dummy_ip_handle), 0, dummy_input_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(shape_op_name, cudashm.get_raw_handle(shm_shape_op_handle), 0, shape_output_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(op_name, cudashm.get_raw_handle(shm_op_handle), 0, output_byte_size)
-                    self.triton_client_.register_cuda_shared_memory(resized_op_name, cudashm.get_raw_handle(shm_resized_op_handle), 0, resized_output_byte_size)
+
+                shm_ip_handle = shm.create_shared_memory_region(
+                    ip_name, '/'+ip_name, input_byte_size)
+                shm_shape_ip_handle = shm.create_shared_memory_region(
+                    shape_ip_name, '/'+shape_ip_name, shape_input_byte_size)
+                shm_dummy_ip_handle = shm.create_shared_memory_region(
+                    dummy_ip_name, '/'+dummy_ip_name, dummy_input_byte_size)
+                shm_shape_op_handle = shm.create_shared_memory_region(
+                    shape_op_name, '/'+shape_op_name, shape_output_byte_size)
+                shm_op_handle = shm.create_shared_memory_region(
+                    op_name, '/'+op_name, output_byte_size)
+                shm_resized_op_handle = shm.create_shared_memory_region(
+                    resized_op_name, '/'+resized_op_name, resized_output_byte_size)
+                shm.set_shared_memory_region(shm_ip_handle, input_list_tmp)
+                shm.set_shared_memory_region(shm_shape_ip_handle, shape_input_list)
+                shm.set_shared_memory_region(shm_dummy_ip_handle, dummy_input_list)
+                self.triton_client_.register_system_shared_memory(ip_name, '/'+ip_name, input_byte_size)
+                self.triton_client_.register_system_shared_memory(shape_ip_name, '/'+shape_ip_name, shape_input_byte_size)
+                self.triton_client_.register_system_shared_memory(dummy_ip_name, '/'+dummy_ip_name, dummy_input_byte_size)
+                self.triton_client_.register_system_shared_memory(shape_op_name, '/'+shape_op_name, shape_output_byte_size)
+                self.triton_client_.register_system_shared_memory(op_name, '/'+op_name, output_byte_size)
+                self.triton_client_.register_system_shared_memory(resized_op_name, '/'+resized_op_name, resized_output_byte_size)
+
                 shm_region_handles.append((ip_name, input_byte_size, shm_ip_handle))
                 shm_region_handles.append((shape_ip_name, shape_input_byte_size, shm_shape_ip_handle))
                 shm_region_handles.append((dummy_ip_name, dummy_input_byte_size, shm_dummy_ip_handle))
@@ -638,8 +604,8 @@ class SequenceBatcherTestUtil(unittest.TestCase):
         tensor_shape = (1,1)
         # shape tensor is 1-D tensor that doesn't contain batch size as first value
         shape_tensor_shape = (1,)
-        self.assertFalse(_test_system_shared_memory and _test_cuda_shared_memory,
-                        "Cannot set both System and CUDA shared memory flags to 1")
+        self.assertFalse(_test_cuda_shared_memory,
+                        "Shape tensors does not support CUDA shared memory")
 
         client_utils = grpcclient
         triton_client = client_utils.InferenceServerClient("localhost:8001", verbose=True)
@@ -676,7 +642,7 @@ class SequenceBatcherTestUtil(unittest.TestCase):
 
                 # Set IO values
                 shape_values.append(np.full(shape_tensor_shape, shape_value, dtype=np.int32))
-                if not (_test_system_shared_memory or _test_cuda_shared_memory):
+                if not _test_system_shared_memory:
                     if using_dynamic_batcher:
                         if input_dtype == np.object:
                             dummy_in0 = np.full(tensor_shape, value, dtype=np.int32)
@@ -727,17 +693,14 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                     raise error
                 # Get value of "OUTPUT", for shared memory, need to get it via
                 # shared memory utils
-                if (not _test_system_shared_memory) and (not _test_cuda_shared_memory):
+                if (not _test_system_shared_memory):
                     out = results.as_numpy("OUTPUT")
                 else:
                     output = results.get_output("OUTPUT")
                     output_offset = 6*processed_count+4 if using_dynamic_batcher else 5*processed_count+3
                     output_shape = output.shape
                     output_type = np.int32 if using_dynamic_batcher else np.float32
-                    if _test_system_shared_memory:
-                        out = shm.get_contents_as_numpy(shm_region_handles[output_offset][2], output_type, output_shape)
-                    else:
-                        out = cudashm.get_contents_as_numpy(shm_region_handles[output_offset][2], output_type, output_shape)
+                    out = shm.get_contents_as_numpy(shm_region_handles[output_offset][2], output_type, output_shape)
                 result = out[0][0]
 
                 # Validate the (debatched) shape of the resized output matches

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -134,7 +134,8 @@ class PlanBackend : public InferenceBackend {
     bool SetOutputShapeTensorBuffer(
         const int32_t* content, std::unique_ptr<InferenceResponse>* response,
         InferenceResponse::Output* response_output,
-        const size_t tensor_element_count, cudaStream_t stream);
+        const size_t tensor_element_count, const int64_t batch_size,
+        cudaStream_t stream);
 
     // See BackendContext::Run()
     void Run(

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -664,7 +664,7 @@ BackendInputCollector::SetFixedSizeInputTensor(
         std::move(*response),
         Status(
             Status::Code::INVALID_ARG,
-            "unexpected total batch size " +
+            "unexpected total byte size " +
                 std::to_string(
                     tensor_buffer_offset +
                     request_input->Data()->TotalByteSize()) +


### PR DESCRIPTION
This PR in itself doesn't fix the L0_trt_shape_tensor tests. There is only one failing test left:test_sequence_different_shape_values. 
We can not use the dummy value as content for shape tensors in null requests for sequence scheduler . The shape values must be in range of optimization profile. I am working out on a solution.