### PR TITLE
Fix timestamp locations in Plan backend

### DIFF
--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -1869,7 +1869,6 @@ PlanBackend::Context::Run(
   // available at this point as the execution and output copy are on the same
   // stream.
   cudaStreamWaitEvent(stream_, events_[next_set_].input_ready_, 0);
-  INFER_STATS_SET_TIMESTAMP(payload_->compute_input_end_ns_);
 
   // Async execute the inference using a CUDA graph if available for
   // the batch-size, otherwise execution normally.
@@ -1940,7 +1939,6 @@ PlanBackend::Context::Run(
   }
 
   cudaEventRecord(events_[next_set_].ready_for_output_, stream_);
-  INFER_STATS_SET_TIMESTAMP(payload_->compute_output_start_ns_);
 
   // Collect the names of requested outputs. Do not include outputs
   // for requests that have already responded with an error.
@@ -2100,8 +2098,14 @@ PlanBackend::Context::ProcessResponse(
     // has consumed the inputs. Put the context back into the available queue
     // so that it can begin enqueuing new memcpys into the input buffers
     cudaEventSynchronize(event_set.ready_for_input_);
+    INFER_STATS_SET_TIMESTAMP(compute_input_end_ns);
     context_queue->Put(context_idx);
     NVTX_MARKER("plan_input_available");
+
+#ifdef TRITON_ENABLE_STATS
+    cudaEventSynchronize(event_set.ready_for_output_);
+    INFER_STATS_SET_TIMESTAMP(compute_output_start_ns);
+#endif  // TRITON_ENABLE_STATS
 
     // Call Finalize() here to defer CUDA synchronization as much as possible
     payload->responder_->Finalize();
@@ -2117,8 +2121,8 @@ PlanBackend::Context::ProcessResponse(
       auto& request = payload->requests_[i];
       request->ReportStatistics(
           metric_reporter_.get(), (payload->responses_[i] != nullptr),
-          payload->compute_start_ns_, payload->compute_input_end_ns_,
-          payload->compute_output_start_ns_, compute_end_ns);
+          payload->compute_start_ns_, compute_input_end_ns,
+          compute_output_start_ns, compute_end_ns);
 
 #ifdef TRITON_ENABLE_TRACING
       if (request->Trace() != nullptr) {
@@ -2126,11 +2130,9 @@ PlanBackend::Context::ProcessResponse(
         trace->Report(
             TRITONSERVER_TRACE_COMPUTE_START, payload->compute_start_ns_);
         trace->Report(
-            TRITONSERVER_TRACE_COMPUTE_INPUT_END,
-            payload->compute_input_end_ns_);
+            TRITONSERVER_TRACE_COMPUTE_INPUT_END, compute_input_end_ns);
         trace->Report(
-            TRITONSERVER_TRACE_COMPUTE_OUTPUT_START,
-            payload->compute_output_start_ns_);
+            TRITONSERVER_TRACE_COMPUTE_OUTPUT_START, compute_output_start_ns);
         trace->Report(TRITONSERVER_TRACE_COMPUTE_END, compute_end_ns);
       }
 #endif  // TRITON_ENABLE_TRACING
@@ -2140,8 +2142,8 @@ PlanBackend::Context::ProcessResponse(
     payload->inference_backend_->MutableStatsAggregator()
         ->UpdateInferBatchStats(
             metric_reporter_.get(), payload->total_batch_size_,
-            payload->compute_start_ns_, payload->compute_input_end_ns_,
-            payload->compute_output_start_ns_, compute_end_ns);
+            payload->compute_start_ns_, compute_input_end_ns,
+            compute_output_start_ns, compute_end_ns);
 #endif  // TRITON_ENABLE_STATS
 
     // Send all the responses that haven't already been sent because of

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -240,8 +240,7 @@ class PlanBackend : public InferenceBackend {
           std::vector<std::unique_ptr<InferenceRequest>>&& requests)
           : inference_backend_(inference_backend),
             event_set_idx_(event_set_idx), total_batch_size_(0),
-            compute_start_ns_(0), compute_input_end_ns_(0),
-            compute_output_start_ns_(0), requests_(std::move(requests))
+            compute_start_ns_(0), requests_(std::move(requests))
       {
       }
 
@@ -256,8 +255,6 @@ class PlanBackend : public InferenceBackend {
 
       // The timestamps for reporting stats
       uint64_t compute_start_ns_;
-      uint64_t compute_input_end_ns_;
-      uint64_t compute_output_start_ns_;
 
       // All the composing InferenceRequest objects
       std::vector<std::unique_ptr<InferenceRequest>> requests_;


### PR DESCRIPTION
timestamps should be recorded when event is completed instead of when event is recorded. Note that this is still not the exact timestamp as the event may be completed before the synchronize call (bottleneck on launching CUDA jobs).
Use trace summary as example:
Before:
```
File: trtis_trace.log.resnet_1
Summary for model (1): trace count = 42006
Infer request (avg): 9144us

	Handler (avg): 9154us
		Overhead (avg): 131us
		Queue (avg): 121us
		Compute (avg): 8901us
			Input (avg): 397us
			Infer (avg): 357us
			Output (avg): 8146us
```
After:
```
File: triton_trace.log.resnet_1
Summary for model (1): trace count = 42012
Infer request (avg): 9146us

	Handler (avg): 9155us
		Overhead (avg): 131us
		Queue (avg): 120us
		Compute (avg): 8904us
			Input (avg): 3556us
			Infer (avg): 5324us
			Output (avg): 23us

```