### PR TITLE
Fix json representation of model configuration

### DIFF
--- a/qa/L0_config_json/ensemble_config.pbtxt
+++ b/qa/L0_config_json/ensemble_config.pbtxt
@@ -1,0 +1,105 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "simple_ensemble"
+platform: "ensemble"
+max_batch_size: 0
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  },
+  {
+    name: "INPUT1"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  }
+]
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  },
+  {
+    name: "OUTPUT1"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  }
+]
+ensemble_scheduling {
+  step [
+    {
+      model_name: "custom_nobatch_float32_float32_float32"
+      model_version: 1
+      input_map [
+        {
+          key : "INPUT0"
+          value : "INPUT0"
+        },
+        {
+          key : "INPUT1"
+          value : "INPUT1"
+        }
+      ]
+      output_map [
+        {
+          key : "OUTPUT0"
+          value : "out0"
+        },
+        {
+          key : "OUTPUT1"
+          value : "out1"
+        }
+      ]
+    },
+    {
+      model_name: "custom_nobatch_float32_float32_float32"
+      model_version: -1
+      input_map [
+        {
+          key : "INPUT0"
+          value : "out0"
+        },
+        {
+          key : "INPUT1"
+          value : "out1"
+        }
+      ]
+      output_map [
+        {
+          key : "OUTPUT0"
+          value : "OUTPUT0"
+        },
+        {
+          key : "OUTPUT1"
+          value : "OUTPUT1"
+        }
+      ]
+    }
+  ]
+}

--- a/qa/L0_config_json/test.sh
+++ b/qa/L0_config_json/test.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+export CUDA_VISIBLE_DEVICES=0
+
+CLIENT_LOG="./client.log"
+SERVER_LOG="./inference_server.log"
+
+SERVER=/opt/tritonserver/bin/tritonserver
+SERVER_ARGS="--model-repository=`pwd`/models"
+source ../common/util.sh
+
+RET=0
+rm -fr *.log
+
+rm -fr models && mkdir models
+cp -r ../custom_models/custom_nobatch_float32_float32_float32 models/.
+cp models/custom_nobatch_float32_float32_float32/config.pbtxt .
+
+# Test input and output dims are shown as numbers
+TRIAL=ios
+cp ./config.pbtxt models/custom_nobatch_float32_float32_float32/.
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+code=`curl -s -w %{http_code} -o ./$TRIAL.out localhost:8000/v2/models/custom_nobatch_float32_float32_float32/config`
+set -e
+if [ "$code" != "200" ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"dims\":\[16\]" $TRIAL.out | wc -l`
+if [ $matches -ne 4 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 4 dims, got $matches\n***"
+    RET=1
+fi
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+# Test input and output reshape are shown as numbers
+TRIAL=reshape
+
+cp ./config.pbtxt models/custom_nobatch_float32_float32_float32/.
+(cd models/custom_nobatch_float32_float32_float32 && \
+     sed -i "s/data_type:.*TYPE_FP32/data_type: TYPE_FP32\nreshape: { shape: [ 16 ]}/g" config.pbtxt)
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+code=`curl -s -w %{http_code} -o ./$TRIAL.out localhost:8000/v2/models/custom_nobatch_float32_float32_float32/config`
+set -e
+if [ "$code" != "200" ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"reshape\":{\"shape\":\[16\]}" $TRIAL.out | wc -l`
+if [ $matches -ne 4 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 4 reshape:shape, got $matches\n***"
+    RET=1
+fi
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+# Test version_policy::specific
+TRIAL=specific
+
+cp ./config.pbtxt models/custom_nobatch_float32_float32_float32/.
+(cd models/custom_nobatch_float32_float32_float32 && \
+     echo "version_policy: { specific: { versions: [ 1 ] } }" >> config.pbtxt)
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+code=`curl -s -w %{http_code} -o ./$TRIAL.out localhost:8000/v2/models/custom_nobatch_float32_float32_float32/config`
+set -e
+if [ "$code" != "200" ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"version_policy\":{\"specific\":{\"versions\":\[1\]}}" $TRIAL.out | wc -l`
+if [ $matches -ne 1 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 1 version_policy:specific:versions, got $matches\n***"
+    RET=1
+fi
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+# Test dynamic_batching::max_queue_delay_microseconds,
+# dynamic_batching::default_queue_policy::default_timeout_microseconds,
+# dynamic_batching::priority_queue_policy::value::default_timeout_microseconds
+TRIAL=dbatch
+
+cp ./config.pbtxt models/custom_nobatch_float32_float32_float32/.
+(cd models/custom_nobatch_float32_float32_float32 && \
+     echo "dynamic_batching: { max_queue_delay_microseconds: 42 \
+          default_queue_policy: { default_timeout_microseconds: 123 } \
+          priority_queue_policy: { key: 1  value: { default_timeout_microseconds: 123 }} \
+          priority_queue_policy: { key: 2  value: { default_timeout_microseconds: 123 }}}" >> config.pbtxt)
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+code=`curl -s -w %{http_code} -o ./$TRIAL.out localhost:8000/v2/models/custom_nobatch_float32_float32_float32/config`
+set -e
+if [ "$code" != "200" ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"dynamic_batching\":{\"max_queue_delay_microseconds\":42" $TRIAL.out | wc -l`
+if [ $matches -ne 1 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 1 dynamic_batching:max_queue_delay_microseconds, got $matches\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"default_timeout_microseconds\":123}" $TRIAL.out | wc -l`
+if [ $matches -ne 3 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 3 dynamic_batching:*_queue_policy:default_timeout_microseconds, got $matches\n***"
+    RET=1
+fi
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+# Test sequence_batching::oldest::max_queue_delay_microseconds,
+# sequence_batching::max_sequence_idle_microseconds
+TRIAL=sbatch
+
+cp ./config.pbtxt models/custom_nobatch_float32_float32_float32/.
+(cd models/custom_nobatch_float32_float32_float32 && \
+     echo "sequence_batching: { max_sequence_idle_microseconds: 42 \
+          oldest: { max_queue_delay_microseconds: 987 }}" >> config.pbtxt)
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+code=`curl -s -w %{http_code} -o ./$TRIAL.out localhost:8000/v2/models/custom_nobatch_float32_float32_float32/config`
+set -e
+if [ "$code" != "200" ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"sequence_batching\":{\"max_sequence_idle_microseconds\":42" $TRIAL.out | wc -l`
+if [ $matches -ne 1 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 1 sequence_batching:max_sequence_idle_microseconds, got $matches\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"oldest\":{\"max_queue_delay_microseconds\":987}" $TRIAL.out | wc -l`
+if [ $matches -ne 1 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 1 sequence_batching:oldest:max_queue_delay_microseconds, got $matches\n***"
+    RET=1
+fi
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+# Test ensemble_scheduling::step::model_version
+TRIAL=ensemble
+
+cp ./config.pbtxt models/custom_nobatch_float32_float32_float32/.
+mkdir -p models/simple_ensemble/1 && cp ensemble_config.pbtxt models/simple_ensemble/config.pbtxt
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+code=`curl -s -w %{http_code} -o ./$TRIAL.out localhost:8000/v2/models/simple_ensemble/config`
+set -e
+if [ "$code" != "200" ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"model_version\":1" $TRIAL.out | wc -l`
+if [ $matches -ne 1 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 1 ensemble_scheduling:step:model_version == 1, got $matches\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"model_version\":-1" $TRIAL.out | wc -l`
+if [ $matches -ne 1 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 1 ensemble_scheduling:step:model_version == -1, got $matches\n***"
+    RET=1
+fi
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+rm -fr models/simple_ensemble
+
+# Test model_warmup::inputs::value::dims
+TRIAL=warmup
+
+cp ./config.pbtxt models/custom_nobatch_float32_float32_float32/.
+(cd models/custom_nobatch_float32_float32_float32 && \
+     echo "model_warmup [{" >> config.pbtxt && \
+     echo "    name : \"warmup 1\"" >> config.pbtxt && \
+     echo "    batch_size: 1" >> config.pbtxt && \
+     echo "    inputs [{" >> config.pbtxt && \
+     echo "        key: \"INPUT0\"" >> config.pbtxt && \
+     echo "        value: {" >> config.pbtxt && \
+     echo "            data_type: TYPE_FP32" >> config.pbtxt && \
+     echo "            dims: 16" >> config.pbtxt && \
+     echo "            zero_data: true" >> config.pbtxt && \
+     echo "        }" >> config.pbtxt && \
+     echo "    }, {" >> config.pbtxt && \
+     echo "        key: \"INPUT1\"" >> config.pbtxt && \
+     echo "        value: {" >> config.pbtxt && \
+     echo "            data_type: TYPE_FP32" >> config.pbtxt && \
+     echo "            dims: 16" >> config.pbtxt && \
+     echo "            random_data: true" >> config.pbtxt && \
+     echo "        }" >> config.pbtxt && \
+     echo "    }]" >> config.pbtxt && \
+     echo "  }, {" >> config.pbtxt && \
+     echo "    name : \"warmup 2\"" >> config.pbtxt && \
+     echo "    batch_size: 1" >> config.pbtxt && \
+     echo "    inputs [{" >> config.pbtxt && \
+     echo "        key: \"INPUT0\"" >> config.pbtxt && \
+     echo "        value: {" >> config.pbtxt && \
+     echo "            data_type: TYPE_FP32" >> config.pbtxt && \
+     echo "            dims: 16" >> config.pbtxt && \
+     echo "            zero_data: true" >> config.pbtxt && \
+     echo "        }" >> config.pbtxt && \
+     echo "    }, {" >> config.pbtxt && \
+     echo "        key: \"INPUT1\"" >> config.pbtxt && \
+     echo "        value: {" >> config.pbtxt && \
+     echo "            data_type: TYPE_FP32" >> config.pbtxt && \
+     echo "            dims: 16" >> config.pbtxt && \
+     echo "            random_data: true" >> config.pbtxt && \
+     echo "        }" >> config.pbtxt && \
+     echo "    }]" >> config.pbtxt && \
+     echo "  }]" >> config.pbtxt)
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+code=`curl -s -w %{http_code} -o ./$TRIAL.out localhost:8000/v2/models/custom_nobatch_float32_float32_float32/config`
+set -e
+if [ "$code" != "200" ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+matches=`grep -o "\"dims\":\[16\]" $TRIAL.out | wc -l`
+if [ $matches -ne 8 ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Expected 8 model_warmup:inputs:dims, got $matches\n***"
+    RET=1
+fi
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    echo -e "\n***\n*** Test Failed\n***"
+fi
+
+exit $RET

--- a/src/backends/backend/examples/identity.cc
+++ b/src/backends/backend/examples/identity.cc
@@ -88,25 +88,9 @@ ParseShape(
   ni::TritonJson::Value shape_array;
   RETURN_IF_ERROR(io.MemberAsArray(name.c_str(), &shape_array));
   for (size_t i = 0; i < shape_array.ArraySize(); ++i) {
-    std::string str;
-
-    // The model configuration is specified in protobuf (sigh) and it
-    // has no option to produce json where uint64 and int64 fields are
-    // actually represented as numbers. Instead it always represents
-    // them as strings so have to parse appropriately and convert.
-    RETURN_IF_ERROR(shape_array.IndexAsString(i, &str));
-
-    try {
-      int64_t d = std::atoll(str.c_str());
-      shape->push_back(d);
-    }
-    catch (...) {
-      return TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INTERNAL,
-          (std::string("unable to convert shape dimension '") + str +
-           "' to integer")
-              .c_str());
-    }
+    int64_t d;
+    RETURN_IF_ERROR(shape_array.IndexAsInt(i, &d));
+    shape->push_back(d);
   }
 
   return nullptr;  // success

--- a/src/clients/c++/perf_client/model_parser.cc
+++ b/src/clients/c++/perf_client/model_parser.cc
@@ -299,10 +299,12 @@ ModelParser::GetEnsembleSchedulerType(
   if (std::string(config["platform"].GetString()).compare("ensemble") == 0) {
     const auto step_itr = config["ensemble_scheduling"].FindMember("step");
     for (const auto& step : step_itr->value.GetArray()) {
-      std::string step_model_version(step["model_version"].GetString());
-      int64_t model_version_int = std::stol(step_model_version);
+      std::string step_model_version;
+      const int64_t model_version_int = step["model_version"].GetInt64();
       if (model_version_int == -1) {
         step_model_version = "";
+      } else {
+        step_model_version = std::to_string(model_version_int);
       }
       (*composing_models_map_)[config["name"].GetString()].emplace(
           std::string(step["model_name"].GetString()), step_model_version);

--- a/src/core/model_config_utils.h
+++ b/src/core/model_config_utils.h
@@ -150,4 +150,10 @@ Status ParseLongLongParameter(
 /// value.
 Status GetProfileIndex(const std::string& profile_name, int* profile_index);
 
+/// Convert a model configuration protobuf to the equivalent json.
+/// \param config The protobuf model configuration.
+/// \param json Returns the equivalent JSON.
+/// \return The error status.
+Status ModelConfigToJson(const ModelConfig& config, std::string* json_str);
+
 }}  // namespace nvidia::inferenceserver


### PR DESCRIPTION
Protobuf json utilities represent 64-bit integers as strings in the generated json. There is no option to disable this unwanted behavior. So fix up the json generated for the config so integers are represented as json numbers.