### PR TITLE
Fix QA tests to correctly specify client verbosity

### DIFF
--- a/qa/L0_custom_backend/param_test.py
+++ b/qa/L0_custom_backend/param_test.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
    model_name = "param"
 
    # Create the inference context for the model.
-   client = client_util.InferenceServerClient(FLAGS.url, FLAGS.verbose)
+   client = client_util.InferenceServerClient(FLAGS.url, verbose=FLAGS.verbose)
 
    # Input tensor can be any size int32 vector...
    input_data = np.zeros(shape=1, dtype=np.int32)

--- a/qa/L0_custom_image_preprocess/preprocess_test.py
+++ b/qa/L0_custom_image_preprocess/preprocess_test.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
    model_name = "image_preprocess_nhwc_224x224x3"
 
    # Create the inference context for the model.
-   client = client_util.InferenceServerClient(FLAGS.url, FLAGS.verbose)
+   client = client_util.InferenceServerClient(FLAGS.url, verbose=FLAGS.verbose)
 
    # Input tensor will be raw content from image file
    image_path = FLAGS.image_filename

--- a/qa/L0_custom_ops/cuda_op_test.py
+++ b/qa/L0_custom_ops/cuda_op_test.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     elements = 8
 
     # Create the inference context for the model.
-    client = client_util.InferenceServerClient(FLAGS.url, FLAGS.verbose)
+    client = client_util.InferenceServerClient(FLAGS.url, verbose=FLAGS.verbose)
 
     # Create the data for one input tensor.
     input_data = np.arange(start=42, stop=42+elements, dtype=np.int32)

--- a/qa/L0_custom_ops/mod_op_test.py
+++ b/qa/L0_custom_ops/mod_op_test.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
     elements = 10
 
     # Create the inference context for the model.
-    client = client_util.InferenceServerClient(FLAGS.url, FLAGS.verbose)
+    client = client_util.InferenceServerClient(FLAGS.url, verbose=FLAGS.verbose)
 
     # Create the data for one input tensor.
     input_data = []

--- a/qa/L0_custom_ops/onnx_op_test.py
+++ b/qa/L0_custom_ops/onnx_op_test.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     dtype = np.float32
 
     # Create the inference context for the model.
-    client = client_util.InferenceServerClient(FLAGS.url, FLAGS.verbose)
+    client = client_util.InferenceServerClient(FLAGS.url, verbose=FLAGS.verbose)
 
     # Create the data for one input tensor.
     input_data = []

--- a/qa/L0_custom_ops/zero_out_test.py
+++ b/qa/L0_custom_ops/zero_out_test.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
     elements = 8
 
     # Create the inference context for the model.
-    client = client_util.InferenceServerClient(FLAGS.url, FLAGS.verbose)
+    client = client_util.InferenceServerClient(FLAGS.url, verbose=FLAGS.verbose)
 
     # Create the data for one input tensor.
     input_data = np.arange(start=42, stop=42+elements, dtype=np.int32)

--- a/qa/L0_custom_param/param_test.py
+++ b/qa/L0_custom_param/param_test.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
    model_name = "param"
 
    # Create the inference context for the model.
-   client = client_util.InferenceServerClient(FLAGS.url, FLAGS.verbose)
+   client = client_util.InferenceServerClient(FLAGS.url, verbose=FLAGS.verbose)
 
    # Input tensor can be any size int32 vector...
    input_data = np.zeros(shape=1, dtype=np.int32)

--- a/qa/L0_nullchar_string/nullchar_string_client.py
+++ b/qa/L0_nullchar_string/nullchar_string_client.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     client_util = httpclient if FLAGS.protocol == "http" else grpcclient
     # Create the inference context for the model.
-    client = client_util.InferenceServerClient(FLAGS.url, FLAGS.verbose)
+    client = client_util.InferenceServerClient(FLAGS.url, verbose=FLAGS.verbose)
 
     # We use identity string models that takes 1 input tensor of a single string
     # and returns 1 output tensor of a single string. The output tensor is the

--- a/qa/L0_sequence_stress/sequence_stress.py
+++ b/qa/L0_sequence_stress/sequence_stress.py
@@ -325,7 +325,7 @@ def stress_thread(name, seed, pass_cnt, correlation_id_base, trial, model_name, 
 
         for c in range(common_cnt + rare_cnt):
             client_metadata_list.append(
-                (grpcclient.InferenceServerClient("localhost:8001", FLAGS.verbose),
+                (grpcclient.InferenceServerClient("localhost:8001", verbose=FLAGS.verbose),
                     correlation_id_base + c))
             last_choices.append(None)
 
@@ -406,7 +406,7 @@ def stress_thread(name, seed, pass_cnt, correlation_id_base, trial, model_name, 
     print("Exiting thread {}".format(name))
 
 def check_status(model_name):
-    client = grpcclient.InferenceServerClient("localhost:8001", FLAGS.verbose)
+    client = grpcclient.InferenceServerClient("localhost:8001", verbose=FLAGS.verbose)
     stats = client.get_inference_statistics(model_name)
     print(stats)
 

--- a/src/clients/python/library/httpclient.py
+++ b/src/clients/python/library/httpclient.py
@@ -127,6 +127,8 @@ class InferenceServerClient:
     ----------
     url : str
         The inference server URL, e.g. 'localhost:8000'.
+    verbose : bool
+        If True generate verbose output. Default value is False.
     connection_count : int
         The number of connections to create for this client.
         Default value is 1.
@@ -136,8 +138,6 @@ class InferenceServerClient:
     network_timeout : float
         The timeout value for the network. Default value is
         60.0 sec
-    verbose : bool
-        If True generate verbose output. Default value is False.
     max_greenlets : int
         Determines the maximum allowed number of worker greenlets
         for handling asynchronous inference requests. Default value
@@ -168,10 +168,10 @@ class InferenceServerClient:
 
     def __init__(self,
                  url,
+                 verbose=False,
                  connection_count=1,
                  connection_timeout=60.0,
                  network_timeout=60.0,
-                 verbose=False,
                  max_greenlets=None,
                  ssl=False,
                  ssl_options=None,


### PR DESCRIPTION
## Description
Optional parameters must be provided along with the keyword. 

### Before
```
root@48c7caea4b4a:/opt/tritonserver/qa/L0_custom_ops# python zero_out_test.py -m graphdef_zeroout
Traceback (most recent call last):
  File "zero_out_test.py", line 72, in <module>
    results = client.infer(model_name, inputs)
  File "/usr/local/lib/python3.6/dist-packages/tritonhttpclient/__init__.py", line 1076, in infer
    query_params=query_params)
  File "/usr/local/lib/python3.6/dist-packages/tritonhttpclient/__init__.py", line 277, in _post
    body=request_body)
  File "/usr/local/lib/python3.6/dist-packages/geventhttpclient/client.py", line 272, in post
    return self.request(METHOD_POST, request_uri, body=body, headers=headers)
  File "/usr/local/lib/python3.6/dist-packages/geventhttpclient/client.py", line 226, in request
    sock = self._connection_pool.get_socket()
  File "/usr/local/lib/python3.6/dist-packages/geventhttpclient/connectionpool.py", line 159, in get_socket
    self._semaphore.acquire()
  File "src/gevent/_semaphore.py", line 143, in gevent._gevent_c_semaphore.Semaphore.acquire
  File "src/gevent/_semaphore.py", line 178, in gevent._gevent_c_semaphore.Semaphore.acquire
  File "src/gevent/_abstract_linkable.py", line 381, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait
  File "src/gevent/_abstract_linkable.py", line 346, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 348, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 303, in gevent._gevent_c_abstract_linkable.AbstractLinkable._AbstractLinkable__wait_to_be_notified
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 65, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_gevent_c_greenlet_primitives.pxd", line 35, in gevent._gevent_c_greenlet_primitives._greenlet_switch
gevent.exceptions.LoopExit: This operation would block forever
        Hub: <Hub '' at 0x7f433e5e3f60 epoll default pending=0 ref=0 fileno=3 thread_ident=0x7f4344ffe740>
        Handles:
[]

```
### After
```
root@48c7caea4b4a:/opt/tritonserver/qa/L0_custom_ops# python zero_out_test.py -m graphdef_zeroout
0: input 42, output 42
1: input 43, output 0
2: input 44, output 0
3: input 45, output 0
4: input 46, output 0
5: input 47, output 0
6: input 48, output 0
7: input 49, output 0
```