### PR TITLE
Adding the end-to-end timeout on the client side

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -191,6 +191,8 @@ RUN cp builddir/custom-backend/install/lib/libidentity.so \
         qa/L0_cmdline_trace/. && \
     cp builddir/custom-backend/install/lib/libidentity.so \
         qa/L0_batcher/. && \
+    cp builddir/custom-backend/install/lib/libidentity.so \
+        qa/L0_client_timeout/. && \
     mkdir -p qa/L0_infer_shm && \
     cp -r qa/L0_infer/. qa/L0_infer_shm && \
     mkdir -p qa/L0_infer_cudashm && \

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -71,6 +71,7 @@ RUN mkdir -p qa/common && \
     cp -r docs/examples/model_repository/simple qa/L0_cuda_shared_memory/models/. && \
     mkdir qa/L0_cmdline_trace/models && \
     cp -r docs/examples/model_repository/simple qa/L0_cmdline_trace/models/. && \
+    cp -r /workspace/docs/examples/model_repository/simple qa/L0_client_timeout/models && \
     cp -r /workspace/docs/examples/model_repository/simple qa/L0_grpc/models && \
     cp -r /workspace/docs/examples/model_repository/simple_string qa/L0_grpc/models && \
     cp -r /workspace/docs/examples/model_repository/inception_graphdef qa/L0_grpc/models && \
@@ -134,6 +135,9 @@ RUN mkdir -p qa/L0_backend_identity/models && \
 RUN mkdir -p qa/L0_backend_release/simple_seq_models/simple_sequence/1 && \
     cp builddir/custom-backend/install/lib/libsequence.so \
         qa/L0_backend_release/simple_seq_models/simple_sequence/1/. && \
+    mkdir -p qa/L0_client_timeout/models/simple_sequence/1 && \
+    cp builddir/custom-backend/install/lib/libsequence.so \
+        qa/L0_client_timeout/models/simple_sequence/1/. && \
     mkdir -p qa/L0_grpc/models/simple_sequence/1 && \
     cp builddir/custom-backend/install/lib/libsequence.so \
         qa/L0_grpc/models/simple_sequence/1/. && \

--- a/qa/L0_client_timeout/client_timeout_test.py
+++ b/qa/L0_client_timeout/client_timeout_test.py
@@ -1,0 +1,228 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+sys.path.append("../common")
+
+from functools import partial
+import numpy as np
+import queue
+import unittest
+import os
+import time
+import socket
+
+import tritongrpcclient as grpcclient
+import tritonhttpclient as httpclient
+from tritonclientutils import InferenceServerException
+
+
+class UserData:
+    def __init__(self):
+        self._completed_requests = queue.Queue()
+
+
+def callback(user_data, result, error):
+    if error:
+        user_data._completed_requests.put(error)
+    else:
+        user_data._completed_requests.put(result)
+
+
+class ClientTimeoutTest(unittest.TestCase):
+    def setUp(self):
+        self.model_name_ = "custom_identity_int32"
+        self.input0_data_ = np.array([[10]], dtype=np.int32)
+
+    def _prepare_request(self, protocol):
+        if (protocol == "grpc"):
+            self.inputs_ = []
+            self.inputs_.append(
+                grpcclient.InferInput('INPUT0', [1, 1], "INT32"))
+            self.outputs_ = []
+            self.outputs_.append(grpcclient.InferRequestedOutput('OUTPUT0'))
+        else:
+            self.inputs_ = []
+            self.inputs_.append(
+                httpclient.InferInput('INPUT0', [1, 1], "INT32"))
+            self.outputs_ = []
+            self.outputs_.append(httpclient.InferRequestedOutput('OUTPUT0'))
+
+        self.inputs_[0].set_data_from_numpy(self.input0_data_)
+
+    def test_grpc_infer(self):
+        triton_client = grpcclient.InferenceServerClient(url="localhost:8001",
+                                                         verbose=True)
+        self._prepare_request("grpc")
+
+        # The model is configured to take three seconds to send the
+        # response. Expect an exception for small timeout values.
+        with self.assertRaises(InferenceServerException) as cm:
+            result = triton_client.infer(model_name=self.model_name_,
+                                         inputs=self.inputs_,
+                                         outputs=self.outputs_,
+                                         client_timeout=0.2)
+        self.assertIn("Deadline Exceeded", str(cm.exception))
+
+        # Expect inference to pass successfully for a large timeout
+        # value
+        result = triton_client.infer(model_name=self.model_name_,
+                                     inputs=self.inputs_,
+                                     outputs=self.outputs_,
+                                     client_timeout=10)
+
+        output0_data = result.as_numpy('OUTPUT0')
+        self.assertTrue(np.array_equal(self.input0_data_, output0_data))
+
+    def test_grpc_async_infer(self):
+        triton_client = grpcclient.InferenceServerClient(url="localhost:8001",
+                                                         verbose=True)
+        self._prepare_request("grpc")
+
+        user_data = UserData()
+
+        # The model is configured to take three seconds to send the
+        # response. Expect an exception for small timeout values.
+        with self.assertRaises(InferenceServerException) as cm:
+            triton_client.async_infer(model_name=self.model_name_,
+                                      inputs=self.inputs_,
+                                      callback=partial(callback, user_data),
+                                      outputs=self.outputs_,
+                                      client_timeout=2)
+            data_item = user_data._completed_requests.get()
+            if type(data_item) == InferenceServerException:
+                raise data_item
+        self.assertIn("Deadline Exceeded", str(cm.exception))
+
+        # Expect inference to pass successfully for a large timeout
+        # value
+        triton_client.async_infer(model_name=self.model_name_,
+                                  inputs=self.inputs_,
+                                  callback=partial(callback, user_data),
+                                  outputs=self.outputs_,
+                                  client_timeout=10)
+
+        # Wait until the results are available in user_data
+        data_item = user_data._completed_requests.get()
+        self.assertFalse(type(data_item) == InferenceServerException)
+
+        output0_data = data_item.as_numpy('OUTPUT0')
+        self.assertTrue(np.array_equal(self.input0_data_, output0_data))
+
+    def test_grpc_stream_infer(self):
+
+        triton_client = grpcclient.InferenceServerClient(url="localhost:8001",
+                                                         verbose=True)
+
+        self._prepare_request("grpc")
+        user_data = UserData()
+
+        # The model is configured to take three seconds to send the
+        # response. Expect an exception for small timeout values.
+        with self.assertRaises(InferenceServerException) as cm:
+            triton_client.stop_stream()
+            triton_client.start_stream(callback=partial(callback, user_data),
+                                       stream_timeout=1)
+            triton_client.async_stream_infer(model_name=self.model_name_,
+                                             inputs=self.inputs_,
+                                             outputs=self.outputs_)
+            data_item = user_data._completed_requests.get()
+            if type(data_item) == InferenceServerException:
+                raise data_item
+        self.assertIn("Deadline Exceeded", str(cm.exception))
+
+        # Expect inference to pass successfully for a large timeout
+        # value
+        triton_client.stop_stream()
+        triton_client.start_stream(callback=partial(callback, user_data),
+                                   stream_timeout=10)
+
+        triton_client.async_stream_infer(model_name=self.model_name_,
+                                         inputs=self.inputs_,
+                                         outputs=self.outputs_)
+        data_item = user_data._completed_requests.get()
+        triton_client.stop_stream()
+
+        output0_data = data_item.as_numpy('OUTPUT0')
+        self.assertTrue(np.array_equal(self.input0_data_, output0_data))
+
+    def test_http_infer(self):
+
+        self._prepare_request("http")
+
+        # The model is configured to take three seconds to send the
+        # response. Expect an exception for small timeout values.
+        with self.assertRaises(socket.timeout) as cm:
+            triton_client = httpclient.InferenceServerClient(
+                url="localhost:8000", verbose=True, network_timeout=2.0)
+            result = triton_client.infer(model_name=self.model_name_,
+                                         inputs=self.inputs_,
+                                         outputs=self.outputs_)
+        self.assertIn("timed out", str(cm.exception))
+
+        # Expect to successfully pass with sufficiently large timeout
+        triton_client = httpclient.InferenceServerClient(
+            url="localhost:8000", verbose=True, connection_timeout=10.0)
+
+        result = triton_client.infer(model_name=self.model_name_,
+                                     inputs=self.inputs_,
+                                     outputs=self.outputs_)
+
+        output0_data = result.as_numpy('OUTPUT0')
+        self.assertTrue(np.array_equal(self.input0_data_, output0_data))
+
+    def test_http_async_infer(self):
+
+        self._prepare_request("http")
+
+        # The model is configured to take three seconds to send the
+        # response. Expect an exception for small timeout values.
+        with self.assertRaises(socket.timeout) as cm:
+            triton_client = httpclient.InferenceServerClient(
+                url="localhost:8000", verbose=True, network_timeout=2.0)
+            async_request = triton_client.async_infer(
+                model_name=self.model_name_,
+                inputs=self.inputs_,
+                outputs=self.outputs_)
+            result = async_request.get_result()
+        self.assertIn("timed out", str(cm.exception))
+
+        # Expect to successfully pass with sufficiently large timeout
+        triton_client = httpclient.InferenceServerClient(
+            url="localhost:8000", verbose=True, connection_timeout=10.0)
+
+        async_request = triton_client.async_infer(model_name=self.model_name_,
+                                                  inputs=self.inputs_,
+                                                  outputs=self.outputs_)
+        result = async_request.get_result()
+
+        output0_data = result.as_numpy('OUTPUT0')
+        self.assertTrue(np.array_equal(self.input0_data_, output0_data))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qa/L0_client_timeout/client_timeout_test.py
+++ b/qa/L0_client_timeout/client_timeout_test.py
@@ -159,7 +159,7 @@ class ClientTimeoutTest(unittest.TestCase):
         # value
         triton_client.stop_stream()
         triton_client.start_stream(callback=partial(callback, user_data),
-                                   stream_timeout=10)
+                                   stream_timeout=100)
 
         triton_client.async_stream_infer(model_name=self.model_name_,
                                          inputs=self.inputs_,
@@ -167,6 +167,8 @@ class ClientTimeoutTest(unittest.TestCase):
         data_item = user_data._completed_requests.get()
         triton_client.stop_stream()
 
+        if type(data_item) == InferenceServerException:
+            raise data_item
         output0_data = data_item.as_numpy('OUTPUT0')
         self.assertTrue(np.array_equal(self.input0_data_, output0_data))
 

--- a/qa/L0_client_timeout/models/custom_identity_int32/config.pbtxt
+++ b/qa/L0_client_timeout/models/custom_identity_int32/config.pbtxt
@@ -1,0 +1,55 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "custom_identity_int32"
+platform: "custom"
+max_batch_size: 1024
+version_policy: { latest { num_versions: 1 }}
+default_model_filename: "libidentity.so"
+instance_group [ { kind: KIND_CPU } ]
+
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_INT32
+    dims: [ -1 ]
+    
+  }
+]
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_INT32
+    dims: [ -1 ]
+  }
+]
+
+parameters [
+  {
+    key: "execute_delay_ms"
+    value: { string_value: "3000" }
+  }
+]

--- a/qa/L0_client_timeout/models/simple_sequence/config.pbtxt
+++ b/qa/L0_client_timeout/models/simple_sequence/config.pbtxt
@@ -1,0 +1,71 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "simple_sequence"
+platform: "custom"
+max_batch_size: 8
+default_model_filename: "libsequence.so"
+sequence_batching {
+  control_input [
+    {
+      name: "START"
+      control [
+        {
+          kind: CONTROL_SEQUENCE_START
+          int32_false_true: [ 0, 1 ]
+        }
+      ]
+    },
+    {
+      name: "READY"
+      control [
+        {
+          kind: CONTROL_SEQUENCE_READY
+          int32_false_true: [ 0, 1 ]
+        }
+      ]
+    }
+  ]
+}
+input [
+  {
+    name: "INPUT"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "OUTPUT"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+instance_group [
+  {
+    kind: KIND_CPU
+  }
+]

--- a/qa/L0_client_timeout/test.sh
+++ b/qa/L0_client_timeout/test.sh
@@ -144,7 +144,7 @@ for i in simple_grpc_infer_client \
     simple_http_async_infer_client \
    ; do
    echo "TEST:  $i" >> ${CLIENT_LOG}
-   ../clients/$i -v -t 10000 >> ${CLIENT_LOG} 2>&1
+   ../clients/$i -v -t 100000000 >> ${CLIENT_LOG} 2>&1
    if [ $? -ne 0 ]; then
         RET=1
     fi

--- a/qa/L0_client_timeout/test.sh
+++ b/qa/L0_client_timeout/test.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
+if [ "$#" -ge 1 ]; then
+    REPO_VERSION=$1
+fi
+if [ -z "$REPO_VERSION" ]; then
+    echo -e "Repository version must be specified"
+    echo -e "\n***\n*** Test Failed\n***"
+    exit 1
+fi
+
+export CUDA_VISIBLE_DEVICES=0
+
+RET=0
+
+SIMPLE_GRPC_ASYNC_INFER=../clients/simple_grpc_async_infer_client
+SIMPLE_GRPC_ASYNC_STREAM_INFER=../clients/simple_grpc_sequence_stream_infer_client
+
+SIMPLE_HTTP_INFER=../clients/simple_http_infer_client
+SIMPLE_HTTP_ASYNC_INFER=../clients/simple_http_async_infer_client
+
+rm -f *.log
+rm -f *.log.*
+
+CLIENT_LOG=`pwd`/client.log
+DATADIR=`pwd`/models
+SERVER=/opt/tritonserver/bin/tritonserver
+SERVER_ARGS="--model-repository=$DATADIR"
+source ../common/util.sh
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+
+# CASE 1: Provide too small a timeout and expect a failure.
+
+# Test request timeout in grpc synchronous inference
+CLIENT=../clients/simple_grpc_infer_client
+$CLIENT -t 1000 -v >> ${CLIENT_LOG}.c++.grpc_infer 2>&1
+if [ $? -eq 0 ]; then
+    RET=1
+fi
+if [ `grep -c "Deadline Exceeded" ${CLIENT_LOG}.c++.grpc_infer` != "1" ]; then
+    cat ${CLIENT_LOG}.c++.grpc_infer
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+# Test request timeout in grpc asynchronous inference
+CLIENT=../clients/simple_grpc_async_infer_client
+$CLIENT -t 1000 -v >> ${CLIENT_LOG}.c++.grpc_async_infer 2>&1
+if [ $? -eq 0 ]; then
+    RET=1
+fi
+if [ `grep -c "Deadline Exceeded" ${CLIENT_LOG}.c++.grpc_async_infer` != "1" ]; then
+    cat ${CLIENT_LOG}.c++.grpc_async_infer
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+# Test stream timeout in grpc asynchronous streaming inference
+CLIENT=../clients/simple_grpc_sequence_stream_infer_client
+$CLIENT -t 100 -v >> ${CLIENT_LOG}.c++.grpc_async_stream_infer 2>&1
+if [ $? -eq 0 ]; then
+    RET=1
+fi
+if [ `grep -c "Stream has been closed" ${CLIENT_LOG}.c++.grpc_async_stream_infer` != "1" ]; then
+    cat ${CLIENT_LOG}.c++.grpc_async_stream_infer
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+# Test request timeout in http synchronous inference
+CLIENT=../clients/simple_http_infer_client
+$CLIENT -t 1000 -v >> ${CLIENT_LOG}.c++.http_infer 2>&1
+if [ $? -eq 0 ]; then
+    RET=1
+fi
+if [ `grep -c "Request timedout..." ${CLIENT_LOG}.c++.http_infer` == "0" ]; then
+    cat ${CLIENT_LOG}.c++.http_infer
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+
+# Test request timeout in http asynchronous inference
+CLIENT=../clients/simple_http_async_infer_client
+$CLIENT -t 1000 -v >> ${CLIENT_LOG}.c++.http_async_infer 2>&1
+if [ $? -eq 0 ]; then
+    RET=1
+fi
+if [ `grep -c "Request timedout..." ${CLIENT_LOG}.c++.http_async_infer` == "0" ]; then
+    cat ${CLIENT_LOG}.c++.http_async_infer
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+set -e
+
+if [ $RET -eq 1 ]; then
+    # Return if CASE 1 failed 
+    kill $SERVER_PID
+    wait $SERVER_PID
+    exit $RET
+fi
+
+
+# CASE 2: Provide sufficiently large timeout value
+
+set +e
+for i in simple_grpc_infer_client \
+    simple_grpc_async_infer_client \
+    simple_grpc_sequence_stream_infer_client \
+    simple_http_infer_client \
+    simple_http_async_infer_client \
+   ; do
+   echo "TEST:  $i" >> ${CLIENT_LOG}
+   ../clients/$i -v -t 10000 >> ${CLIENT_LOG} 2>&1
+   if [ $? -ne 0 ]; then
+        RET=1
+    fi
+done
+
+set -e
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    cat ${CLIENT_LOG}
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/src/clients/c++/examples/image_client.cc
+++ b/src/clients/c++/examples/image_client.cc
@@ -1019,7 +1019,8 @@ main(int argc, char** argv)
 
   if (streaming) {
     err = triton_client.grpc_client_->StartStream(
-        callback_func, true /* enable_stats */, http_headers);
+        callback_func, true /* enable_stats */, 0 /* stream_timeout */,
+        http_headers);
     if (!err.IsOk()) {
       std::cerr << "failed to establish the stream: " << err << std::endl;
     }

--- a/src/clients/c++/examples/simple_grpc_async_infer_client.cc
+++ b/src/clients/c++/examples/simple_grpc_async_infer_client.cc
@@ -134,6 +134,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "Usage: " << argv[0] << " [options]" << std::endl;
   std::cerr << "\t-v" << std::endl;
   std::cerr << "\t-u <URL for inference service>" << std::endl;
+  std::cerr << "\t-t <client timeout in microseconds>" << std::endl;
   std::cerr << "\t-H <HTTP header>" << std::endl;
   std::cerr << std::endl;
   std::cerr
@@ -151,16 +152,20 @@ main(int argc, char** argv)
   bool verbose = false;
   std::string url("localhost:8001");
   nic::Headers http_headers;
+  uint32_t client_timeout = 0;
 
   // Parse commandline...
   int opt;
-  while ((opt = getopt(argc, argv, "vu:H:")) != -1) {
+  while ((opt = getopt(argc, argv, "vu:t:H:")) != -1) {
     switch (opt) {
       case 'v':
         verbose = true;
         break;
       case 'u':
         url = optarg;
+        break;
+      case 't':
+        client_timeout = std::stoi(optarg);
         break;
       case 'H': {
         std::string arg = optarg;
@@ -244,6 +249,7 @@ main(int argc, char** argv)
   // The inference settings. Will be using default for now.
   nic::InferOptions options(model_name);
   options.model_version_ = model_version;
+  options.client_timeout_ = client_timeout;
 
   std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
   std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),

--- a/src/clients/c++/examples/simple_grpc_custom_repeat.cc
+++ b/src/clients/c++/examples/simple_grpc_custom_repeat.cc
@@ -166,7 +166,7 @@ main(int argc, char** argv)
             }
             cv_.notify_all();
           },
-          false /*enable_stats*/, http_headers),
+          false /*enable_stats*/, 0 /* stream_timeout */, http_headers),
       "unable to establish a streaming connection to server");
 
   // Prepare the data for the tensors

--- a/src/clients/c++/examples/simple_grpc_infer_client.cc
+++ b/src/clients/c++/examples/simple_grpc_infer_client.cc
@@ -79,6 +79,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-v" << std::endl;
   std::cerr << "\t-m <model name>" << std::endl;
   std::cerr << "\t-u <URL for inference service>" << std::endl;
+  std::cerr << "\t-t <client timeout in microseconds>" << std::endl;
   std::cerr << "\t-H <HTTP header>" << std::endl;
   std::cerr << std::endl;
   std::cerr
@@ -97,10 +98,11 @@ main(int argc, char** argv)
   bool use_custom_model = false;
   std::string url("localhost:8001");
   nic::Headers http_headers;
+  uint32_t client_timeout = 0;
 
   // Parse commandline...
   int opt;
-  while ((opt = getopt(argc, argv, "vcu:H:")) != -1) {
+  while ((opt = getopt(argc, argv, "vcu:t:H:")) != -1) {
     switch (opt) {
       case 'v':
         verbose = true;
@@ -110,6 +112,9 @@ main(int argc, char** argv)
         break;
       case 'u':
         url = optarg;
+        break;
+      case 't':
+        client_timeout = std::stoi(optarg);
         break;
       case 'H': {
         std::string arg = optarg;
@@ -193,6 +198,7 @@ main(int argc, char** argv)
   // The inference settings. Will be using default for now.
   nic::InferOptions options(model_name);
   options.model_version_ = model_version;
+  options.client_timeout_ = client_timeout;
 
   std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
   std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),

--- a/src/clients/c++/examples/simple_grpc_sequence_stream_infer_client.cc
+++ b/src/clients/c++/examples/simple_grpc_sequence_stream_infer_client.cc
@@ -66,6 +66,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr
       << "For -H, header must be 'Header:Value'. May be given multiple times."
       << std::endl;
+  std::cerr << "\t-t <stream timeout in microseconds>" << std::endl;
   std::cerr << "\t-o <offset for sequence ID>" << std::endl;
   std::cerr << std::endl;
   std::cerr << "For -o, the client will use sequence ID <1 + 2 * offset> "
@@ -115,10 +116,11 @@ main(int argc, char** argv)
   std::string url("localhost:8001");
   nic::Headers http_headers;
   int sequence_id_offset = 0;
+  uint32_t stream_timeout = 0;
 
   // Parse commandline...
   int opt;
-  while ((opt = getopt(argc, argv, "vdu:H:o:")) != -1) {
+  while ((opt = getopt(argc, argv, "vdu:H:t:o:")) != -1) {
     switch (opt) {
       case 'v':
         verbose = true;
@@ -135,6 +137,9 @@ main(int argc, char** argv)
         http_headers[header] = arg.substr(header.size() + 1);
         break;
       }
+      case 't':
+        stream_timeout = std::stoi(optarg);
+        break;
       case 'o':
         sequence_id_offset = std::stoi(optarg);
         break;
@@ -179,7 +184,7 @@ main(int argc, char** argv)
             }
             cv_.notify_all();
           },
-          false /*ship_stats*/, http_headers),
+          false /*ship_stats*/, stream_timeout, http_headers),
       "unable to establish a streaming connection to server");
 
   // Send requests, first reset accumulator for the sequence.

--- a/src/clients/c++/examples/simple_http_async_infer_client.cc
+++ b/src/clients/c++/examples/simple_http_async_infer_client.cc
@@ -134,6 +134,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "Usage: " << argv[0] << " [options]" << std::endl;
   std::cerr << "\t-v" << std::endl;
   std::cerr << "\t-u <URL for inference service>" << std::endl;
+  std::cerr << "\t-t <client timeout in microseconds>" << std::endl;
   std::cerr << "\t-H <HTTP header>" << std::endl;
   std::cerr << std::endl;
   std::cerr
@@ -151,16 +152,20 @@ main(int argc, char** argv)
   bool verbose = false;
   std::string url("localhost:8000");
   nic::Headers http_headers;
+  uint32_t client_timeout = 0;
 
   // Parse commandline...
   int opt;
-  while ((opt = getopt(argc, argv, "vu:H:")) != -1) {
+  while ((opt = getopt(argc, argv, "vu:t:H:")) != -1) {
     switch (opt) {
       case 'v':
         verbose = true;
         break;
       case 'u':
         url = optarg;
+        break;
+      case 't':
+        client_timeout = std::stoi(optarg);
         break;
       case 'H': {
         std::string arg = optarg;
@@ -244,6 +249,7 @@ main(int argc, char** argv)
   // The inference settings. Will be using default for now.
   nic::InferOptions options(model_name);
   options.model_version_ = model_version;
+  options.client_timeout_ = client_timeout;
 
   std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
   std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),

--- a/src/clients/c++/examples/simple_http_infer_client.cc
+++ b/src/clients/c++/examples/simple_http_infer_client.cc
@@ -78,6 +78,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "Usage: " << argv[0] << " [options]" << std::endl;
   std::cerr << "\t-v" << std::endl;
   std::cerr << "\t-u <URL for inference service>" << std::endl;
+  std::cerr << "\t-t <client timeout in microseconds>" << std::endl;
   std::cerr << "\t-H <HTTP header>" << std::endl;
   std::cerr << std::endl;
   std::cerr
@@ -96,10 +97,11 @@ main(int argc, char** argv)
   bool use_custom_model = false;
   std::string url("localhost:8000");
   nic::Headers http_headers;
+  uint32_t client_timeout = 0;
 
   // Parse commandline...
   int opt;
-  while ((opt = getopt(argc, argv, "vcu:H:")) != -1) {
+  while ((opt = getopt(argc, argv, "vcu:t:H:")) != -1) {
     switch (opt) {
       case 'v':
         verbose = true;
@@ -109,6 +111,9 @@ main(int argc, char** argv)
         break;
       case 'u':
         url = optarg;
+        break;
+      case 't':
+        client_timeout = std::stoi(optarg);
         break;
       case 'H': {
         std::string arg = optarg;
@@ -192,6 +197,7 @@ main(int argc, char** argv)
   // The inference settings. Will be using default for now.
   nic::InferOptions options(model_name);
   options.model_version_ = model_version;
+  options.client_timeout_ = client_timeout;
 
   std::vector<nic::InferInput*> inputs = {input0_ptr.get(), input1_ptr.get()};
   std::vector<const nic::InferRequestedOutput*> outputs = {output0_ptr.get(),

--- a/src/clients/c++/library/common.h
+++ b/src/clients/c++/library/common.h
@@ -196,7 +196,8 @@ struct InferOptions {
   // The maximum end-to-end time, in microseconds, the request is allowed
   // to take. Note the HTTP library only offer the precision upto
   // milliseconds. The client will abort request when the specified time
-  // elapses. The default value is 0 which means client will wait for the
+  // elapses. The request will return error with message "Deadline Exceeded".
+  // The default value is 0 which means client will wait for the
   // response from the server. This option is not supported for streaming
   // requests. Instead see 'stream_timeout' argument in
   // InferenceServerGrpcClient::StartStream().

--- a/src/clients/c++/library/common.h
+++ b/src/clients/c++/library/common.h
@@ -154,7 +154,7 @@ struct InferOptions {
   explicit InferOptions(const std::string& model_name)
       : model_name_(model_name), model_version_(""), request_id_(""),
         sequence_id_(0), sequence_start_(false), sequence_end_(false),
-        priority_(0), timeout_(0)
+        priority_(0), server_timeout_(0), client_timeout_(0)
   {
   }
   /// The name of the model to run inference.
@@ -188,11 +188,19 @@ struct InferOptions {
   /// will handle the request using default setting for the model.
   uint64_t priority_;
   /// The timeout value for the request, in microseconds. If the request
-  /// cannot be completed within the time the server can take a
+  /// cannot be completed within the time by the server can take a
   /// model-specific action such as terminating the request. If not
   /// provided, the server will handle the request using default setting
   /// for the model.
-  uint64_t timeout_;
+  uint64_t server_timeout_;
+  // The maximum end-to-end time, in microseconds, the request is allowed
+  // to take. Note the HTTP library only offer the precision upto
+  // milliseconds. The client will abort request when the specified time
+  // elapses. The default value is 0 which means client will wait for the
+  // response from the server. This option is not supported for streaming
+  // requests. Instead see 'stream_timeout' argument in
+  // InferenceServerGrpcClient::StartStream().
+  uint64_t client_timeout_;
 };
 
 //==============================================================================

--- a/src/clients/c++/library/grpc_client.h
+++ b/src/clients/c++/library/grpc_client.h
@@ -311,12 +311,16 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// The library does not support client side statistics for decoupled
   /// streaming. Set this option false when there is no 1:1 mapping between
   /// request and response on the stream.
+  /// \param stream_timeout Specifies the end-to-end timeout for the streaming
+  /// connection in microseconds. The default value is 0 which means that
+  /// there is no limitation on deadline. The stream will be closed once
+  /// the specified time elapses.
   /// \param headers Optional map specifying additional HTTP headers to
   /// include in the metadata of gRPC request.
   /// \return Error object indicating success or failure of the request.
   Error StartStream(
       OnCompleteFn callback, bool enable_stats = true,
-      const Headers& headers = Headers());
+      uint32_t stream_timeout = 0, const Headers& headers = Headers());
 
   /// Stops an active grpc bi-directional stream, if one available.
   /// \return Error object indicating success or failure of the request.

--- a/src/clients/c++/perf_client/triton_client_wrapper.cc
+++ b/src/clients/c++/perf_client/triton_client_wrapper.cc
@@ -172,7 +172,7 @@ TritonClientWrapper::StartStream(
 {
   if (protocol_ == ProtocolType::GRPC) {
     RETURN_IF_ERROR(client_.grpc_client_->StartStream(
-        callback, enable_stats, *http_headers_));
+        callback, enable_stats, 0 /* stream_timeout */, *http_headers_));
   } else {
     return nic::Error("HTTP does not support starting streams");
   }

--- a/src/clients/python/examples/simple_grpc_async_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_async_infer_client.py
@@ -48,6 +48,12 @@ if __name__ == '__main__':
                         required=False,
                         default='localhost:8001',
                         help='Inference server URL. Default is localhost:8001.')
+    parser.add_argument('-t',
+                        '--client-timeout',
+                        type=int,
+                        required=False,
+                        default=None,
+                        help='Client timeout in seconds. Default is None.')
 
     FLAGS = parser.parse_args()
     try:
@@ -96,7 +102,8 @@ if __name__ == '__main__':
     triton_client.async_infer(model_name=model_name,
                               inputs=inputs,
                               callback=partial(callback, user_data),
-                              outputs=outputs)
+                              outputs=outputs,
+                              client_timeout=FLAGS.client_timeout)
 
     # Wait until the results are available in user_data
     time_out = 10

--- a/src/clients/python/examples/simple_grpc_async_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_async_infer_client.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
                         help='Inference server URL. Default is localhost:8001.')
     parser.add_argument('-t',
                         '--client-timeout',
-                        type=int,
+                        type=float,
                         required=False,
                         default=None,
                         help='Client timeout in seconds. Default is None.')

--- a/src/clients/python/examples/simple_grpc_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_infer_client.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
                         help='Inference server URL. Default is localhost:8001.')
     parser.add_argument('-t',
                         '--client-timeout',
-                        type=int,
+                        type=float,
                         required=False,
                         default=None,
                         help='Client timeout in seconds. Default is None.')

--- a/src/clients/python/examples/simple_grpc_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_infer_client.py
@@ -51,6 +51,12 @@ if __name__ == '__main__':
                         required=False,
                         default='localhost:8001',
                         help='Inference server URL. Default is localhost:8001.')
+    parser.add_argument('-t',
+                        '--client-timeout',
+                        type=int,
+                        required=False,
+                        default=None,
+                        help='Client timeout in seconds. Default is None.')
 
     FLAGS = parser.parse_args()
     try:
@@ -85,6 +91,7 @@ if __name__ == '__main__':
     results = triton_client.infer(model_name=model_name,
                                   inputs=inputs,
                                   outputs=outputs,
+                                  client_timeout=FLAGS.client_timeout,
                                   headers={'test': '1'})
 
     statistics = triton_client.get_inference_statistics(model_name=model_name)

--- a/src/clients/python/examples/simple_grpc_sequence_stream_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_sequence_stream_infer_client.py
@@ -98,6 +98,12 @@ if __name__ == '__main__':
         default='localhost:8001',
         help='Inference server URL and it gRPC port. Default is localhost:8001.'
     )
+    parser.add_argument('-t',
+                        '--stream-timeout',
+                        type=float,
+                        required=False,
+                        default=None,
+                        help='Stream timeout in seconds. Default is None.')
     parser.add_argument('-d',
                         '--dyna',
                         action="store_true",
@@ -140,7 +146,7 @@ if __name__ == '__main__':
             url=FLAGS.url, verbose=FLAGS.verbose) as triton_client:
         try:
             # Establish stream
-            triton_client.start_stream(callback=partial(callback, user_data))
+            triton_client.start_stream(callback=partial(callback, user_data), stream_timeout=FLAGS.stream_timeout)
             # Now send the inference sequences...
             async_stream_send(triton_client, [0] + values, batch_size,
                               sequence_id0, model_name, model_version)

--- a/src/clients/python/library/grpcclient.py
+++ b/src/clients/python/library/grpcclient.py
@@ -844,6 +844,7 @@ class InferenceServerClient:
               sequence_end=False,
               priority=0,
               timeout=None,
+              client_timeout=None,
               headers=None):
         """Run synchronous inference using the supplied 'inputs' requesting
         the outputs specified by 'outputs'.
@@ -893,6 +894,11 @@ class InferenceServerClient:
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
             for the model.
+        client_timeout : int
+            The maximum end-to-end time, in seconds, the request is allowed
+            to take. The client will abort request when the specified time
+            elapses. The default value is None which means client will
+            wait for the response from the server.
         headers : dict
             Optional dictionary specifying additional HTTP headers to include
             in the request.
@@ -931,7 +937,8 @@ class InferenceServerClient:
 
         try:
             response = self._client_stub.ModelInfer(request=request,
-                                                    metadata=metadata)
+                                                    metadata=metadata,
+                                                    timeout=client_timeout)
             if self._verbose:
                 print(response)
             result = InferResult(response)
@@ -951,6 +958,7 @@ class InferenceServerClient:
                     sequence_end=False,
                     priority=0,
                     timeout=None,
+                    client_timeout=None,
                     headers=None):
         """Run asynchronous inference using the supplied 'inputs' requesting
         the outputs specified by 'outputs'.
@@ -1007,6 +1015,11 @@ class InferenceServerClient:
             model-specific action such as terminating the request. If not
             provided, the server will handle the request using default setting
             for the model.
+        client_timeout : int
+            The maximum end-to-end time, in seconds, the request is allowed
+            to take. The client will abort request when the specified time
+            elapses. The default value is None which means client will
+            wait for the response from the server.
         headers: dict
             Optional dictionary specifying additional HTTP
             headers to include in the request.
@@ -1051,7 +1064,7 @@ class InferenceServerClient:
 
         try:
             self._call_future = self._client_stub.ModelInfer.future(
-                request=request, metadata=metadata)
+                request=request, metadata=metadata, timeout=client_timeout)
             self._call_future.add_done_callback(wrapped_callback)
             if self._verbose:
                 verbose_message = "Sent request"

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -1729,8 +1729,6 @@ class InferHandlerState {
     InferHandlerStateType* WriteResponseIfReady(
         InferHandlerStateType* required_state)
     {
-      std::this_thread::sleep_for(
-            std::chrono::milliseconds(2000));
       std::lock_guard<std::mutex> lock(mu_);
       if (states_.empty()) {
         return nullptr;

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -1729,6 +1729,8 @@ class InferHandlerState {
     InferHandlerStateType* WriteResponseIfReady(
         InferHandlerStateType* required_state)
     {
+      std::this_thread::sleep_for(
+            std::chrono::milliseconds(2000));
       std::lock_guard<std::mutex> lock(mu_);
       if (states_.empty()) {
         return nullptr;


### PR DESCRIPTION
Timeout specification has been added for the inference request. Have intentionally left streaming timeout from the python grpc because of a bug in grpc. For streaming RPC, most likely it treats the timeout in milliseconds instead of seconds(even though it is documented as seconds).  Will explore the issue and add it later. 