### PR TITLE
Include ONNX and Libtorch backends in DeepRecommender perf test

### DIFF
--- a/qa/L0_perf_deeprecommender/run_test.sh
+++ b/qa/L0_perf_deeprecommender/run_test.sh
@@ -59,9 +59,9 @@ for STATIC_BATCH in $STATIC_BATCH_SIZES; do
             fi
 
             if (( $DYNAMIC_BATCH > 1 )); then
-                NAME=${MODEL_NAME}_sbatch${STATIC_BATCH}_dbatch${DYNAMIC_BATCH}_instance${INSTANCE_CNT}
+                NAME=${MODEL_NAME}_sbatch${STATIC_BATCH}_dbatch${DYNAMIC_BATCH}_instance${INSTANCE_CNT}_${PERF_CLIENT_PROTOCOL}
             else
-                NAME=${MODEL_NAME}_sbatch${STATIC_BATCH}_instance${INSTANCE_CNT}
+                NAME=${MODEL_NAME}_sbatch${STATIC_BATCH}_instance${INSTANCE_CNT}_${PERF_CLIENT_PROTOCOL}
             fi
 
             rm -fr models && mkdir -p models && \
@@ -86,9 +86,9 @@ for STATIC_BATCH in $STATIC_BATCH_SIZES; do
 
             # Run the model once to warm up. Some frameworks do
             # optimization on the first requests.
-            $PERF_CLIENT -v -i grpc -m $MODEL_NAME -p5000 -b${STATIC_BATCH}
+            $PERF_CLIENT -v -i ${PERF_CLIENT_PROTOCOL} -m $MODEL_NAME -p5000 -b${STATIC_BATCH}
 
-            $PERF_CLIENT -v -i grpc -m $MODEL_NAME -p5000 \
+            $PERF_CLIENT -v -i ${PERF_CLIENT_PROTOCOL} -m $MODEL_NAME -p5000 \
                          -b${STATIC_BATCH} --concurrency-range ${CONCURRENCY} \
                          -f ${NAME}.csv >> ${NAME}.log 2>&1
             if (( $? != 0 )); then
@@ -103,7 +103,7 @@ for STATIC_BATCH in $STATIC_BATCH_SIZES; do
 
             echo -e "[{\"s_benchmark_kind\":\"benchmark_perf\"," >> ${NAME}.tjson
             echo -e "\"s_benchmark_name\":\"deeprecommender\"," >> ${NAME}.tjson
-            echo -e "\"s_protocol\":\"grpc\"," >> ${NAME}.tjson
+            echo -e "\"s_protocol\":\"${PERF_CLIENT_PROTOCOL}\"," >> ${NAME}.tjson
             echo -e "\"s_framework\":\"${MODEL_FRAMEWORK}\"," >> ${NAME}.tjson
             echo -e "\"s_model\":\"${MODEL_NAME}\"," >> ${NAME}.tjson
             echo -e "\"l_concurrency\":${CONCURRENCY}," >> ${NAME}.tjson

--- a/qa/L0_perf_deeprecommender/test.sh
+++ b/qa/L0_perf_deeprecommender/test.sh
@@ -100,9 +100,9 @@ for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
 done
 
 #
-# Test large static batch = 256 w/ 2 instances
+# Test large static batch = 192 w/ 2 instances
 #
-STATIC_BATCH=256
+STATIC_BATCH=192
 INSTANCE_CNT=2
 
 # Create the TensorRT plan from TF

--- a/qa/L0_perf_deeprecommender/test.sh
+++ b/qa/L0_perf_deeprecommender/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_perf_deeprecommender/test.sh
+++ b/qa/L0_perf_deeprecommender/test.sh
@@ -48,9 +48,9 @@ STATIC_BATCH=1
 DYNAMIC_BATCH=1
 INSTANCE_CNT=1
 
-# Copy TF Model
-rm -fr tfmodels && mkdir -p tfmodels && \
-    cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tfmodels/.
+# Copy TF, ONNX and PyTorch Models
+rm -fr models && mkdir -p models && \
+    cp -r $REPODIR/perf_model_store/deeprecommender_* models/.
 
 # Create the TensorRT plan from TF
 rm -fr tensorrt_models && mkdir tensorrt_models
@@ -60,7 +60,7 @@ rm -fr tensorrt_models && mkdir tensorrt_models
         sed -i "s/tensorflow_graphdef/tensorrt_plan/" config.pbtxt && \
         sed -i "s/\[17736\]/\[17736,1,1\]/" config.pbtxt)
 
-$TRTEXEC --uff=tfmodels/deeprecommender_graphdef/deeprecommender_graphdef.uff \
+$TRTEXEC --uff=models/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --uffInput=Placeholder,1,1,17736\
          --batch=${STATIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
@@ -82,14 +82,14 @@ for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
 done
 
 # Tests with each model
-for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt; do
+for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
     MODEL_NAME=${MODEL}_${FRAMEWORK}
-    if [ "$FRAMEWORK" == "graphdef" ]; then
-        REPO=`pwd`/tfmodels
-    elif [ "$FRAMEWORK" == "plan" ]; then
+    if [ "$FRAMEWORK" == "plan" ]; then
         REPO=`pwd`/tensorrt_models
-    else
+    elif [[ "$FRAMEWORK" == *"_trt" ]]; then
         REPO=`pwd`/optimized_model_store
+    else
+        REPO=`pwd`/models
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \
@@ -107,10 +107,6 @@ STATIC_BATCH=1024
 DYNAMIC_BATCH=1
 INSTANCE_CNT=2
 
-# Copy TF Model
-rm -fr models && mkdir -p models && \
-    cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tfmodels/.
-
 # Create the TensorRT plan from TF
 rm -fr tensorrt_models && mkdir tensorrt_models
     cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tensorrt_models/deeprecommender_plan && \
@@ -119,20 +115,20 @@ rm -fr tensorrt_models && mkdir tensorrt_models
         sed -i "s/tensorflow_graphdef/tensorrt_plan/" config.pbtxt && \
         sed -i "s/\[17736\]/\[17736,1,1\]/" config.pbtxt)
 
-$TRTEXEC --uff=tfmodels/deeprecommender_graphdef/deeprecommender_graphdef.uff \
+$TRTEXEC --uff=models/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --uffInput=Placeholder,1,1,17736\
          --batch=${STATIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
 
 # Tests with each model
-for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt; do
+for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
     MODEL_NAME=${MODEL}_${FRAMEWORK}
-    if [ "$FRAMEWORK" == "graphdef" ]; then
-        REPO=`pwd`/tfmodels
-    elif [ "$FRAMEWORK" == "plan" ]; then
+    if [ "$FRAMEWORK" == "plan" ]; then
         REPO=`pwd`/tensorrt_models
-    else
+    elif [[ "$FRAMEWORK" == *"_trt" ]]; then
         REPO=`pwd`/optimized_model_store
+    else
+        REPO=`pwd`/models
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \
@@ -150,10 +146,6 @@ STATIC_BATCH=1
 DYNAMIC_BATCH=64
 INSTANCE_CNT=2
 
-# Copy TF Model
-rm -fr models && mkdir -p models && \
-    cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tfmodels/.
-
 # Create the TensorRT plan from TF
 rm -fr tensorrt_models && mkdir tensorrt_models
     cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tensorrt_models/deeprecommender_plan && \
@@ -162,20 +154,20 @@ rm -fr tensorrt_models && mkdir tensorrt_models
         sed -i "s/tensorflow_graphdef/tensorrt_plan/" config.pbtxt && \
         sed -i "s/\[17736\]/\[17736,1,1\]/" config.pbtxt)
 
-$TRTEXEC --uff=tfmodels/deeprecommender_graphdef/deeprecommender_graphdef.uff \
+$TRTEXEC --uff=models/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --uffInput=Placeholder,1,1,17736\
          --batch=${DYNAMIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
 
 # Tests with each model
-for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt; do
+for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
     MODEL_NAME=${MODEL}_${FRAMEWORK}
-    if [ "$FRAMEWORK" == "graphdef" ]; then
-        REPO=`pwd`/tfmodels
-    elif [ "$FRAMEWORK" == "plan" ]; then
+    if [ "$FRAMEWORK" == "plan" ]; then
         REPO=`pwd`/tensorrt_models
-    else
+    elif [[ "$FRAMEWORK" == *"_trt" ]]; then
         REPO=`pwd`/optimized_model_store
+    else
+        REPO=`pwd`/models
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \

--- a/qa/L0_perf_deeprecommender/test.sh
+++ b/qa/L0_perf_deeprecommender/test.sh
@@ -61,7 +61,7 @@ $TRTEXEC --uff=$REPODIR/perf_model_store/deeprecommender_graphdef/deeprecommende
          --batch=${STATIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
 
-OPTIMIZED_MODEL_NAMES="deeprecommender_graphdef_trt deeprecommender_onnx_trt"
+OPTIMIZED_MODEL_NAMES="deeprecommender_graphdef_trt"
 
 # Create optimized models (TF-TRT and ONNX-TRT)
 rm -fr optimized_model_store && mkdir optimized_model_store
@@ -78,7 +78,7 @@ for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
 done
 
 # Tests with each model
-for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
+for FRAMEWORK in graphdef plan graphdef_trt onnx libtorch; do
     MODEL_NAME=${MODEL}_${FRAMEWORK}
     if [ "$FRAMEWORK" == "plan" ]; then
         REPO=`pwd`/tensorrt_models
@@ -100,9 +100,9 @@ for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
 done
 
 #
-# Test large static batch = 192 w/ 2 instances
+# Test large static batch = 256 w/ 2 instances
 #
-STATIC_BATCH=192
+STATIC_BATCH=256
 INSTANCE_CNT=2
 
 # Create the TensorRT plan from TF
@@ -119,7 +119,7 @@ $TRTEXEC --uff=$REPODIR/perf_model_store/deeprecommender_graphdef/deeprecommende
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
 
 # Tests with each model
-for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
+for FRAMEWORK in graphdef plan graphdef_trt onnx libtorch; do
     MODEL_NAME=${MODEL}_${FRAMEWORK}
     if [ "$FRAMEWORK" == "plan" ]; then
         REPO=`pwd`/tensorrt_models

--- a/qa/L0_perf_deeprecommender/test.sh
+++ b/qa/L0_perf_deeprecommender/test.sh
@@ -48,10 +48,6 @@ STATIC_BATCH=1
 DYNAMIC_BATCH=1
 INSTANCE_CNT=1
 
-# Copy TF, ONNX and PyTorch Models
-rm -fr models && mkdir -p models && \
-    cp -r $REPODIR/perf_model_store/deeprecommender_* models/.
-
 # Create the TensorRT plan from TF
 rm -fr tensorrt_models && mkdir tensorrt_models
     cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tensorrt_models/deeprecommender_plan && \
@@ -60,7 +56,7 @@ rm -fr tensorrt_models && mkdir tensorrt_models
         sed -i "s/tensorflow_graphdef/tensorrt_plan/" config.pbtxt && \
         sed -i "s/\[17736\]/\[17736,1,1\]/" config.pbtxt)
 
-$TRTEXEC --uff=models/deeprecommender_graphdef/deeprecommender_graphdef.uff \
+$TRTEXEC --uff=$REPODIR/perf_model_store/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --uffInput=Placeholder,1,1,17736\
          --batch=${STATIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
@@ -89,7 +85,7 @@ for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
     elif [[ "$FRAMEWORK" == *"_trt" ]]; then
         REPO=`pwd`/optimized_model_store
     else
-        REPO=`pwd`/models
+        REPO=$REPODIR/perf_model_store
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \
@@ -115,7 +111,7 @@ rm -fr tensorrt_models && mkdir tensorrt_models
         sed -i "s/tensorflow_graphdef/tensorrt_plan/" config.pbtxt && \
         sed -i "s/\[17736\]/\[17736,1,1\]/" config.pbtxt)
 
-$TRTEXEC --uff=models/deeprecommender_graphdef/deeprecommender_graphdef.uff \
+$TRTEXEC --uff=$REPODIR/perf_model_store/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --uffInput=Placeholder,1,1,17736\
          --batch=${STATIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
@@ -128,7 +124,7 @@ for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
     elif [[ "$FRAMEWORK" == *"_trt" ]]; then
         REPO=`pwd`/optimized_model_store
     else
-        REPO=`pwd`/models
+        REPO=$REPODIR/perf_model_store
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \
@@ -154,7 +150,7 @@ rm -fr tensorrt_models && mkdir tensorrt_models
         sed -i "s/tensorflow_graphdef/tensorrt_plan/" config.pbtxt && \
         sed -i "s/\[17736\]/\[17736,1,1\]/" config.pbtxt)
 
-$TRTEXEC --uff=models/deeprecommender_graphdef/deeprecommender_graphdef.uff \
+$TRTEXEC --uff=$REPODIR/perf_model_store/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --uffInput=Placeholder,1,1,17736\
          --batch=${DYNAMIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
@@ -167,7 +163,7 @@ for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
     elif [[ "$FRAMEWORK" == *"_trt" ]]; then
         REPO=`pwd`/optimized_model_store
     else
-        REPO=`pwd`/models
+        REPO=$REPODIR/perf_model_store
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \

--- a/qa/L0_perf_deeprecommender/test.sh
+++ b/qa/L0_perf_deeprecommender/test.sh
@@ -100,9 +100,9 @@ for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt libtorch; do
 done
 
 #
-# Test large static batch = 1024 w/ 2 instances
+# Test large static batch = 256 w/ 2 instances
 #
-STATIC_BATCH=1024
+STATIC_BATCH=256
 INSTANCE_CNT=2
 
 # Create the TensorRT plan from TF

--- a/qa/L0_perf_deeprecommender/test.sh
+++ b/qa/L0_perf_deeprecommender/test.sh
@@ -65,26 +65,31 @@ $TRTEXEC --uff=tfmodels/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --batch=${STATIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
 
-# Create the TFTRT plan from TF
-rm -fr tftrt_models && mkdir tftrt_models
-    cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tftrt_models/deeprecommender_graphdef_trt && \
-    (cd tftrt_models/deeprecommender_graphdef_trt && \
-        sed -i "s/^name:.*/name: \"deeprecommender_graphdef_trt\"/" config.pbtxt && \
-        echo "optimization { execution_accelerators {" >> config.pbtxt
-        echo "gpu_execution_accelerator : [ {" >> config.pbtxt
-        echo "name : \"tensorrt\" " >> config.pbtxt
-        echo "} ]" >> config.pbtxt
-        echo "}}" >> config.pbtxt)
+OPTIMIZED_MODEL_NAMES="deeprecommender_graphdef_trt deeprecommender_onnx_trt"
+
+# Create optimized models (TF-TRT and ONNX-TRT)
+rm -fr optimized_model_store && mkdir optimized_model_store
+for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
+    BASE_MODEL=$(echo ${MODEL_NAME} | cut -d '_' -f 1,2)
+    cp -r $REPODIR/perf_model_store/${BASE_MODEL} optimized_model_store/${MODEL_NAME}
+    CONFIG_PATH="optimized_model_store/${MODEL_NAME}/config.pbtxt"
+    sed -i "s/^name: \"${BASE_MODEL}\"/name: \"${MODEL_NAME}\"/" ${CONFIG_PATH}
+    echo "optimization { execution_accelerators {" >> ${CONFIG_PATH}
+    echo "gpu_execution_accelerator : [ {" >> ${CONFIG_PATH}
+    echo "name : \"tensorrt\" " >> ${CONFIG_PATH}
+    echo "} ]" >> ${CONFIG_PATH}
+    echo "}}" >> ${CONFIG_PATH}
+done
 
 # Tests with each model
-for FRAMEWORK in graphdef plan graphdef_trt; do
+for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt; do
     MODEL_NAME=${MODEL}_${FRAMEWORK}
     if [ "$FRAMEWORK" == "graphdef" ]; then
         REPO=`pwd`/tfmodels
     elif [ "$FRAMEWORK" == "plan" ]; then
         REPO=`pwd`/tensorrt_models
     else
-        REPO=`pwd`/tftrt_models
+        REPO=`pwd`/optimized_model_store
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \
@@ -119,26 +124,15 @@ $TRTEXEC --uff=tfmodels/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --batch=${STATIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
 
-# Create the TFTRT plan from TF
-rm -fr tftrt_models && mkdir tftrt_models
-    cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tftrt_models/deeprecommender_graphdef_trt && \
-    (cd tftrt_models/deeprecommender_graphdef_trt && \
-        sed -i "s/^name:.*/name: \"deeprecommender_graphdef_trt\"/" config.pbtxt && \
-        echo "optimization { execution_accelerators {" >> config.pbtxt
-        echo "gpu_execution_accelerator : [ {" >> config.pbtxt
-        echo "name : \"tensorrt\" " >> config.pbtxt
-        echo "} ]" >> config.pbtxt
-        echo "}}" >> config.pbtxt)
-
 # Tests with each model
-for FRAMEWORK in graphdef plan graphdef_trt; do
+for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt; do
     MODEL_NAME=${MODEL}_${FRAMEWORK}
     if [ "$FRAMEWORK" == "graphdef" ]; then
         REPO=`pwd`/tfmodels
     elif [ "$FRAMEWORK" == "plan" ]; then
         REPO=`pwd`/tensorrt_models
     else
-        REPO=`pwd`/tftrt_models
+        REPO=`pwd`/optimized_model_store
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \
@@ -173,26 +167,15 @@ $TRTEXEC --uff=tfmodels/deeprecommender_graphdef/deeprecommender_graphdef.uff \
          --batch=${DYNAMIC_BATCH} --output=fc5/Relu --verbose \
          --saveEngine=tensorrt_models/deeprecommender_plan/0/model.plan
 
-# Create the TFTRT plan from TF
-rm -fr tftrt_models && mkdir tftrt_models
-    cp -r $REPODIR/perf_model_store/deeprecommender_graphdef tftrt_models/deeprecommender_graphdef_trt && \
-    (cd tftrt_models/deeprecommender_graphdef_trt && \
-        sed -i "s/^name:.*/name: \"deeprecommender_graphdef_trt\"/" config.pbtxt && \
-        echo "optimization { execution_accelerators {" >> config.pbtxt
-        echo "gpu_execution_accelerator : [ {" >> config.pbtxt
-        echo "name : \"tensorrt\" " >> config.pbtxt
-        echo "} ]" >> config.pbtxt
-        echo "}}" >> config.pbtxt)
-
 # Tests with each model
-for FRAMEWORK in graphdef plan graphdef_trt; do
+for FRAMEWORK in graphdef plan graphdef_trt onnx onnx_trt; do
     MODEL_NAME=${MODEL}_${FRAMEWORK}
     if [ "$FRAMEWORK" == "graphdef" ]; then
         REPO=`pwd`/tfmodels
     elif [ "$FRAMEWORK" == "plan" ]; then
         REPO=`pwd`/tensorrt_models
     else
-        REPO=`pwd`/tftrt_models
+        REPO=`pwd`/optimized_model_store
     fi
     MODEL_NAME=${MODEL_NAME} \
             MODEL_FRAMEWORK=${FRAMEWORK} \


### PR DESCRIPTION
@deadeyegoodwin I removed the Dynamic Batch case and include coverage for HTTP perf as well. I'll update the dashboard as well shortly. 

Limit to batch size 256 to prevent OOM for libtorch. Remove onnx_trt for now due to segfault in server with batch size 256.