### PR TITLE
Fix delegator to be invoked on sending "null" response. Fix preserve ordering

### DIFF
--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -595,6 +595,7 @@ DynamicBatchScheduler::FinalizeResponses()
     while (!completion_queue_.empty() && !completion_queue_.front().empty()) {
       bool response_complete = false;
       for (auto& response_pair : completion_queue_.front()) {
+        // Assuming FINAL flag is set only in the last response of the request
         response_complete =
             ((response_pair.second & TRITONSERVER_RESPONSE_COMPLETE_FINAL) !=
              0);

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -616,7 +616,11 @@ DynamicBatchScheduler::FinalizeResponses()
   }
 
   for (auto& response : responses) {
-    InferenceResponse::Send(std::move(response.first), response.second);
+    // if response is nullptr, the delegator is called from response factory and
+    // nothing needed to be done
+    if (response.first != nullptr) {
+      InferenceResponse::Send(std::move(response.first), response.second);
+    }
   }
 }
 

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -609,11 +609,7 @@ DynamicBatchScheduler::FinalizeResponses()
   }
 
   for (auto& response : responses) {
-    // if response is nullptr, the delegator is called from response factory and
-    // nothing needed to be done
-    if (response.first != nullptr) {
-      InferenceResponse::Send(std::move(response.first), response.second);
-    }
+    InferenceResponse::Send(std::move(response.first), response.second);
   }
 }
 

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -149,8 +149,9 @@ class DynamicBatchScheduler : public Scheduler {
   // even when there are multiple scheduler threads.
   const bool preserve_ordering_;
 
-  // Per completion-id queues to store the ready requests
-  std::deque<std::pair<std::unique_ptr<InferenceResponse>, uint32_t>>
+  // Per completion-id queues to store the ready responses
+  std::deque<
+      std::vector<std::pair<std::unique_ptr<InferenceResponse>, uint32_t>>>
       completion_queue_;
   // Lock to protect the completion_queues_
   std::mutex completion_queue_mtx_;

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -352,9 +352,8 @@ class InferenceRequest {
   }
 
   // Add a delegator to be invoked on sending the responses of this request.
-  // The responses will be passed to 'delegator', a response may be a response
-  // object or may be nullptr, 'delegator' must call the
-  // InferenceResponse::Send() to send non-null responses.
+  // The response will be passed to 'delegator' and 'delegator' must call the
+  // InferenceResponse::Send() to send the response.
   Status SetResponseDelegator(
       std::function<void(
           std::unique_ptr<InferenceResponse>&&, const uint32_t)>&& delegator)

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -352,8 +352,9 @@ class InferenceRequest {
   }
 
   // Add a delegator to be invoked on sending the responses of this request.
-  // The response will be passed to 'delegator' and 'delegator' must call the
-  // InferenceResponse::Send() to send the response.
+  // The responses will be passed to 'delegator', a response may be a response
+  // object or may be nullptr, 'delegator' must call the
+  // InferenceResponse::Send() to send non-null responses.
   Status SetResponseDelegator(
       std::function<void(
           std::unique_ptr<InferenceResponse>&&, const uint32_t)>&& delegator)

--- a/src/core/infer_response.cc
+++ b/src/core/infer_response.cc
@@ -49,6 +49,9 @@ InferenceResponseFactory::CreateResponse(
 Status
 InferenceResponseFactory::SendFlags(const uint32_t flags) const
 {
+  if (response_delegator_ != nullptr) {
+    response_delegator_(nullptr /* response */, flags);
+  }
   void* userp = response_userp_;
   response_fn_(nullptr /* response */, flags, userp);
   return Status::Success;

--- a/src/core/infer_response.h
+++ b/src/core/infer_response.h
@@ -300,6 +300,8 @@ class InferenceResponse {
   // Delegator to be invoked on sending responses.
   std::function<void(std::unique_ptr<InferenceResponse>&&, const uint32_t)>
       response_delegator_;
+
+  bool null_response_;
 };
 
 std::ostream& operator<<(std::ostream& out, const InferenceResponse& response);

--- a/src/core/infer_response.h
+++ b/src/core/infer_response.h
@@ -207,6 +207,14 @@ class InferenceResponse {
       const std::function<void(
           std::unique_ptr<InferenceResponse>&&, const uint32_t)>& delegator);
 
+  // "null" InferenceResponse is a special instance of InferenceResponse which
+  // contains minimal information for calling InferenceResponse::Send,
+  // InferenceResponse::NullResponse. nullptr will be passed as response in
+  // 'response_fn'.
+  InferenceResponse(
+      TRITONSERVER_InferenceResponseCompleteFn_t response_fn,
+      void* response_userp);
+
   const std::string& Id() const { return id_; }
   const std::string& ModelName() const;
   int64_t ActualModelVersion() const;


### PR DESCRIPTION
With this fix, calling `InferenceResponseFactory::SendFlags` will invoke the dynamic batcher's preserve ordering so that all "responses" will be checked. Previously the "null response" carrying the FINISH flag will be lost and cause dynamic batcher not sending responses from sequential requests.