### PR TITLE
Fixes some of the memory leaks

### DIFF
--- a/src/backends/backend/examples/backend_utils.h
+++ b/src/backends/backend/examples/backend_utils.h
@@ -42,18 +42,34 @@
 
 namespace nvidia { namespace inferenceserver { namespace backend {
 
+#define IGNORE_ERROR(X)                   \
+  do {                                    \
+    TRITONSERVER_Error* ie_err__ = (X);   \
+    if (ie_err__ != nullptr) {            \
+      TRITONSERVER_ErrorDelete(ie_err__); \
+    }                                     \
+  } while (false)
+
 #define LOG_IF_ERROR(X, MSG)                                                   \
   do {                                                                         \
     TRITONSERVER_Error* lie_err__ = (X);                                       \
     if (lie_err__ != nullptr) {                                                \
-      TRITONSERVER_LogMessage(                                                 \
+      IGNORE_ERROR(TRITONSERVER_LogMessage(                                    \
           TRITONSERVER_LOG_INFO, __FILE__, __LINE__,                           \
           (std::string(MSG) + ": " + TRITONSERVER_ErrorCodeString(lie_err__) + \
            " - " + TRITONSERVER_ErrorMessage(lie_err__))                       \
-              .c_str());                                                       \
+              .c_str()));                                                      \
       TRITONSERVER_ErrorDelete(lie_err__);                                     \
     }                                                                          \
   } while (false)
+
+#define LOG_MESSAGE(LEVEL, MSG)                                  \
+  do {                                                           \
+    LOG_IF_ERROR(                                                \
+        TRITONSERVER_LogMessage(LEVEL, __FILE__, __LINE__, MSG), \
+        ("failed to log message: "));                            \
+  } while (false)
+
 
 #define RETURN_ERROR_IF_FALSE(P, C, MSG)              \
   do {                                                \

--- a/src/backends/backend/examples/identity.cc
+++ b/src/backends/backend/examples/identity.cc
@@ -205,8 +205,8 @@ ModelInstance::Execute(
 void
 ModelInstance::ExecuteThread()
 {
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("model ") + model_state_->ModelName() +
        ": starting execute thread for instance " + props_.AsString())
           .c_str());
@@ -250,8 +250,8 @@ ModelInstance::ExecuteThread()
     uint32_t request_count = exec_requests->request_count_;
     std::vector<TRITONBACKEND_Response*>& responses = exec_requests->responses_;
 
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
         (std::string("model ") + model_state_->ModelName() + ": executing " +
          std::to_string(request_count) + " requests on instance " +
          props_.AsString())
@@ -297,16 +297,16 @@ ModelInstance::ExecuteThread()
       // If an error response was sent for the above then display an
       // error message and move on to next request.
       if (responses[r] == nullptr) {
-        TRITONSERVER_LogMessage(
-            TRITONSERVER_LOG_ERROR, __FILE__, __LINE__,
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_ERROR,
             (std::string("request ") + std::to_string(r) +
              ": failed to read request properties, error response sent")
                 .c_str());
         continue;
       }
 
-      TRITONSERVER_LogMessage(
-          TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_INFO,
           (std::string("request ") + std::to_string(r) + ": id = \"" +
            request_id +
            "\", correlation_id = " + std::to_string(correlation_id) +
@@ -337,8 +337,8 @@ ModelInstance::ExecuteThread()
       // requested output name then display an error message and move on
       // to next request.
       if (responses[r] == nullptr) {
-        TRITONSERVER_LogMessage(
-            TRITONSERVER_LOG_ERROR, __FILE__, __LINE__,
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_ERROR,
             (std::string("request ") + std::to_string(r) +
              ": failed to read input or requested output name, error response "
              "sent")
@@ -358,24 +358,24 @@ ModelInstance::ExecuteThread()
               input, &input_name, &input_datatype, &input_shape,
               &input_dims_count, &input_byte_size, &input_buffer_count));
       if (responses[r] == nullptr) {
-        TRITONSERVER_LogMessage(
-            TRITONSERVER_LOG_ERROR, __FILE__, __LINE__,
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_ERROR,
             (std::string("request ") + std::to_string(r) +
              ": failed to read input properties, error response sent")
                 .c_str());
         continue;
       }
 
-      TRITONSERVER_LogMessage(
-          TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_INFO,
           (std::string("\tinput ") + input_name +
            ": datatype = " + TRITONSERVER_DataTypeString(input_datatype) +
            ", shape = " + nib::ShapeToString(input_shape, input_dims_count) +
            ", byte_size = " + std::to_string(input_byte_size) +
            ", buffer_count = " + std::to_string(input_buffer_count))
               .c_str());
-      TRITONSERVER_LogMessage(
-          TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_INFO,
           (std::string("\trequested_output ") + requested_output_name).c_str());
 
       // For statistics we need to collect the total batch size of all
@@ -412,8 +412,8 @@ ModelInstance::ExecuteThread()
                 response, &output, requested_output_name, input_datatype,
                 input_shape, input_dims_count));
         if (responses[r] == nullptr) {
-          TRITONSERVER_LogMessage(
-              TRITONSERVER_LOG_ERROR, __FILE__, __LINE__,
+          LOG_MESSAGE(
+              TRITONSERVER_LOG_ERROR,
               (std::string("request ") + std::to_string(r) +
                ": failed to create response output, error response sent")
                   .c_str());
@@ -438,8 +438,8 @@ ModelInstance::ExecuteThread()
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_UNSUPPORTED,
                   "failed to create output buffer in CPU memory"));
-          TRITONSERVER_LogMessage(
-              TRITONSERVER_LOG_ERROR, __FILE__, __LINE__,
+          LOG_MESSAGE(
+              TRITONSERVER_LOG_ERROR,
               (std::string("request ") + std::to_string(r) +
                ": failed to create output buffer in CPU memory, error response "
                "sent")
@@ -476,8 +476,8 @@ ModelInstance::ExecuteThread()
         }
 
         if (responses[r] == nullptr) {
-          TRITONSERVER_LogMessage(
-              TRITONSERVER_LOG_ERROR, __FILE__, __LINE__,
+          LOG_MESSAGE(
+              TRITONSERVER_LOG_ERROR,
               (std::string("request ") + std::to_string(r) +
                ": failed to get input buffer in CPU memory, error response "
                "sent")
@@ -570,8 +570,8 @@ ModelInstance::ExecuteThread()
     }
   } while (true);
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("model ") + model_state_->ModelName() +
        ": ending execute thread for instance " + props_.AsString())
           .c_str());
@@ -649,8 +649,8 @@ ModelState::ValidateModelConfig()
   // We have the json DOM for the model configuration...
   ni::TritonJson::WriteBuffer buffer;
   RETURN_IF_ERROR(model_config_.PrettyWrite(&buffer));
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("model configuration:\n") + buffer.Contents()).c_str());
 
   ni::TritonJson::Value inputs, outputs;
@@ -716,8 +716,8 @@ ModelState::CreateModelInstances()
     // so set it appropriately.
     instance.id_ = idx++;
 
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
         (std::string("created instance: ") + instance.AsString()).c_str());
 
     instances_.emplace_back(new ModelInstance(this, instance));
@@ -769,8 +769,8 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
   RETURN_IF_ERROR(TRITONBACKEND_BackendName(backend, &cname));
   std::string name(cname);
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_Initialize: ") + name).c_str());
 
   // We should check the backend API version that Triton supports
@@ -778,13 +778,13 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
   uint32_t api_version;
   RETURN_IF_ERROR(TRITONBACKEND_BackendApiVersion(backend, &api_version));
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("Triton TRITONBACKEND API version: ") +
        std::to_string(api_version))
           .c_str());
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("'") + name + "' TRITONBACKEND API version: " +
        std::to_string(TRITONBACKEND_API_VERSION))
           .c_str());
@@ -810,8 +810,8 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
   size_t byte_size;
   RETURN_IF_ERROR(TRITONSERVER_MessageSerializeToJson(
       backend_config_message, &buffer, &byte_size));
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("backend configuration:\n") + buffer).c_str());
 
   // If we have any global backend state we create and set it here. We
@@ -834,8 +834,8 @@ TRITONBACKEND_Finalize(TRITONBACKEND_Backend* backend)
   RETURN_IF_ERROR(TRITONBACKEND_BackendState(backend, &vstate));
   std::string* state = reinterpret_cast<std::string*>(vstate);
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_Finalize: state is '") + *state + "'")
           .c_str());
 
@@ -857,8 +857,8 @@ TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model)
   uint64_t version;
   RETURN_IF_ERROR(TRITONBACKEND_ModelVersion(model, &version));
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_ModelInitialize: ") + name + " (version " +
        std::to_string(version) + ")")
           .c_str());
@@ -869,9 +869,8 @@ TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model)
   RETURN_IF_ERROR(TRITONBACKEND_ModelRepositoryPath(model, &cdir));
   std::string dir(cdir);
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
-      (std::string("Repository path: ") + dir).c_str());
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO, (std::string("Repository path: ") + dir).c_str());
 
   // The model can access the backend as well... here we can access
   // the backend global state.
@@ -882,8 +881,8 @@ TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model)
   RETURN_IF_ERROR(TRITONBACKEND_BackendState(backend, &vbackendstate));
   std::string* backend_state = reinterpret_cast<std::string*>(vbackendstate);
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("backend state is '") + *backend_state + "'").c_str());
 
   // With each model we create a ModelState object and associate it
@@ -918,9 +917,8 @@ TRITONBACKEND_ModelFinalize(TRITONBACKEND_Model* model)
   RETURN_IF_ERROR(TRITONBACKEND_ModelState(model, &vstate));
   ModelState* model_state = reinterpret_cast<ModelState*>(vstate);
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
-      "TRITONBACKEND_ModelFinalize: delete model state");
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO, "TRITONBACKEND_ModelFinalize: delete model state");
 
   delete model_state;
 

--- a/src/backends/backend/examples/repeat.cc
+++ b/src/backends/backend/examples/repeat.cc
@@ -197,8 +197,8 @@ ModelState::ValidateModelConfig()
   // We have the json DOM for the model configuration...
   ni::TritonJson::WriteBuffer buffer;
   RETURN_IF_ERROR(model_config_.PrettyWrite(&buffer));
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("model configuration:\n") + buffer.Contents()).c_str());
 
   // max_batch_size must be 0 because this backend does not support
@@ -324,8 +324,8 @@ ModelState::ValidateModelConfig()
   std::vector<nib::InstanceProperties> instances;
   RETURN_IF_ERROR(nib::ParseInstanceGroups(model_config_, &instances));
   if (instances.size() != 1) {
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_WARN, __FILE__, __LINE__,
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_WARN,
         (std::string("model configuration specifies ") +
          std::to_string(instances.size()) +
          " instances but repeat backend supports only a single CPU instance. "
@@ -455,8 +455,8 @@ ModelState::ResponseThread(
   // IN and DELAY are INT32 vectors... wait, copy IN->OUT, and send a
   // response.
   for (uint32_t e = 0; e < element_count; ++e) {
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
         (std::string("waiting ") + std::to_string(delay_buffer.get()[e]) +
          " ms, then sending response " + std::to_string(e + 1) + " of " +
          std::to_string(element_count))
@@ -533,8 +533,8 @@ ModelState::ResponseThread(
             response, 0 /* flags */, nullptr /* success */),
         "failed sending response");
 
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
         (std::string("sent response ") + std::to_string(e + 1) + " of " +
          std::to_string(element_count))
             .c_str());
@@ -543,9 +543,7 @@ ModelState::ResponseThread(
   // Add some logging for the case where IN was size 0 and so no
   // responses were sent.
   if (element_count == 0) {
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
-        "IN size is zero, no responses sent");
+    LOG_MESSAGE(TRITONSERVER_LOG_INFO, "IN size is zero, no responses sent");
   }
 
   // All responses have been sent so we must signal that we are done
@@ -581,8 +579,8 @@ TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model)
   uint64_t version;
   RETURN_IF_ERROR(TRITONBACKEND_ModelVersion(model, &version));
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_ModelInitialize: ") + name + " (version " +
        std::to_string(version) + ")")
           .c_str());
@@ -613,9 +611,8 @@ TRITONBACKEND_ModelFinalize(TRITONBACKEND_Model* model)
   RETURN_IF_ERROR(TRITONBACKEND_ModelState(model, &vstate));
   ModelState* model_state = reinterpret_cast<ModelState*>(vstate);
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
-      "TRITONBACKEND_ModelFinalize: delete model state");
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO, "TRITONBACKEND_ModelFinalize: delete model state");
 
   delete model_state;
 
@@ -631,8 +628,8 @@ TRITONBACKEND_ModelExecute(
   const char* model_name;
   RETURN_IF_ERROR(TRITONBACKEND_ModelName(model, &model_name));
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_ModelExecute: model ") + model_name +
        " with " + std::to_string(request_count) + " requests")
           .c_str());
@@ -670,8 +667,8 @@ TRITONBACKEND_ModelExecute(
   }
 
   // Wait, release, return...
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("waiting ") + std::to_string(wait_milliseconds) +
        " ms before releasing requests")
           .c_str());
@@ -708,8 +705,8 @@ TRITONBACKEND_ModelExecute(
           exec_end_ns, exec_end_ns),
       "failed reporting batch request statistics");
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_ModelExecute: model ") + model_name +
        " released " + std::to_string(request_count) + " requests")
           .c_str());

--- a/src/backends/backend/examples/square.cc
+++ b/src/backends/backend/examples/square.cc
@@ -174,8 +174,8 @@ ModelState::ValidateModelConfig()
   // We have the json DOM for the model configuration...
   ni::TritonJson::WriteBuffer buffer;
   RETURN_IF_ERROR(model_config_.PrettyWrite(&buffer));
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("model configuration:\n") + buffer.Contents()).c_str());
 
   ni::TritonJson::Value inputs, outputs;
@@ -243,8 +243,8 @@ ModelState::ValidateModelConfig()
   std::vector<nib::InstanceProperties> instances;
   RETURN_IF_ERROR(nib::ParseInstanceGroups(model_config_, &instances));
   if (instances.size() != 1) {
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_WARN, __FILE__, __LINE__,
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_WARN,
         (std::string("model configuration specifies ") +
          std::to_string(instances.size()) +
          " instances but square backend supports only a single CPU instance. "
@@ -364,8 +364,8 @@ ModelState::RequestThread(
             response, 0 /* flags */, nullptr /* success */),
         "failed sending response");
 
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
         (std::string("sent response ") + std::to_string(e + 1) + " of " +
          std::to_string(element_count))
             .c_str());
@@ -374,9 +374,7 @@ ModelState::RequestThread(
   // Add some logging for the case where IN was size 0 and so no
   // responses were sent.
   if (element_count == 0) {
-    TRITONSERVER_LogMessage(
-        TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
-        "IN size is zero, no responses send ");
+    LOG_MESSAGE(TRITONSERVER_LOG_INFO, "IN size is zero, no responses send ");
   }
 
   // All responses have been sent so we must signal that we are done
@@ -412,8 +410,8 @@ TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model)
   uint64_t version;
   RETURN_IF_ERROR(TRITONBACKEND_ModelVersion(model, &version));
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_ModelInitialize: ") + name + " (version " +
        std::to_string(version) + ")")
           .c_str());
@@ -444,9 +442,8 @@ TRITONBACKEND_ModelFinalize(TRITONBACKEND_Model* model)
   RETURN_IF_ERROR(TRITONBACKEND_ModelState(model, &vstate));
   ModelState* model_state = reinterpret_cast<ModelState*>(vstate);
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
-      "TRITONBACKEND_ModelFinalize: delete model state");
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO, "TRITONBACKEND_ModelFinalize: delete model state");
 
   delete model_state;
 
@@ -462,8 +459,8 @@ TRITONBACKEND_ModelExecute(
   const char* model_name;
   RETURN_IF_ERROR(TRITONBACKEND_ModelName(model, &model_name));
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_ModelExecute: model ") + model_name +
        " with " + std::to_string(request_count) + " requests")
           .c_str());
@@ -501,8 +498,8 @@ TRITONBACKEND_ModelExecute(
         "failed releasing request");
   }
 
-  TRITONSERVER_LogMessage(
-      TRITONSERVER_LOG_INFO, __FILE__, __LINE__,
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_ModelExecute: model ") + model_name +
        " released " + std::to_string(request_count) + " requests")
           .c_str());

--- a/src/core/json.h
+++ b/src/core/json.h
@@ -117,13 +117,6 @@ class TritonJson {
     // Move constructor.
     explicit Value(Value&& other) { *this = std::move(other); }
 
-    ~Value()
-    {
-      if (value_ != nullptr) {
-        delete value_;
-      }
-    }
-
     // Move assignment operator.
     Value& operator=(Value&& other)
     {
@@ -960,15 +953,6 @@ class TritonJson {
       return TRITONJSON_STATUSSUCCESS;
     }
 
-   private:
-    // Construct a non-top-level JSON value that references an
-    // existing element in a docuemnt.
-    explicit Value(
-        rapidjson::Value& v, rapidjson::Document::AllocatorType* allocator)
-        : value_(&v), allocator_(allocator)
-    {
-    }
-
     // Release/clear a value.
     void Release()
     {
@@ -976,6 +960,15 @@ class TritonJson {
         delete value_;
         value_ = nullptr;
       }
+    }
+
+   private:
+    // Construct a non-top-level JSON value that references an
+    // existing element in a docuemnt.
+    explicit Value(
+        rapidjson::Value& v, rapidjson::Document::AllocatorType* allocator)
+        : value_(&v), allocator_(allocator)
+    {
     }
 
     // Return a value object that can be used for both a top-level

--- a/src/core/json.h
+++ b/src/core/json.h
@@ -117,6 +117,13 @@ class TritonJson {
     // Move constructor.
     explicit Value(Value&& other) { *this = std::move(other); }
 
+    ~Value()
+    {
+      if (value_ != nullptr) {
+        delete value_;
+      }
+    }
+
     // Move assignment operator.
     Value& operator=(Value&& other)
     {

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -1446,6 +1446,7 @@ FixIntArray(
   }
 
   shape_array.Swap(fixed_shape_array);
+  fixed_shape_array.Release();
 
   return Status::Success;
 }

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -317,7 +317,7 @@ class ModelRepositoryManager::BackendLifeCycle {
       const BackendCmdlineConfigMap& backend_cmdline_config_map,
       std::unique_ptr<BackendLifeCycle>* life_cycle);
 
-  ~BackendLifeCycle() = default;
+  ~BackendLifeCycle() { map_.clear(); }
 
   // Start loading model backends with specified versions asynchronously.
   // If 'force_unload', all versions that are being served will

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -552,7 +552,7 @@ TRITONSERVER_LogIsEnabled(TRITONSERVER_LogLevel level)
   return false;
 }
 
-TRITONSERVER_Error*
+void
 TRITONSERVER_LogMessage(
     TRITONSERVER_LogLevel level, const char* filename, const int line,
     const char* msg)
@@ -570,12 +570,10 @@ TRITONSERVER_LogMessage(
     case TRITONSERVER_LOG_VERBOSE:
       LOG_VERBOSE_FL(1, filename, line) << msg;
       break;
+    default:
+      LOG_ERROR_FL(__FILE__, __LINE__)
+          << "unknown logging level '" << level << "'";
   }
-
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_INVALID_ARG,
-      std::string("unknown logging level '" + std::to_string(level) + "'")
-          .c_str());
 }
 
 //

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -552,7 +552,7 @@ TRITONSERVER_LogIsEnabled(TRITONSERVER_LogLevel level)
   return false;
 }
 
-void
+TRITONSERVER_Error*
 TRITONSERVER_LogMessage(
     TRITONSERVER_LogLevel level, const char* filename, const int line,
     const char* msg)
@@ -560,19 +560,21 @@ TRITONSERVER_LogMessage(
   switch (level) {
     case TRITONSERVER_LOG_INFO:
       LOG_INFO_FL(filename, line) << msg;
-      break;
+      return nullptr;
     case TRITONSERVER_LOG_WARN:
       LOG_WARNING_FL(filename, line) << msg;
-      break;
+      return nullptr;
     case TRITONSERVER_LOG_ERROR:
       LOG_ERROR_FL(filename, line) << msg;
-      break;
+      return nullptr;
     case TRITONSERVER_LOG_VERBOSE:
       LOG_VERBOSE_FL(1, filename, line) << msg;
-      break;
+      return nullptr;
     default:
-      LOG_ERROR_FL(__FILE__, __LINE__)
-          << "unknown logging level '" << level << "'";
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          std::string("unknown logging level '" + std::to_string(level) + "'")
+              .c_str());
   }
 }
 

--- a/src/core/tritonserver.h
+++ b/src/core/tritonserver.h
@@ -161,6 +161,7 @@ TRITONSERVER_EXPORT bool TRITONSERVER_LogIsEnabled(TRITONSERVER_LogLevel level);
 /// \param filename The file name of the location of the log message.
 /// \param line The line number of the log message.
 /// \param msg The log message.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_EXPORT TRITONSERVER_Error* TRITONSERVER_LogMessage(
     TRITONSERVER_LogLevel level, const char* filename, const int line,
     const char* msg);

--- a/src/core/tritonserver.h
+++ b/src/core/tritonserver.h
@@ -161,7 +161,7 @@ TRITONSERVER_EXPORT bool TRITONSERVER_LogIsEnabled(TRITONSERVER_LogLevel level);
 /// \param filename The file name of the location of the log message.
 /// \param line The line number of the log message.
 /// \param msg The log message.
-TRITONSERVER_EXPORT void TRITONSERVER_LogMessage(
+TRITONSERVER_EXPORT TRITONSERVER_Error* TRITONSERVER_LogMessage(
     TRITONSERVER_LogLevel level, const char* filename, const int line,
     const char* msg);
 

--- a/src/core/tritonserver.h
+++ b/src/core/tritonserver.h
@@ -161,8 +161,7 @@ TRITONSERVER_EXPORT bool TRITONSERVER_LogIsEnabled(TRITONSERVER_LogLevel level);
 /// \param filename The file name of the location of the log message.
 /// \param line The line number of the log message.
 /// \param msg The log message.
-/// \return a TRITONSERVER_Error indicating success or failure.
-TRITONSERVER_EXPORT TRITONSERVER_Error* TRITONSERVER_LogMessage(
+TRITONSERVER_EXPORT void TRITONSERVER_LogMessage(
     TRITONSERVER_LogLevel level, const char* filename, const int line,
     const char* msg);
 

--- a/src/servers/common.h
+++ b/src/servers/common.h
@@ -76,6 +76,14 @@ namespace nvidia { namespace inferenceserver {
     }                                                             \
   } while (false)
 
+#define IGNORE_ERR(X)                  \
+  do {                                 \
+    TRITONSERVER_Error* err__ = (X);   \
+    if (err__ != nullptr) {            \
+      TRITONSERVER_ErrorDelete(err__); \
+    }                                  \
+  } while (false)
+
 #ifdef TRITON_ENABLE_GPU
 #define FAIL_IF_CUDA_ERR(X, MSG)                                           \
   do {                                                                     \

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -2906,6 +2906,13 @@ class ModelInferHandler
         "creating inference response allocator");
   }
 
+  ~ModelInferHandler()
+  {
+    LOG_TRITONSERVER_ERROR(
+        TRITONSERVER_ResponseAllocatorDelete(allocator_),
+        "deleting response allocator");
+  }
+
  protected:
   void StartNewRequest() override;
   bool Process(State* state, bool rpc_ok) override;
@@ -3237,6 +3244,13 @@ class ModelStreamInferHandler
             &allocator_, StreamInferResponseAlloc, InferResponseFree,
             StreamInferResponseStart),
         "creating response allocator");
+  }
+
+  ~ModelStreamInferHandler()
+  {
+    LOG_TRITONSERVER_ERROR(
+        TRITONSERVER_ResponseAllocatorDelete(allocator_),
+        "deleting response allocator");
   }
 
  protected:
@@ -3757,7 +3771,7 @@ GRPCServer::GRPCServer(
 
 GRPCServer::~GRPCServer()
 {
-  Stop();
+  IGNORE_ERR(Stop());
 }
 
 TRITONSERVER_Error*

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -1215,6 +1215,7 @@ main(int argc, char** argv)
   if (keep_alive == nullptr) {
     return 1;
   }
+  delete keep_alive;
 
   return 0;
 }

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -1209,13 +1209,5 @@ main(int argc, char** argv)
   //  __lsan_do_leak_check();
 #endif  // TRITON_ENABLE_ASAN
 
-  // FIXME. TF backend aborts if we attempt cleanup...
-  std::shared_ptr<TRITONSERVER_Server>* keep_alive =
-      new std::shared_ptr<TRITONSERVER_Server>(server);
-  if (keep_alive == nullptr) {
-    return 1;
-  }
-  delete keep_alive;
-
   return 0;
 }


### PR DESCRIPTION
Fixes most of the 'definitely lost' memory leaks reported by valgrind. This effort covers only custom models and does not fixes leaks in other backends. There is a 32 bytes leak within cnmem library and in dlopen calls. I read that valgrind sometimes report false positive leaks in dlopen. 

See the attached file for detail report after the fixes : [mem_custom.txt](https://github.com/NVIDIA/triton-inference-server/files/4929019/mem_custom.txt)
