### PR TITLE
Improving gRPC server performance with new message hierarchy

### DIFF
--- a/docs/protocol/grpc_core_service.proto
+++ b/docs/protocol/grpc_core_service.proto
@@ -266,8 +266,8 @@ message ModelInferRequest
     map<string, InferParameter> parameters = 4;
 
     // The tensor contents using a data-type format. This field must
-    // not be specified if "raw" tensor contents are being used for
-    // the inference request.
+    // not be specified if tensor contents are being specified in
+    // ModelInferRequest.raw_input_contents.
     InferTensorContents contents = 5;
   }
 
@@ -346,8 +346,8 @@ message ModelInferResponse
     map<string, InferParameter> parameters = 4;
 
     // The tensor contents using a data-type format. This field must
-    // not be specified if "raw" tensor contents are being used for
-    // the inference response.
+    // not be specified if tensor contents are being specified in
+    // ModelInferResponse.raw_output_contents.
     InferTensorContents contents = 5;
   }
 

--- a/docs/protocol/grpc_core_service.proto
+++ b/docs/protocol/grpc_core_service.proto
@@ -190,69 +190,59 @@ message InferParameter
 }
 
 //
-// The data contained in a tensor. For a given data type the tensor
-// contents can be represented in "raw" bytes form or in the repeated
-// type that matches the tensor's data type. Protobuf oneof is not
-// used because oneofs cannot contain repeated fields.
+// The data contained in a tensor represented by the repeated type
+// that matches the tensor's data type. Protobuf oneof is not used
+// because oneofs cannot contain repeated fields.
 //
 message InferTensorContents
 {
-  // Raw representation of the tensor contents. The size of this
-  // content must match what is expected by the tensor's shape
-  // and data type. The raw data must be the flattened, one-dimensional,
-  // row-major order of the tensor elements without any stride or padding
-  // between the elements. Note that the FP16 data type must be
-  // represented as raw content as there is no standard support for a
-  // 16-bit float type.
-  bytes raw_contents = 1;
-
   // Representation for BOOL data type. The size must match what is
   // expected by the tensor's shape. The contents must be the
   // flattened, one-dimensional, row-major order of the tensor
   // elements.
-  repeated bool bool_contents = 2;
+  repeated bool bool_contents = 1;
 
   // Representation for INT8, INT16, and INT32 data types. The size
   // must match what is expected by the tensor's shape. The contents
   // must be the flattened, one-dimensional, row-major order of the
   // tensor elements.
-  repeated int32 int_contents = 3;
+  repeated int32 int_contents = 2;
 
   // Representation for INT64 data types. The size must match what is
   // expected by the tensor's shape. The contents must be the
   // flattened, one-dimensional, row-major order of the tensor
   // elements.
-  repeated int64 int64_contents = 4;
+  repeated int64 int64_contents = 3;
 
   // Representation for UINT8, UINT16, and UINT32 data types. The size
   // must match what is expected by the tensor's shape. The contents
   // must be the flattened, one-dimensional, row-major order of the
   // tensor elements.
-  repeated uint32 uint_contents = 5;
+  repeated uint32 uint_contents = 4;
 
   // Representation for UINT64 data types. The size must match what is
   // expected by the tensor's shape. The contents must be the
   // flattened, one-dimensional, row-major order of the tensor
   // elements.
-  repeated uint64 uint64_contents = 6;
+  repeated uint64 uint64_contents = 5;
 
   // Representation for FP32 data type. The size must match what is
   // expected by the tensor's shape. The contents must be the
   // flattened, one-dimensional, row-major order of the tensor
   // elements.
-  repeated float fp32_contents = 7;
+  repeated float fp32_contents = 6;
 
   // Representation for FP64 data type. The size must match what is
   // expected by the tensor's shape. The contents must be the
   // flattened, one-dimensional, row-major order of the tensor
   // elements.
-  repeated double fp64_contents = 8;
+  repeated double fp64_contents = 7;
 
   // Representation for BYTES data type. The size must match what is
   // expected by the tensor's shape. The contents must be the
   // flattened, one-dimensional, row-major order of the tensor
   // elements.
-  repeated bytes byte_contents = 9;
+  repeated bytes byte_contents = 8;
 }
 
 //
@@ -275,7 +265,9 @@ message ModelInferRequest
     // Optional inference input tensor parameters.
     map<string, InferParameter> parameters = 4;
 
-    // The input tensor data.
+    // The tensor contents using a data-type format. This field must
+    // not be specified if "raw" tensor contents are being used for
+    // the inference request.
     InferTensorContents contents = 5;
   }
 
@@ -310,6 +302,27 @@ message ModelInferRequest
   // specified all outputs specified in the model config will be
   // returned.
   repeated InferRequestedOutputTensor outputs = 6;
+
+  // The data contained in an input tensor can be represented in "raw"
+  // bytes form or in the repeated type that matches the tensor's data
+  // type. Using the "raw" bytes form will typically allow higher
+  // performance due to the way protobuf allocation and reuse
+  // interacts with GRPC. For example, see
+  // https://github.com/grpc/grpc/issues/23231.
+  //
+  // To use the raw representation 'raw_input_contents' must be
+  // initialized with data for each tensor in the same order as
+  // 'inputs'. For each tensor, the size of this content must match
+  // what is expected by the tensor's shape and data type. The raw
+  // data must be the flattened, one-dimensional, row-major order of
+  // the tensor elements without any stride or padding between the
+  // elements. Note that the FP16 data type must be represented as raw
+  // content as there is no specific data type for a 16-bit float
+  // type.
+  //
+  // If this field is specified then InferInputTensor::contents must
+  // not be specified for any input tensor.
+  repeated bytes raw_input_contents = 7;
 }
 
 //
@@ -332,7 +345,9 @@ message ModelInferResponse
     // Tensor parameters.
     map<string, InferParameter> parameters = 4;
 
-    // The output tensor data.
+    // The tensor contents using a data-type format. This field must
+    // not be specified if "raw" tensor contents are being used for
+    // the inference response.
     InferTensorContents contents = 5;
   }
 
@@ -350,4 +365,25 @@ message ModelInferResponse
 
   // The output tensors holding inference results.
   repeated InferOutputTensor outputs = 5;
+
+  // The data contained in an output tensor can be represented in
+  // "raw" bytes form or in the repeated type that matches the
+  // tensor's data type. Using the "raw" bytes form will typically
+  // allow higher performance due to the way protobuf allocation and
+  // reuse interacts with GRPC. For example, see
+  // https://github.com/grpc/grpc/issues/23231.
+  //
+  // To use the raw representation 'raw_output_contents' must be
+  // initialized with data for each tensor in the same order as
+  // 'outputs'. For each tensor, the size of this content must match
+  // what is expected by the tensor's shape and data type. The raw
+  // data must be the flattened, one-dimensional, row-major order of
+  // the tensor elements without any stride or padding between the
+  // elements. Note that the FP16 data type must be represented as raw
+  // content as there is no specific data type for a 16-bit float
+  // type.
+  //
+  // If this field is specified then InferOutputTensor::contents must
+  // not be specified for any output tensor.
+  repeated bytes raw_output_contents = 6;
 }

--- a/qa/L0_output_name/output_name_test.py
+++ b/qa/L0_output_name/output_name_test.py
@@ -52,16 +52,14 @@ class OutputNameValidationTest(unittest.TestCase):
         input.datatype = "FP32"
         input.shape.extend([1])
 
-        input_contents = grpc_service_pb2.InferTensorContents()
-        input_contents.raw_contents = bytes(4 * 'a', 'utf-8')
-        input.contents.CopyFrom(input_contents)
-
         request.inputs.extend([input])
 
         output = grpc_service_pb2.ModelInferRequest(
         ).InferRequestedOutputTensor()
         output.name = output_name
         request.outputs.extend([output])
+
+        request.raw_input_contents.extend([bytes(4 * 'a', 'utf-8')])
 
         return request
 

--- a/src/clients/python/examples/grpc_client.py
+++ b/src/clients/python/examples/grpc_client.py
@@ -105,16 +105,13 @@ if __name__ == '__main__':
     input.name = "input"
     input.datatype = "FP32"
     input.shape.extend([1, 224, 224, 3])
-
-    input_contents = grpc_service_pb2.InferTensorContents()
-    input_contents.raw_contents = bytes(602112 * 'a', 'utf-8')
-    input.contents.CopyFrom(input_contents)
-
     request.inputs.extend([input])
 
     output = grpc_service_pb2.ModelInferRequest().InferRequestedOutputTensor()
     output.name = "resnet_v1_50/predictions/Softmax"
     request.outputs.extend([output])
+
+    request.raw_input_contents.extend([bytes(602112 * 'a', 'utf-8')])
 
     response = grpc_stub.ModelInfer(request)
     print("model infer:\n{}".format(response))

--- a/src/clients/python/examples/grpc_explicit_byte_content_client.py
+++ b/src/clients/python/examples/grpc_explicit_byte_content_client.py
@@ -97,13 +97,15 @@ if __name__ == '__main__':
 
     # Deserialize the output raw tensor to numpy array for proper comparison
     output_results = []
+    index = 0
     for output in response.outputs:
         shape = []
         for value in output.shape:
             shape.append(value)
         output_results.append(
-            utils.deserialize_bytes_tensor(output.contents.raw_contents))
+            utils.deserialize_bytes_tensor(response.raw_output_contents[index]))
         output_results[-1] = np.resize(output_results[-1], shape)
+        index += 1
 
     if len(output_results) != 2:
         print("expected two output results")

--- a/src/clients/python/examples/grpc_explicit_int8_content_client.py
+++ b/src/clients/python/examples/grpc_explicit_int8_content_client.py
@@ -95,13 +95,15 @@ if __name__ == '__main__':
     response = grpc_stub.ModelInfer(request)
 
     output_results = []
+    index = 0
     for output in response.outputs:
         shape = []
         for value in output.shape:
             shape.append(value)
         output_results.append(
-            np.frombuffer(output.contents.raw_contents, dtype=np.int32))
+            np.frombuffer(response.raw_output_contents[index], dtype=np.int32))
         output_results[-1] = np.resize(output_results[-1], shape)
+        index += 1
 
     if len(output_results) != 2:
         print("expected two output results")

--- a/src/clients/python/examples/grpc_image_client.py
+++ b/src/clients/python/examples/grpc_image_client.py
@@ -273,6 +273,7 @@ def requestGenerator(input_name, output_name, c, h, w, format, dtype, FLAGS,
         input_bytes = None
         input_filenames = []
         request.ClearField("inputs")
+        request.ClearField("raw_input_contents")
         for idx in range(FLAGS.batch_size):
             input_filenames.append(filenames[image_idx])
             if input_bytes is None:

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -579,8 +579,8 @@ message ModelInferRequest
     //@@    .. cpp:var:: InferTensorContents contents
     //@@
     //@@       The tensor contents using a data-type format. This field
-    //@@       must not be specified if "raw" tensor contents are being
-    //@@       used for the inference request.
+    //@@       must not be specified if tensor contents are being specified
+    //@@       in ModelInferRequest.raw_input_contents.
     //@@
     InferTensorContents contents = 5;
   }
@@ -718,8 +718,8 @@ message ModelInferResponse
     //@@    .. cpp:var:: InferTensorContents contents
     //@@
     //@@       The tensor contents using a data-type format. This field
-    //@@       must not be specified if "raw" tensor contents are being
-    //@@       used for the inference response.
+    //@@       must not be specified if tensor contents are being specified
+    //@@       in ModelInferResponse.raw_output_contents.
     //@@
     InferTensorContents contents = 5;
   }

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -454,26 +454,12 @@ message InferParameter
 //@@
 //@@.. cpp:var:: message InferTensorContents
 //@@
-//@@   The data contained in a tensor. For a given data type the
-//@@   tensor contents can be represented in "raw" bytes form or in
-//@@   the repeated type that matches the tensor's data type. Protobuf
-//@@   oneof is not used because oneofs cannot contain repeated fields.
+//@@   The data contained in a tensor represented by the repeated type
+//@@   that matches the tensor's data type. Protobuf oneof is not used
+//@@   because oneofs cannot contain repeated fields.
 //@@
 message InferTensorContents
 {
-  //@@
-  //@@  .. cpp:var:: bytes raw_contents
-  //@@
-  //@@     Raw representation of the tensor contents. The size of this
-  //@@     content must match what is expected by the tensor's shape
-  //@@     and data type. The raw data must be the flattened, one-dimensional,
-  //@@     row-major order of the tensor elements without any stride or padding
-  //@@     between the elements. Note that the FP16 data type must be
-  //@@     represented as raw content as there is no standard support for a
-  //@@     16-bit float type.
-  //@@
-  bytes raw_contents = 1;
-
   //@@
   //@@  .. cpp:var:: bool bool_contents (repeated)
   //@@
@@ -481,7 +467,7 @@ message InferTensorContents
   //@@     expected by the tensor's shape. The contents must be the flattened,
   //@@     one-dimensional, row-major order of the tensor elements.
   //@@
-  repeated bool bool_contents = 2;
+  repeated bool bool_contents = 1;
 
   //@@
   //@@  .. cpp:var:: int32 int_contents (repeated)
@@ -491,7 +477,7 @@ message InferTensorContents
   //@@     must be the flattened, one-dimensional, row-major order of the
   //@@     tensor elements.
   //@@
-  repeated int32 int_contents = 3;
+  repeated int32 int_contents = 2;
 
   //@@
   //@@  .. cpp:var:: int64 int64_contents (repeated)
@@ -500,7 +486,7 @@ message InferTensorContents
   //@@     is expected by the tensor's shape. The contents must be the
   //@@     flattened, one-dimensional, row-major order of the tensor elements.
   //@@
-  repeated int64 int64_contents = 4;
+  repeated int64 int64_contents = 3;
 
   //@@
   //@@  .. cpp:var:: uint32 uint_contents (repeated)
@@ -510,7 +496,7 @@ message InferTensorContents
   //@@     must be the flattened, one-dimensional, row-major order of the
   //@@     tensor elements.
   //@@
-  repeated uint32 uint_contents = 5;
+  repeated uint32 uint_contents = 4;
 
   //@@
   //@@  .. cpp:var:: uint64 uint64_contents (repeated)
@@ -519,7 +505,7 @@ message InferTensorContents
   //@@     is expected by the tensor's shape. The contents must be the
   //@@     flattened, one-dimensional, row-major order of the tensor elements.
   //@@
-  repeated uint64 uint64_contents = 6;
+  repeated uint64 uint64_contents = 5;
 
   //@@
   //@@  .. cpp:var:: float fp32_contents (repeated)
@@ -528,7 +514,7 @@ message InferTensorContents
   //@@     expected by the tensor's shape. The contents must be the flattened,
   //@@     one-dimensional, row-major order of the tensor elements.
   //@@
-  repeated float fp32_contents = 7;
+  repeated float fp32_contents = 6;
 
   //@@
   //@@  .. cpp:var:: double fp64_contents (repeated)
@@ -537,7 +523,7 @@ message InferTensorContents
   //@@     expected by the tensor's shape. The contents must be the flattened,
   //@@     one-dimensional, row-major order of the tensor elements.
   //@@
-  repeated double fp64_contents = 8;
+  repeated double fp64_contents = 7;
 
   //@@
   //@@  .. cpp:var:: bytes byte_contents (repeated)
@@ -546,7 +532,7 @@ message InferTensorContents
   //@@     expected by the tensor's shape. The contents must be the flattened,
   //@@     one-dimensional, row-major order of the tensor elements.
   //@@
-  repeated bytes byte_contents = 9;
+  repeated bytes byte_contents = 8;
 }
 
 //@@
@@ -590,9 +576,11 @@ message ModelInferRequest
     //@@
     map<string, InferParameter> parameters = 4;
 
-    //@@    .. cpp:var:: InferTensorContents
+    //@@    .. cpp:var:: InferTensorContents contents
     //@@
-    //@@       The input tensor data.
+    //@@       The tensor contents using a data-type format. This field
+    //@@       must not be specified if "raw" tensor contents are being
+    //@@       used for the inference request.
     //@@
     InferTensorContents contents = 5;
   }
@@ -659,6 +647,31 @@ message ModelInferRequest
   //@@     returned.
   //@@
   repeated InferRequestedOutputTensor outputs = 6;
+
+  //@@
+  //@@  .. cpp:var:: bytes raw_input_contents
+  //@@
+  //@@     The data contained in an input tensor can be represented in
+  //@@     "raw" bytes form or in the repeated type that matches the
+  //@@     tensor's data type. Using the "raw" bytes form will
+  //@@     typically allow higher performance due to the way protobuf
+  //@@     allocation and reuse interacts with GRPC. For example, see
+  //@@     https://github.com/grpc/grpc/issues/23231.
+  //@@
+  //@@     To use the raw representation 'raw_input_contents' must be
+  //@@     initialized with data for each tensor in the same order as
+  //@@     'inputs'. For each tensor, the size of this content must
+  //@@     match what is expected by the tensor's shape and data
+  //@@     type. The raw data must be the flattened, one-dimensional,
+  //@@     row-major order of the tensor elements without any stride
+  //@@     or padding between the elements. Note that the FP16 data
+  //@@     type must be represented as raw content as there is no
+  //@@     specific data type for a 16-bit float type.
+  //@@
+  //@@     If this field is specified then InferInputTensor::contents
+  //@@     must not be specified for any input tensor.
+  //@@
+  repeated bytes raw_input_contents = 7;
 }
 
 //@@
@@ -702,9 +715,11 @@ message ModelInferResponse
     //@@
     map<string, InferParameter> parameters = 4;
 
-    //@@    .. cpp:var:: InferTensorContents
+    //@@    .. cpp:var:: InferTensorContents contents
     //@@
-    //@@       The output tensor data.
+    //@@       The tensor contents using a data-type format. This field
+    //@@       must not be specified if "raw" tensor contents are being
+    //@@       used for the inference response.
     //@@
     InferTensorContents contents = 5;
   }
@@ -739,6 +754,31 @@ message ModelInferResponse
   //@@     The output tensors holding inference results.
   //@@
   repeated InferOutputTensor outputs = 5;
+
+  //@@
+  //@@  .. cpp:var:: bytes raw_output_contents
+  //@@
+  //@@     The data contained in an output tensor can be represented in
+  //@@     "raw" bytes form or in the repeated type that matches the
+  //@@     tensor's data type. Using the "raw" bytes form will
+  //@@     typically allow higher performance due to the way protobuf
+  //@@     allocation and reuse interacts with GRPC. For example, see
+  //@@     https://github.com/grpc/grpc/issues/23231.
+  //@@
+  //@@     To use the raw representation 'raw_output_contents' must be
+  //@@     initialized with data for each tensor in the same order as
+  //@@     'outputs'. For each tensor, the size of this content must
+  //@@     match what is expected by the tensor's shape and data
+  //@@     type. The raw data must be the flattened, one-dimensional,
+  //@@     row-major order of the tensor elements without any stride
+  //@@     or padding between the elements. Note that the FP16 data
+  //@@     type must be represented as raw content as there is no
+  //@@     specific data type for a 16-bit float type.
+  //@@
+  //@@     If this field is specified then InferOutputTensor::contents
+  //@@     must not be specified for any output tensor.
+  //@@
+  repeated bytes raw_output_contents = 6;
 }
 
 //@@


### PR DESCRIPTION
Perf client arguments: `-m resnet50_fp16_plan -b 128 --concurrency-range=4 -i grpc`
### V1
> Inferences/Second vs. Client Average Batch Latency
> Concurrency: 4, throughput: 3814.4 infer/sec, latency 134257 usec

### V2 (Before changes)
> Inferences/Second vs. Client Average Batch Latency
> Concurrency: 4, throughput: 2816 infer/sec, latency 183080 usec

### V2 (After changes)
> Inferences/Second vs. Client Average Batch Latency
> Concurrency: 4, throughput: 3865.6 infer/sec, latency 132671 usec