### PR TITLE
Remove backend API to get input by index

### DIFF
--- a/src/backends/backend/examples/backend_utils.cc
+++ b/src/backends/backend/examples/backend_utils.cc
@@ -142,7 +142,7 @@ ReadInputTensor(
 {
   TRITONBACKEND_Input* input;
   RETURN_IF_ERROR(
-      TRITONBACKEND_RequestInputByName(request, input_name.c_str(), &input));
+      TRITONBACKEND_RequestInput(request, input_name.c_str(), &input));
 
   uint64_t input_byte_size;
   uint32_t input_buffer_count;

--- a/src/backends/backend/examples/identity.cc
+++ b/src/backends/backend/examples/identity.cc
@@ -317,10 +317,15 @@ ModelInstance::ExecuteThread()
 
       // We already validated that the model configuration specifies
       // only a single input and Triton enforces that.
+      const char* input_name;
+      GUARDED_RESPOND_IF_ERROR(
+          responses, r,
+          TRITONBACKEND_RequestInputName(request, 0 /* index */, &input_name));
+
       TRITONBACKEND_Input* input = nullptr;
       GUARDED_RESPOND_IF_ERROR(
           responses, r,
-          TRITONBACKEND_RequestInput(request, 0 /* index */, &input));
+          TRITONBACKEND_RequestInput(request, input_name, &input));
 
       // We also validated that the model configuration specifies only a
       // single output, but the request is not required to request any
@@ -346,7 +351,6 @@ ModelInstance::ExecuteThread()
         continue;
       }
 
-      const char* input_name;
       TRITONSERVER_DataType input_datatype;
       const int64_t* input_shape;
       uint32_t input_dims_count;
@@ -355,7 +359,7 @@ ModelInstance::ExecuteThread()
       GUARDED_RESPOND_IF_ERROR(
           responses, r,
           TRITONBACKEND_InputProperties(
-              input, &input_name, &input_datatype, &input_shape,
+              input, nullptr /* input_name */, &input_datatype, &input_shape,
               &input_dims_count, &input_byte_size, &input_buffer_count));
       if (responses[r] == nullptr) {
         LOG_MESSAGE(

--- a/src/backends/backend/examples/repeat.cc
+++ b/src/backends/backend/examples/repeat.cc
@@ -362,10 +362,10 @@ ModelState::ProcessRequest(TRITONBACKEND_Request* request, uint32_t* wait_ms)
   // check that for each request they are equal.
   TRITONBACKEND_Input* in;
   RESPOND_AND_RETURN_IF_ERROR(
-      request, TRITONBACKEND_RequestInputByName(request, "IN", &in));
+      request, TRITONBACKEND_RequestInput(request, "IN", &in));
   TRITONBACKEND_Input* delay;
   RESPOND_AND_RETURN_IF_ERROR(
-      request, TRITONBACKEND_RequestInputByName(request, "DELAY", &delay));
+      request, TRITONBACKEND_RequestInput(request, "DELAY", &delay));
 
   const int64_t* in_shape_arr;
   uint32_t in_dims_count;

--- a/src/backends/backend/examples/square.cc
+++ b/src/backends/backend/examples/square.cc
@@ -262,7 +262,7 @@ ModelState::ProcessRequest(TRITONBACKEND_Request* request)
   // response.
   TRITONBACKEND_Input* in;
   RESPOND_AND_RETURN_IF_ERROR(
-      request, TRITONBACKEND_RequestInputByName(request, "IN", &in));
+      request, TRITONBACKEND_RequestInput(request, "IN", &in));
 
   const int64_t* in_shape_arr;
   uint32_t in_dims_count;

--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -378,14 +378,15 @@ TRITONBACKEND_RequestInputCount(TRITONBACKEND_Request* request, uint32_t* count)
 }
 
 TRITONSERVER_Error*
-TRITONBACKEND_RequestInput(
+TRITONBACKEND_RequestInputName(
     TRITONBACKEND_Request* request, const uint32_t index,
-    TRITONBACKEND_Input** input)
+    const char** input_name)
 {
+  *input_name = nullptr;
+
   InferenceRequest* tr = reinterpret_cast<InferenceRequest*>(request);
   const auto& inputs = tr->ImmutableInputs();
   if (index >= inputs.size()) {
-    *input = nullptr;
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
         (std::string("out of bounds index ") + std::to_string(index) +
@@ -403,7 +404,7 @@ TRITONBACKEND_RequestInput(
   for (const auto& pr : inputs) {
     if (cnt++ == index) {
       InferenceRequest::Input* in = pr.second;
-      *input = reinterpret_cast<TRITONBACKEND_Input*>(in);
+      *input_name = in->Name().c_str();
       break;
     }
   }
@@ -412,7 +413,7 @@ TRITONBACKEND_RequestInput(
 }
 
 TRITONSERVER_Error*
-TRITONBACKEND_RequestInputByName(
+TRITONBACKEND_RequestInput(
     TRITONBACKEND_Request* request, const char* name,
     TRITONBACKEND_Input** input)
 {
@@ -446,10 +447,11 @@ TRITONBACKEND_RequestOutputName(
     TRITONBACKEND_Request* request, const uint32_t index,
     const char** output_name)
 {
+  *output_name = nullptr;
+
   InferenceRequest* tr = reinterpret_cast<InferenceRequest*>(request);
   const auto& routputs = tr->ImmutableRequestedOutputs();
   if (index >= routputs.size()) {
-    *output_name = nullptr;
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
         (std::string("out of bounds index ") + std::to_string(index) +

--- a/src/backends/backend/tritonbackend.h
+++ b/src/backends/backend/tritonbackend.h
@@ -170,31 +170,30 @@ TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestCorrelationId(
 TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestInputCount(
     TRITONBACKEND_Request* request, uint32_t* count);
 
-/// Get a request input tensor. The lifetime of the returned input
-/// tensor object matches that of the request and so the input tensor
-/// object should not be accessed after the request object is
-/// released.
+/// Get the name of an input tensor. The caller does not own
+/// the returned string and must not modify or delete it. The lifetime
+/// of the returned string extends only as long as 'request'.
 ///
 /// \param request The inference request.
 /// \param index The index of the input tensor. Must be 0 <= index <
 /// count, where count is the value returned by
 /// TRITONBACKEND_RequestInputCount.
-/// \param input Returns the input tensor corresponding to the index.
+/// \param input_name Returns the name of the input tensor
+/// corresponding to the index.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestInput(
+TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestInputName(
     TRITONBACKEND_Request* request, const uint32_t index,
-    TRITONBACKEND_Input** input);
+    const char** input_name);
 
-/// Get a named request input tensor. The lifetime of the returned
-/// input tensor object matches that of the request and so the input
-/// tensor object should not be accessed after the request object is
-/// released.
+/// Get a request input. The lifetime of the returned input object
+/// matches that of the request and so the input object should not be
+/// accessed after the request object is released.
 ///
 /// \param request The inference request.
-/// \param name The name of the input tensor.
-/// \param input Returns the input tensor corresponding to the name.
+/// \param name The name of the input.
+/// \param input Returns the input corresponding to the name.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestInputByName(
+TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestInput(
     TRITONBACKEND_Request* request, const char* name,
     TRITONBACKEND_Input** input);
 


### PR DESCRIPTION
Inputs must be looked up by name. Using index would likely lead to
errors since it implies that every request in a batch would have the
same input->index mapping, which is not true.