### PR TITLE
Use 'inference' package for GRPC protobuf

### DIFF
--- a/src/backends/backend/backend_factory.h
+++ b/src/backends/backend/backend_factory.h
@@ -48,7 +48,7 @@ class TritonBackendFactory {
 
   Status CreateBackend(
       const std::string& model_repository_path, const std::string& model_name,
-      const int64_t version, const ModelConfig& model_config,
+      const int64_t version, const inference::ModelConfig& model_config,
       std::unique_ptr<InferenceBackend>* backend)
   {
     std::unique_ptr<TritonModel> model;

--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -81,7 +81,7 @@ TritonModel::Create(
     InferenceServer* server, const std::string& model_repository_path,
     const BackendCmdlineConfigMap& backend_cmdline_config_map,
     const std::string& model_name, const int64_t version,
-    const ModelConfig& model_config, std::unique_ptr<TritonModel>* model)
+    const inference::ModelConfig& model_config, std::unique_ptr<TritonModel>* model)
 {
   model->reset();
 

--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -81,7 +81,8 @@ TritonModel::Create(
     InferenceServer* server, const std::string& model_repository_path,
     const BackendCmdlineConfigMap& backend_cmdline_config_map,
     const std::string& model_name, const int64_t version,
-    const inference::ModelConfig& model_config, std::unique_ptr<TritonModel>* model)
+    const inference::ModelConfig& model_config,
+    std::unique_ptr<TritonModel>* model)
 {
   model->reset();
 

--- a/src/backends/backend/triton_model.h
+++ b/src/backends/backend/triton_model.h
@@ -51,7 +51,8 @@ class TritonModel : public InferenceBackend {
       InferenceServer* server, const std::string& model_repository_path,
       const BackendCmdlineConfigMap& backend_cmdline_config_map,
       const std::string& model_name, const int64_t version,
-      const inference::ModelConfig& model_config, std::unique_ptr<TritonModel>* model);
+      const inference::ModelConfig& model_config,
+      std::unique_ptr<TritonModel>* model);
   ~TritonModel();
 
   const std::string& LocalizedModelPath() const

--- a/src/backends/backend/triton_model.h
+++ b/src/backends/backend/triton_model.h
@@ -51,7 +51,7 @@ class TritonModel : public InferenceBackend {
       InferenceServer* server, const std::string& model_repository_path,
       const BackendCmdlineConfigMap& backend_cmdline_config_map,
       const std::string& model_name, const int64_t version,
-      const ModelConfig& model_config, std::unique_ptr<TritonModel>* model);
+      const inference::ModelConfig& model_config, std::unique_ptr<TritonModel>* model);
   ~TritonModel();
 
   const std::string& LocalizedModelPath() const

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -53,16 +53,16 @@ TritonModelInstance::~TritonModelInstance()
 
 Status
 TritonModelInstance::CreateInstances(
-    TritonModel* model, const ModelConfig& model_config,
+    TritonModel* model, const inference::ModelConfig& model_config,
     std::vector<std::unique_ptr<TritonModelInstance>>* instances)
 {
   for (const auto& group : model_config.instance_group()) {
     for (int32_t c = 0; c < group.count(); ++c) {
-      if (group.kind() == ModelInstanceGroup::KIND_CPU) {
+      if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
         RETURN_IF_ERROR(CreateInstance(
             model, group.name(), c, TRITONSERVER_INSTANCEGROUPKIND_CPU,
             0 /* device_id */, instances));
-      } else if (group.kind() == ModelInstanceGroup::KIND_GPU) {
+      } else if (group.kind() == inference::ModelInstanceGroup::KIND_GPU) {
         for (const int32_t device_id : group.gpus()) {
           RETURN_IF_ERROR(CreateInstance(
               model, group.name(), c, TRITONSERVER_INSTANCEGROUPKIND_GPU,

--- a/src/backends/backend/triton_model_instance.h
+++ b/src/backends/backend/triton_model_instance.h
@@ -41,7 +41,7 @@ class TritonModel;
 class TritonModelInstance {
  public:
   static Status CreateInstances(
-      TritonModel* model, const ModelConfig& model_config,
+      TritonModel* model, const inference::ModelConfig& model_config,
       std::vector<std::unique_ptr<TritonModelInstance>>* instances);
   ~TritonModelInstance();
 

--- a/src/backends/caffe2/autofill.cc
+++ b/src/backends/caffe2/autofill.cc
@@ -35,11 +35,11 @@ namespace nvidia { namespace inferenceserver {
 class AutoFillNetDefImpl : public AutoFill {
  public:
   AutoFillNetDefImpl(const std::string& model_name) : AutoFill(model_name) {}
-  Status Fix(ModelConfig* config) override;
+  Status Fix(inference::ModelConfig* config) override;
 };
 
 Status
-AutoFillNetDefImpl::Fix(ModelConfig* config)
+AutoFillNetDefImpl::Fix(inference::ModelConfig* config)
 {
   config->set_platform(kCaffe2NetDefPlatform);
 

--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -240,17 +240,17 @@ NetDefBackend::CreateExecutionContext(
   // inputs are available in the model.
   if (Config().has_sequence_batching()) {
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, &input_names,
-        false /* required */));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
+        &input_names, false /* required */));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, &input_names,
-        false /* required */));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END,
+        &input_names, false /* required */));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, &input_names,
-        false /* required */));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY,
+        &input_names, false /* required */));
     RETURN_IF_ERROR(ValidateTypedSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, &input_names,
-        false /* required */));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID,
+        &input_names, false /* required */));
   }
 
   try {

--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -44,34 +44,34 @@ namespace {
 // Convert model datatype to non-protobuf equivalent datatype required
 // by Caffe2Workspace.
 Caffe2Workspace::DataType
-ConvertDataType(DataType dtype)
+ConvertDataType(inference::DataType dtype)
 {
   switch (dtype) {
-    case DataType::TYPE_INVALID:
+    case inference::DataType::TYPE_INVALID:
       return Caffe2Workspace::DataType::TYPE_INVALID;
-    case DataType::TYPE_BOOL:
+    case inference::DataType::TYPE_BOOL:
       return Caffe2Workspace::DataType::TYPE_BOOL;
-    case DataType::TYPE_UINT8:
+    case inference::DataType::TYPE_UINT8:
       return Caffe2Workspace::DataType::TYPE_UINT8;
-    case DataType::TYPE_UINT16:
+    case inference::DataType::TYPE_UINT16:
       return Caffe2Workspace::DataType::TYPE_UINT16;
-    case DataType::TYPE_UINT32:
+    case inference::DataType::TYPE_UINT32:
       return Caffe2Workspace::DataType::TYPE_UINT32;
-    case DataType::TYPE_UINT64:
+    case inference::DataType::TYPE_UINT64:
       return Caffe2Workspace::DataType::TYPE_UINT64;
-    case DataType::TYPE_INT8:
+    case inference::DataType::TYPE_INT8:
       return Caffe2Workspace::DataType::TYPE_INT8;
-    case DataType::TYPE_INT16:
+    case inference::DataType::TYPE_INT16:
       return Caffe2Workspace::DataType::TYPE_INT16;
-    case DataType::TYPE_INT32:
+    case inference::DataType::TYPE_INT32:
       return Caffe2Workspace::DataType::TYPE_INT32;
-    case DataType::TYPE_INT64:
+    case inference::DataType::TYPE_INT64:
       return Caffe2Workspace::DataType::TYPE_INT64;
-    case DataType::TYPE_FP16:
+    case inference::DataType::TYPE_FP16:
       return Caffe2Workspace::DataType::TYPE_FP16;
-    case DataType::TYPE_FP32:
+    case inference::DataType::TYPE_FP32:
       return Caffe2Workspace::DataType::TYPE_FP32;
-    case DataType::TYPE_FP64:
+    case inference::DataType::TYPE_FP64:
       return Caffe2Workspace::DataType::TYPE_FP64;
     default:
       break;
@@ -110,7 +110,7 @@ NetDefBackend::CreateExecutionContexts(
   // (across all instances?).
   for (const auto& group : Config().instance_group()) {
     for (int c = 0; c < group.count(); c++) {
-      if (group.kind() == ModelInstanceGroup::KIND_CPU) {
+      if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
         const std::string instance_name =
             group.name() + "_" + std::to_string(c) + "_cpu";
         RETURN_IF_ERROR(CreateExecutionContext(
@@ -240,16 +240,16 @@ NetDefBackend::CreateExecutionContext(
   // inputs are available in the model.
   if (Config().has_sequence_batching()) {
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, &input_names,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, &input_names,
         false /* required */));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, &input_names,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, &input_names,
         false /* required */));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, &input_names,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, &input_names,
         false /* required */));
     RETURN_IF_ERROR(ValidateTypedSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, &input_names,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, &input_names,
         false /* required */));
   }
 
@@ -281,7 +281,7 @@ NetDefBackend::CreateExecutionContext(
 
 Status
 NetDefBackend::ValidateBooleanSequenceControl(
-    const ModelSequenceBatching::Control::Kind control_kind,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
     std::vector<std::string>* input_names, bool required)
 {
   std::string tensor_name;
@@ -297,7 +297,7 @@ NetDefBackend::ValidateBooleanSequenceControl(
 
 Status
 NetDefBackend::ValidateTypedSequenceControl(
-    const ModelSequenceBatching::Control::Kind control_kind,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
     std::vector<std::string>* input_names, bool required)
 {
   std::string tensor_name;
@@ -313,7 +313,7 @@ NetDefBackend::ValidateTypedSequenceControl(
 
 Status
 NetDefBackend::Context::ValidateInputs(
-    const ::google::protobuf::RepeatedPtrField<ModelInput>& ios)
+    const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios)
 {
   for (const auto& io : ios) {
     // For now, skipping the check if potential names is empty
@@ -326,7 +326,7 @@ NetDefBackend::Context::ValidateInputs(
         Caffe2Workspace::DataType::TYPE_INVALID) {
       return Status(
           Status::Code::INTERNAL,
-          "unsupported datatype " + DataType_Name(io.data_type()) +
+          "unsupported datatype " + inference::DataType_Name(io.data_type()) +
               " for input '" + io.name() + "' for model '" + name_ + "'");
     }
   }
@@ -337,7 +337,7 @@ NetDefBackend::Context::ValidateInputs(
 
 Status
 NetDefBackend::Context::ValidateOutputs(
-    const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios)
+    const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios)
 {
   for (const auto& io : ios) {
     // For now, skipping the check if potential names is empty
@@ -350,7 +350,7 @@ NetDefBackend::Context::ValidateOutputs(
         Caffe2Workspace::DataType::TYPE_INVALID) {
       return Status(
           Status::Code::INTERNAL,
-          "unsupported datatype " + DataType_Name(io.data_type()) +
+          "unsupported datatype " + inference::DataType_Name(io.data_type()) +
               " for output '" + io.name() + "' for model '" + name_ + "'");
     }
   }
@@ -372,7 +372,7 @@ NetDefBackend::Context::ReadOutputTensors(
   for (const auto& output : base->Config().output()) {
     const std::string& name = output.name();
 
-    const ModelOutput* output_config;
+    const inference::ModelOutput* output_config;
     RETURN_IF_ERROR(base->GetOutput(name, &output_config));
 
     // Checked at initialization time to make sure that STRING is not
@@ -429,7 +429,7 @@ NetDefBackend::Context::SetInputTensors(
     }
     batchn_shape.insert(
         batchn_shape.end(), batch1_shape.begin(), batch1_shape.end());
-    const DataType datatype = repr_input->DType();
+    const inference::DataType datatype = repr_input->DType();
 
     // Checked at initialization time to make sure that STRING is not
     // being used for an input, so can just assume fixed-sized here.

--- a/src/backends/caffe2/netdef_backend.h
+++ b/src/backends/caffe2/netdef_backend.h
@@ -78,7 +78,8 @@ class NetDefBackend : public InferenceBackend {
     Status ValidateInputs(
         const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status ValidateOutputs(
-        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>&
+            ios);
 
     // Set input tensors from one or more requests.
     Status SetInputTensors(

--- a/src/backends/caffe2/netdef_backend.h
+++ b/src/backends/caffe2/netdef_backend.h
@@ -54,10 +54,10 @@ class NetDefBackend : public InferenceBackend {
 
  private:
   Status ValidateBooleanSequenceControl(
-      const ModelSequenceBatching::Control::Kind control_kind,
+      const inference::ModelSequenceBatching::Control::Kind control_kind,
       std::vector<std::string>* input_names, bool required);
   Status ValidateTypedSequenceControl(
-      const ModelSequenceBatching::Control::Kind control_kind,
+      const inference::ModelSequenceBatching::Control::Kind control_kind,
       std::vector<std::string>* input_names, bool required);
 
  private:
@@ -76,9 +76,9 @@ class NetDefBackend : public InferenceBackend {
     DISALLOW_COPY_AND_ASSIGN(Context);
 
     Status ValidateInputs(
-        const ::google::protobuf::RepeatedPtrField<ModelInput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status ValidateOutputs(
-        const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
 
     // Set input tensors from one or more requests.
     Status SetInputTensors(

--- a/src/backends/caffe2/netdef_backend_c2.cc
+++ b/src/backends/caffe2/netdef_backend_c2.cc
@@ -56,7 +56,8 @@ class Caffe2WorkspaceImpl : public Caffe2Workspace {
 
   Error SetInputTensor(
       const std::string& name, const std::vector<int64_t>& shape,
-      const inference::DataType dtype, const char* content, size_t byte_size) override;
+      const inference::DataType dtype, const char* content,
+      size_t byte_size) override;
   Error GetOutputTensor(
       const std::string& name, const Caffe2Workspace::DataType dtype,
       const char** content, size_t* byte_size,

--- a/src/backends/caffe2/netdef_backend_c2.cc
+++ b/src/backends/caffe2/netdef_backend_c2.cc
@@ -56,7 +56,7 @@ class Caffe2WorkspaceImpl : public Caffe2Workspace {
 
   Error SetInputTensor(
       const std::string& name, const std::vector<int64_t>& shape,
-      const DataType dtype, const char* content, size_t byte_size) override;
+      const inference::DataType dtype, const char* content, size_t byte_size) override;
   Error GetOutputTensor(
       const std::string& name, const Caffe2Workspace::DataType dtype,
       const char** content, size_t* byte_size,
@@ -118,51 +118,51 @@ ReadBinaryProto(
 std::pair<bool, const caffe2::TypeMeta>
 ConvertDatatype(Caffe2Workspace::DataType dtype)
 {
-  caffe2::TensorProto::DataType ctype;
+  caffe2::TensorProto::inference::DataType ctype;
 
   switch (dtype) {
     case Caffe2Workspace::DataType::TYPE_BOOL:
-      ctype = caffe2::TensorProto_DataType_BOOL;
+      ctype = caffe2::TensorProto_inference::DataType_BOOL;
       break;
     case Caffe2Workspace::DataType::TYPE_UINT8:
-      ctype = caffe2::TensorProto_DataType_UINT8;
+      ctype = caffe2::TensorProto_inference::DataType_UINT8;
       break;
     case Caffe2Workspace::DataType::TYPE_UINT16:
-      ctype = caffe2::TensorProto_DataType_UINT16;
+      ctype = caffe2::TensorProto_inference::DataType_UINT16;
       break;
     case Caffe2Workspace::DataType::TYPE_INT8:
-      ctype = caffe2::TensorProto_DataType_INT8;
+      ctype = caffe2::TensorProto_inference::DataType_INT8;
       break;
     case Caffe2Workspace::DataType::TYPE_INT16:
-      ctype = caffe2::TensorProto_DataType_INT16;
+      ctype = caffe2::TensorProto_inference::DataType_INT16;
       break;
     case Caffe2Workspace::DataType::TYPE_INT32:
-      ctype = caffe2::TensorProto_DataType_INT32;
+      ctype = caffe2::TensorProto_inference::DataType_INT32;
       break;
     case Caffe2Workspace::DataType::TYPE_INT64:
-      ctype = caffe2::TensorProto_DataType_INT64;
+      ctype = caffe2::TensorProto_inference::DataType_INT64;
       break;
     case Caffe2Workspace::DataType::TYPE_FP16:
-      ctype = caffe2::TensorProto_DataType_FLOAT16;
+      ctype = caffe2::TensorProto_inference::DataType_FLOAT16;
       break;
     case Caffe2Workspace::DataType::TYPE_FP32:
-      ctype = caffe2::TensorProto_DataType_FLOAT;
+      ctype = caffe2::TensorProto_inference::DataType_FLOAT;
       break;
     case Caffe2Workspace::DataType::TYPE_FP64:
-      ctype = caffe2::TensorProto_DataType_DOUBLE;
+      ctype = caffe2::TensorProto_inference::DataType_DOUBLE;
       break;
     case Caffe2Workspace::DataType::TYPE_STRING:
-      ctype = caffe2::TensorProto_DataType_STRING;
+      ctype = caffe2::TensorProto_inference::DataType_STRING;
       break;
     default:
       return std::make_pair(false, caffe2::TypeMeta());
   }
 
-  return std::make_pair(true, caffe2::DataTypeToTypeMeta(ctype));
+  return std::make_pair(true, caffe2::inference::DataTypeToTypeMeta(ctype));
 }
 
 const std::string
-DataTypeName(const Caffe2Workspace::DataType datatype)
+inference::DataTypeName(const Caffe2Workspace::DataType datatype)
 {
   switch (datatype) {
     case Caffe2Workspace::DataType::TYPE_INVALID:
@@ -450,7 +450,7 @@ Caffe2WorkspaceImpl::SetInputTensor(
   const auto pr = ConvertDatatype(dtype);
   if (!pr.first) {
     return Error(
-        "Failed to convert datatype '" + DataTypeName(dtype) +
+        "Failed to convert datatype '" + inference::DataTypeName(dtype) +
         "' to Caffe2 NetDef datatype");
   }
 
@@ -500,7 +500,7 @@ Caffe2WorkspaceImpl::GetOutputTensor(
   const auto pr = ConvertDatatype(dtype);
   if (!pr.first) {
     return Error(
-        "Failed to convert datatype '" + DataTypeName(dtype) +
+        "Failed to convert datatype '" + inference::DataTypeName(dtype) +
         "' to Caffe2 NetDef datatype");
   }
 

--- a/src/backends/caffe2/netdef_backend_factory.cc
+++ b/src/backends/caffe2/netdef_backend_factory.cc
@@ -52,7 +52,7 @@ NetDefBackendFactory::Create(
 
 Status
 NetDefBackendFactory::CreateBackend(
-    const std::string& path, const ModelConfig& model_config,
+    const std::string& path, const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/caffe2/netdef_backend_factory.h
+++ b/src/backends/caffe2/netdef_backend_factory.h
@@ -46,7 +46,7 @@ class NetDefBackendFactory {
       std::unique_ptr<NetDefBackendFactory>* factory);
 
   Status CreateBackend(
-      const std::string& path, const ModelConfig& model_config,
+      const std::string& path, const inference::ModelConfig& model_config,
       const double min_compute_capability,
       std::unique_ptr<InferenceBackend>* backend);
 

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -105,7 +105,7 @@ CustomBackend::Context::~Context()
 Status
 CustomBackend::Init(
     const std::string& path, const std::vector<std::string>& server_params,
-    const ModelConfig& config)
+    const inference::ModelConfig& config)
 {
   RETURN_IF_ERROR(InferenceBackend::Init(path, config, kCustomPlatform));
   server_params_ = server_params;
@@ -121,7 +121,7 @@ CustomBackend::CreateExecutionContexts(
   // Create the context for each instance.
   for (const auto& group : Config().instance_group()) {
     for (int c = 0; c < group.count(); c++) {
-      if (group.kind() == ModelInstanceGroup::KIND_CPU) {
+      if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
         const std::string instance_name =
             group.name() + "_" + std::to_string(c) + "_cpu";
         RETURN_IF_ERROR(CreateExecutionContext(

--- a/src/backends/custom/custom_backend.h
+++ b/src/backends/custom/custom_backend.h
@@ -46,7 +46,7 @@ class CustomBackend : public InferenceBackend {
 
   Status Init(
       const std::string& path, const std::vector<std::string>& server_params,
-      const ModelConfig& config);
+      const inference::ModelConfig& config);
 
   // Create a context for execution for each instance for the custom
   // 'models'.
@@ -172,7 +172,7 @@ class CustomBackend : public InferenceBackend {
     // V1/V2 API doesn't require the backend to indicate an output
     // datatype so we need to use the datatype from the model
     // configuration.
-    std::unordered_map<std::string, DataType> output_datatypes_;
+    std::unordered_map<std::string, inference::DataType> output_datatypes_;
 
     // The current device from last model execution. Use to ensure invariant
     // from custom backend's point of view.

--- a/src/backends/custom/custom_backend_factory.cc
+++ b/src/backends/custom/custom_backend_factory.cc
@@ -53,7 +53,7 @@ CustomBackendFactory::Create(
 Status
 CustomBackendFactory::CreateBackend(
     const std::string& model_repository_path, const std::string& model_name,
-    const int64_t version, const ModelConfig& model_config,
+    const int64_t version, const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/custom/custom_backend_factory.h
+++ b/src/backends/custom/custom_backend_factory.h
@@ -46,7 +46,7 @@ class CustomBackendFactory {
 
   Status CreateBackend(
       const std::string& model_repository_path, const std::string& model_name,
-      const int64_t version, const ModelConfig& model_config,
+      const int64_t version, const inference::ModelConfig& model_config,
       const double min_compute_capability,
       std::unique_ptr<InferenceBackend>* backend);
 

--- a/src/backends/ensemble/ensemble_backend.cc
+++ b/src/backends/ensemble/ensemble_backend.cc
@@ -37,7 +37,7 @@ namespace nvidia { namespace inferenceserver {
 Status
 EnsembleBackend::Init(
     InferenceServer* const server, const std::string& path,
-    const ModelConfig& config)
+    const inference::ModelConfig& config)
 {
   RETURN_IF_ERROR(InferenceBackend::Init(path, config, kEnsemblePlatform));
 

--- a/src/backends/ensemble/ensemble_backend.h
+++ b/src/backends/ensemble/ensemble_backend.h
@@ -44,7 +44,7 @@ class EnsembleBackend : public InferenceBackend {
 
   Status Init(
       InferenceServer* const server, const std::string& path,
-      const ModelConfig& config);
+      const inference::ModelConfig& config);
 
  private:
   // Override InferenceBackend::Run() to return proper error if

--- a/src/backends/ensemble/ensemble_backend_factory.cc
+++ b/src/backends/ensemble/ensemble_backend_factory.cc
@@ -54,7 +54,7 @@ EnsembleBackendFactory::Create(
 
 Status
 EnsembleBackendFactory::CreateBackend(
-    const std::string& path, const ModelConfig& model_config,
+    const std::string& path, const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/ensemble/ensemble_backend_factory.h
+++ b/src/backends/ensemble/ensemble_backend_factory.h
@@ -43,7 +43,7 @@ class EnsembleBackendFactory {
       std::unique_ptr<EnsembleBackendFactory>* factory);
 
   Status CreateBackend(
-      const std::string& path, const ModelConfig& model_config,
+      const std::string& path, const inference::ModelConfig& model_config,
       const double min_compute_capability,
       std::unique_ptr<InferenceBackend>* backend);
 

--- a/src/backends/onnx/autofill.cc
+++ b/src/backends/onnx/autofill.cc
@@ -47,7 +47,7 @@ SetIOConfig(
   config_io->set_name(name);
 
   // only set type and shape if they are not set
-  if (config_io->data_type() == DataType::TYPE_INVALID) {
+  if (config_io->data_type() == inference::DataType::TYPE_INVALID) {
     config_io->set_data_type(ConvertFromOnnxDataType(info.type_));
   }
 
@@ -74,7 +74,7 @@ ValidateIOInfoType(
   // Validate all tensors are in supported data type
   for (const auto& io_info : infos) {
     if (ConvertFromOnnxDataType(io_info.second.type_) ==
-        DataType::TYPE_INVALID) {
+        inference::DataType::TYPE_INVALID) {
       return Status(
           Status::Code::INTERNAL, "unable to autofill for '" + model_name +
                                       "', unsupported data-type '" +
@@ -95,14 +95,14 @@ class AutoFillOnnxImpl : public AutoFill {
   {
   }
 
-  Status Fix(ModelConfig* config) override;
+  Status Fix(inference::ModelConfig* config) override;
 
   Status SetConfigFromOrtSession(OrtSession* session, OrtAllocator* allocator);
 
  private:
-  Status FixBatchingSupport(ModelConfig* config);
-  Status FixInputConfig(ModelConfig* config);
-  Status FixOutputConfig(ModelConfig* config);
+  Status FixBatchingSupport(inference::ModelConfig* config);
+  Status FixInputConfig(inference::ModelConfig* config);
+  Status FixOutputConfig(inference::ModelConfig* config);
 
   Status SetBatchingSupport();
 
@@ -113,7 +113,7 @@ class AutoFillOnnxImpl : public AutoFill {
 };
 
 Status
-AutoFillOnnxImpl::Fix(ModelConfig* config)
+AutoFillOnnxImpl::Fix(inference::ModelConfig* config)
 {
   config->set_platform(kOnnxRuntimeOnnxPlatform);
 
@@ -141,7 +141,7 @@ AutoFillOnnxImpl::Fix(ModelConfig* config)
 }
 
 Status
-AutoFillOnnxImpl::FixBatchingSupport(ModelConfig* config)
+AutoFillOnnxImpl::FixBatchingSupport(inference::ModelConfig* config)
 {
   if (!model_support_batching_ && (config->max_batch_size() > 0)) {
     return Status(
@@ -214,12 +214,12 @@ AutoFillOnnxImpl::FixBatchingSupport(ModelConfig* config)
 }
 
 Status
-AutoFillOnnxImpl::FixInputConfig(ModelConfig* config)
+AutoFillOnnxImpl::FixInputConfig(inference::ModelConfig* config)
 {
   if (config->input_size() == 0) {
     // fill all corresponding i/o tensors
     for (const auto& io_info : input_infos_) {
-      ModelInput* config_io = config->add_input();
+      inference::ModelInput* config_io = config->add_input();
       SetIOConfig(
           io_info.first, io_info.second, model_support_batching_, config_io);
     }
@@ -235,12 +235,12 @@ AutoFillOnnxImpl::FixInputConfig(ModelConfig* config)
 }
 
 Status
-AutoFillOnnxImpl::FixOutputConfig(ModelConfig* config)
+AutoFillOnnxImpl::FixOutputConfig(inference::ModelConfig* config)
 {
   if (config->output_size() == 0) {
     // fill all corresponding i/o tensors
     for (const auto& io_info : output_infos_) {
-      ModelOutput* config_io = config->add_output();
+      inference::ModelOutput* config_io = config->add_output();
       SetIOConfig(
           io_info.first, io_info.second, model_support_batching_, config_io);
     }

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -362,9 +362,10 @@ OnnxBackend::CreateExecutionContext(
 
 Status
 OnnxBackend::Context::ValidateBooleanSequenceControl(
-    const std::string& model_name, const inference::ModelSequenceBatching& batcher,
-    const inference::ModelSequenceBatching::Control::Kind control_kind, bool required,
-    bool* have_control)
+    const std::string& model_name,
+    const inference::ModelSequenceBatching& batcher,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
+    bool required, bool* have_control)
 {
   std::string tensor_name;
   inference::DataType tensor_datatype;
@@ -414,9 +415,10 @@ OnnxBackend::Context::ValidateBooleanSequenceControl(
 
 Status
 OnnxBackend::Context::ValidateTypedSequenceControl(
-    const std::string& model_name, const inference::ModelSequenceBatching& batcher,
-    const inference::ModelSequenceBatching::Control::Kind control_kind, bool required,
-    bool* have_control)
+    const std::string& model_name,
+    const inference::ModelSequenceBatching& batcher,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
+    bool required, bool* have_control)
 {
   std::string tensor_name;
   inference::DataType tensor_datatype;
@@ -500,7 +502,8 @@ OnnxBackend::Context::ValidateInputs(
       return Status(
           Status::Code::INVALID_ARG,
           "unable to load model '" + model_name + ", unexpected datatype " +
-              inference::DataType_Name(ConvertFromOnnxDataType(iit->second.type_)) +
+              inference::DataType_Name(
+                  ConvertFromOnnxDataType(iit->second.type_)) +
               " for input '" + io.name() + "', expecting " +
               inference::DataType_Name(io.data_type()));
     }
@@ -544,7 +547,8 @@ OnnxBackend::Context::ValidateOutputs(
       return Status(
           Status::Code::INVALID_ARG,
           "unable to load model '" + model_name + ", unexpected datatype " +
-              inference::DataType_Name(ConvertFromOnnxDataType(iit->second.type_)) +
+              inference::DataType_Name(
+                  ConvertFromOnnxDataType(iit->second.type_)) +
               " for output '" + io.name() + "', expecting " +
               inference::DataType_Name(io.data_type()));
     }
@@ -1093,7 +1097,8 @@ OnnxBackend::Context::SetStringOutputBuffer(
       }
       InferenceResponse::Output* response_output = nullptr;
       response->AddOutput(
-          name, inference::DataType::TYPE_STRING, *batchn_shape, &response_output);
+          name, inference::DataType::TYPE_STRING, *batchn_shape,
+          &response_output);
       // Calculate expected byte size in advance using string offsets
       const size_t data_byte_size =
           offsets[element_idx + expected_element_cnt] - offsets[element_idx];

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -80,18 +80,18 @@ class OnnxBackend : public InferenceBackend {
 
     Status ValidateInputs(
         const std::string& model_name,
-        const ::google::protobuf::RepeatedPtrField<ModelInput>& ios,
+        const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios,
         const size_t expected_input_cnt);
     Status ValidateOutputs(
         const std::string& model_name,
-        const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
     Status ValidateBooleanSequenceControl(
-        const std::string& model_name, const ModelSequenceBatching& batcher,
-        const ModelSequenceBatching::Control::Kind control_kind, bool required,
+        const std::string& model_name, const inference::ModelSequenceBatching& batcher,
+        const inference::ModelSequenceBatching::Control::Kind control_kind, bool required,
         bool* have_control);
     Status ValidateTypedSequenceControl(
-        const std::string& model_name, const ModelSequenceBatching& batcher,
-        const ModelSequenceBatching::Control::Kind control_kind, bool required,
+        const std::string& model_name, const inference::ModelSequenceBatching& batcher,
+        const inference::ModelSequenceBatching::Control::Kind control_kind, bool required,
         bool* have_control);
 
     // See BackendContext::Run()

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -84,15 +84,18 @@ class OnnxBackend : public InferenceBackend {
         const size_t expected_input_cnt);
     Status ValidateOutputs(
         const std::string& model_name,
-        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>&
+            ios);
     Status ValidateBooleanSequenceControl(
-        const std::string& model_name, const inference::ModelSequenceBatching& batcher,
-        const inference::ModelSequenceBatching::Control::Kind control_kind, bool required,
-        bool* have_control);
+        const std::string& model_name,
+        const inference::ModelSequenceBatching& batcher,
+        const inference::ModelSequenceBatching::Control::Kind control_kind,
+        bool required, bool* have_control);
     Status ValidateTypedSequenceControl(
-        const std::string& model_name, const inference::ModelSequenceBatching& batcher,
-        const inference::ModelSequenceBatching::Control::Kind control_kind, bool required,
-        bool* have_control);
+        const std::string& model_name,
+        const inference::ModelSequenceBatching& batcher,
+        const inference::ModelSequenceBatching::Control::Kind control_kind,
+        bool required, bool* have_control);
 
     // See BackendContext::Run()
     void Run(

--- a/src/backends/onnx/onnx_backend_factory.cc
+++ b/src/backends/onnx/onnx_backend_factory.cc
@@ -64,7 +64,8 @@ OnnxBackendFactory::Create(
 
 Status
 OnnxBackendFactory::CreateBackend(
-    const std::string& nonlocal_path, const inference::ModelConfig& model_config,
+    const std::string& nonlocal_path,
+    const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/onnx/onnx_backend_factory.cc
+++ b/src/backends/onnx/onnx_backend_factory.cc
@@ -64,7 +64,7 @@ OnnxBackendFactory::Create(
 
 Status
 OnnxBackendFactory::CreateBackend(
-    const std::string& nonlocal_path, const ModelConfig& model_config,
+    const std::string& nonlocal_path, const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/onnx/onnx_backend_factory.h
+++ b/src/backends/onnx/onnx_backend_factory.h
@@ -48,7 +48,7 @@ class OnnxBackendFactory {
       std::unique_ptr<OnnxBackendFactory>* factory);
 
   Status CreateBackend(
-      const std::string& path, const ModelConfig& model_config,
+      const std::string& path, const inference::ModelConfig& model_config,
       const double min_compute_capability,
       std::unique_ptr<InferenceBackend>* backend);
 

--- a/src/backends/onnx/onnx_utils.cc
+++ b/src/backends/onnx/onnx_utils.cc
@@ -203,38 +203,38 @@ OnnxDataTypeName(ONNXTensorElementDataType onnx_type)
   return "UNDEFINED";
 }
 
-DataType
+inference::DataType
 ConvertFromOnnxDataType(ONNXTensorElementDataType onnx_type)
 {
   switch (onnx_type) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
       // maps to c type float (4 bytes)
-      return TYPE_FP32;
+      return inference::DataType::TYPE_FP32;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-      return TYPE_UINT8;
+      return inference::DataType::TYPE_UINT8;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-      return TYPE_INT8;
+      return inference::DataType::TYPE_INT8;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
-      return TYPE_UINT16;
+      return inference::DataType::TYPE_UINT16;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
-      return TYPE_INT16;
+      return inference::DataType::TYPE_INT16;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
-      return TYPE_INT32;
+      return inference::DataType::TYPE_INT32;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-      return TYPE_INT64;
+      return inference::DataType::TYPE_INT64;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:
-      return TYPE_STRING;
+      return inference::DataType::TYPE_STRING;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
-      return TYPE_BOOL;
+      return inference::DataType::TYPE_BOOL;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
-      return TYPE_FP16;
+      return inference::DataType::TYPE_FP16;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
       // maps to c type double (8 bytes)
-      return TYPE_FP64;
+      return inference::DataType::TYPE_FP64;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
-      return TYPE_UINT32;
+      return inference::DataType::TYPE_UINT32;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
-      return TYPE_UINT64;
+      return inference::DataType::TYPE_UINT64;
     // The following types are not supported:
     // complex with float32 real and imaginary components
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
@@ -247,38 +247,38 @@ ConvertFromOnnxDataType(ONNXTensorElementDataType onnx_type)
       break;
   }
 
-  return TYPE_INVALID;
+  return inference::DataType::TYPE_INVALID;
 }
 
 ONNXTensorElementDataType
-ConvertToOnnxDataType(DataType data_type)
+ConvertToOnnxDataType(inference::DataType data_type)
 {
   switch (data_type) {
-    case TYPE_UINT8:
+    case inference::DataType::TYPE_UINT8:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
-    case TYPE_UINT16:
+    case inference::DataType::TYPE_UINT16:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
-    case TYPE_UINT32:
+    case inference::DataType::TYPE_UINT32:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32;
-    case TYPE_UINT64:
+    case inference::DataType::TYPE_UINT64:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64;
-    case TYPE_INT8:
+    case inference::DataType::TYPE_INT8:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
-    case TYPE_INT16:
+    case inference::DataType::TYPE_INT16:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
-    case TYPE_INT32:
+    case inference::DataType::TYPE_INT32:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
-    case TYPE_INT64:
+    case inference::DataType::TYPE_INT64:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
-    case TYPE_FP16:
+    case inference::DataType::TYPE_FP16:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
-    case TYPE_FP32:
+    case inference::DataType::TYPE_FP32:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
-    case TYPE_FP64:
+    case inference::DataType::TYPE_FP64:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
-    case TYPE_STRING:
+    case inference::DataType::TYPE_STRING:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING;
-    case TYPE_BOOL:
+    case inference::DataType::TYPE_BOOL:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
     default:
       break;

--- a/src/backends/onnx/onnx_utils.h
+++ b/src/backends/onnx/onnx_utils.h
@@ -77,7 +77,8 @@ using OnnxTensorInfoMap = std::unordered_map<std::string, OnnxTensorInfo>;
 
 std::string OnnxDataTypeName(ONNXTensorElementDataType onnx_type);
 
-inference::DataType ConvertFromOnnxDataType(ONNXTensorElementDataType onnx_type);
+inference::DataType ConvertFromOnnxDataType(
+    ONNXTensorElementDataType onnx_type);
 
 ONNXTensorElementDataType ConvertToOnnxDataType(inference::DataType data_type);
 

--- a/src/backends/onnx/onnx_utils.h
+++ b/src/backends/onnx/onnx_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -77,9 +77,9 @@ using OnnxTensorInfoMap = std::unordered_map<std::string, OnnxTensorInfo>;
 
 std::string OnnxDataTypeName(ONNXTensorElementDataType onnx_type);
 
-DataType ConvertFromOnnxDataType(ONNXTensorElementDataType onnx_type);
+inference::DataType ConvertFromOnnxDataType(ONNXTensorElementDataType onnx_type);
 
-ONNXTensorElementDataType ConvertToOnnxDataType(DataType data_type);
+ONNXTensorElementDataType ConvertToOnnxDataType(inference::DataType data_type);
 
 Status InputNames(OrtSession* session, std::set<std::string>& names);
 

--- a/src/backends/pytorch/autofill.cc
+++ b/src/backends/pytorch/autofill.cc
@@ -35,11 +35,11 @@ namespace nvidia { namespace inferenceserver {
 class AutoFillPyTorchImpl : public AutoFill {
  public:
   AutoFillPyTorchImpl(const std::string& model_name) : AutoFill(model_name) {}
-  Status Fix(ModelConfig* config) override;
+  Status Fix(inference::ModelConfig* config) override;
 };
 
 Status
-AutoFillPyTorchImpl::Fix(ModelConfig* config)
+AutoFillPyTorchImpl::Fix(inference::ModelConfig* config)
 {
   config->set_platform(kPyTorchLibTorchPlatform);
 

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -63,41 +63,41 @@ LibTorchBackend::Context::~Context()
 }
 
 std::pair<bool, torch::ScalarType>
-ConvertDataTypeToTorchType(const DataType& dtype)
+ConvertDataTypeToTorchType(const inference::DataType& dtype)
 {
   torch::ScalarType type = torch::kInt;
   switch (dtype) {
-    case TYPE_BOOL:
+    case inference::DataType::TYPE_BOOL:
       type = torch::kBool;
       break;
-    case TYPE_UINT8:
+    case inference::DataType::TYPE_UINT8:
       type = torch::kByte;
       break;
-    case TYPE_INT8:
+    case inference::DataType::TYPE_INT8:
       type = torch::kChar;
       break;
-    case TYPE_INT16:
+    case inference::DataType::TYPE_INT16:
       type = torch::kShort;
       break;
-    case TYPE_INT32:
+    case inference::DataType::TYPE_INT32:
       type = torch::kInt;
       break;
-    case TYPE_INT64:
+    case inference::DataType::TYPE_INT64:
       type = torch::kLong;
       break;
-    case TYPE_FP16:
+    case inference::DataType::TYPE_FP16:
       type = torch::kHalf;
       break;
-    case TYPE_FP32:
+    case inference::DataType::TYPE_FP32:
       type = torch::kFloat;
       break;
-    case TYPE_FP64:
+    case inference::DataType::TYPE_FP64:
       type = torch::kDouble;
       break;
-    case TYPE_UINT16:
-    case TYPE_UINT32:
-    case TYPE_UINT64:
-    case TYPE_STRING:
+    case inference::DataType::TYPE_UINT16:
+    case inference::DataType::TYPE_UINT32:
+    case inference::DataType::TYPE_UINT64:
+    case inference::DataType::TYPE_STRING:
     default:
       return std::make_pair(false, type);
   }
@@ -105,30 +105,30 @@ ConvertDataTypeToTorchType(const DataType& dtype)
   return std::make_pair(true, type);
 }
 
-DataType
+inference::DataType
 ConvertTorchTypeToDataType(const torch::ScalarType& ttype)
 {
   switch (ttype) {
     case torch::kBool:
-      return TYPE_BOOL;
+      return inference::DataType::TYPE_BOOL;
     case torch::kByte:
-      return TYPE_UINT8;
+      return inference::DataType::TYPE_UINT8;
     case torch::kChar:
-      return TYPE_INT8;
+      return inference::DataType::TYPE_INT8;
     case torch::kShort:
-      return TYPE_INT16;
+      return inference::DataType::TYPE_INT16;
     case torch::kInt:
-      return TYPE_INT32;
+      return inference::DataType::TYPE_INT32;
     case torch::kLong:
-      return TYPE_INT64;
+      return inference::DataType::TYPE_INT64;
     case torch::kHalf:
-      return TYPE_FP16;
+      return inference::DataType::TYPE_FP16;
     case torch::kFloat:
-      return TYPE_FP32;
+      return inference::DataType::TYPE_FP32;
     case torch::kDouble:
-      return TYPE_FP64;
+      return inference::DataType::TYPE_FP64;
     default:
-      return TYPE_FP32;
+      return inference::DataType::TYPE_FP32;
   }
 }
 
@@ -141,7 +141,7 @@ LibTorchBackend::CreateExecutionContexts(
   // Create a context for each instance.
   for (const auto& group : Config().instance_group()) {
     for (int c = 0; c < group.count(); c++) {
-      if (group.kind() == ModelInstanceGroup::KIND_CPU) {
+      if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
         const std::string instance_name =
             group.name() + "_" + std::to_string(c) + "_cpu";
         RETURN_IF_ERROR(CreateExecutionContext(
@@ -273,7 +273,7 @@ LibTorchBackend::CreateExecutionContext(
 
 Status
 LibTorchBackend::Context::ValidateInputs(
-    const ::google::protobuf::RepeatedPtrField<ModelInput>& ios)
+    const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios)
 {
   std::string deliminator = "__";
   int ip_index = 0;
@@ -283,7 +283,7 @@ LibTorchBackend::Context::ValidateInputs(
     if (!pr.first) {
       return Status(
           Status::Code::INTERNAL,
-          "unsupported datatype " + DataType_Name(io.data_type()) +
+          "unsupported datatype " + inference::DataType_Name(io.data_type()) +
               " for input '" + io.name() + "' for model '" + name_ + "'");
     } else {
       const std::string& name = io.name();
@@ -311,7 +311,7 @@ LibTorchBackend::Context::ValidateInputs(
 
 Status
 LibTorchBackend::Context::ValidateControlInputs(
-    const ModelSequenceBatching& batching)
+    const inference::ModelSequenceBatching& batching)
 {
   std::string deliminator = "__";
   int ip_index = 0;
@@ -341,7 +341,7 @@ LibTorchBackend::Context::ValidateControlInputs(
 
 Status
 LibTorchBackend::Context::ValidateOutputs(
-    const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios)
+    const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios)
 {
   std::string deliminator = "__";
   int op_index;
@@ -351,7 +351,7 @@ LibTorchBackend::Context::ValidateOutputs(
     if (!pr.first) {
       return Status(
           Status::Code::INTERNAL,
-          "unsupported datatype " + DataType_Name(io.data_type()) +
+          "unsupported datatype " + inference::DataType_Name(io.data_type()) +
               " for output '" + io.name() + "' for model '" + name_ + "'");
     } else {
       const std::string& name = io.name();
@@ -401,7 +401,7 @@ LibTorchBackend::Context::SetInputTensors(
     }
     batchn_shape.insert(
         batchn_shape.end(), batch1_shape.begin(), batch1_shape.end());
-    const DataType datatype = repr_input->DType();
+    const inference::DataType datatype = repr_input->DType();
 
     int ip_index = input_index_map_[input_name];
 
@@ -409,7 +409,7 @@ LibTorchBackend::Context::SetInputTensors(
     if (!torch_dtype.first) {
       return Status(
           Status::Code::INTERNAL, "Failed to convert DataType '" +
-                                      DataType_Name(datatype) +
+                                      inference::DataType_Name(datatype) +
                                       "' to Torch datatype");
     }
 
@@ -475,12 +475,12 @@ LibTorchBackend::Context::ReadOutputTensors(
     const std::string& name = output.name();
     int op_index = (*output_index_map)[name];
 
-    const ModelOutput* output_config;
+    const inference::ModelOutput* output_config;
     RETURN_IF_ERROR(base->GetOutput(name, &output_config));
 
     // Checked at initialization time to make sure that STRING is not
     // being used for an output, so can just assume fixed-sized here.
-    const DataType dtype = output_config->data_type();
+    const inference::DataType dtype = output_config->data_type();
 
     const char* output_buffer = nullptr;
     size_t byte_size = 0;
@@ -510,20 +510,20 @@ LibTorchBackend::Context::ReadOutputTensors(
 Status
 LibTorchBackend::Context::GetOutputTensor(
     std::vector<torch::Tensor>* outputs_, const int& op_index,
-    const std::string& name, const DataType dtype, const char** content,
+    const std::string& name, const inference::DataType dtype, const char** content,
     size_t* byte_size, std::vector<int64_t>* content_shape)
 {
   try {
     torch::Tensor output_flat = (*outputs_)[op_index].contiguous().flatten();
 
     // verify output datatype matches datatype from model config
-    DataType rec_dtype = ConvertTorchTypeToDataType(output_flat.scalar_type());
+    inference::DataType rec_dtype = ConvertTorchTypeToDataType(output_flat.scalar_type());
     if (dtype != rec_dtype) {
       return Status(
           Status::Code::INVALID_ARG,
-          "unexpected datatype " + DataType_Name(rec_dtype) +
+          "unexpected datatype " + inference::DataType_Name(rec_dtype) +
               " for inference output '" + name + "', expecting " +
-              DataType_Name(dtype));
+              inference::DataType_Name(dtype));
     }
 
     *byte_size = output_flat.nbytes();

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -510,14 +510,16 @@ LibTorchBackend::Context::ReadOutputTensors(
 Status
 LibTorchBackend::Context::GetOutputTensor(
     std::vector<torch::Tensor>* outputs_, const int& op_index,
-    const std::string& name, const inference::DataType dtype, const char** content,
-    size_t* byte_size, std::vector<int64_t>* content_shape)
+    const std::string& name, const inference::DataType dtype,
+    const char** content, size_t* byte_size,
+    std::vector<int64_t>* content_shape)
 {
   try {
     torch::Tensor output_flat = (*outputs_)[op_index].contiguous().flatten();
 
     // verify output datatype matches datatype from model config
-    inference::DataType rec_dtype = ConvertTorchTypeToDataType(output_flat.scalar_type());
+    inference::DataType rec_dtype =
+        ConvertTorchTypeToDataType(output_flat.scalar_type());
     if (dtype != rec_dtype) {
       return Status(
           Status::Code::INVALID_ARG,

--- a/src/backends/pytorch/libtorch_backend.h
+++ b/src/backends/pytorch/libtorch_backend.h
@@ -77,14 +77,14 @@ class LibTorchBackend : public InferenceBackend {
     DISALLOW_MOVE(Context);
 
     Status ValidateInputs(
-        const ::google::protobuf::RepeatedPtrField<ModelInput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status ValidateOutputs(
-        const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios);
-    Status ValidateControlInputs(const ModelSequenceBatching& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
+    Status ValidateControlInputs(const inference::ModelSequenceBatching& ios);
 
     // Set the meta data of an input from payloads.
     Status SetInputMetaData(
-        const std::string& name, const DataType datatype,
+        const std::string& name, const inference::DataType datatype,
         const std::vector<int64_t>& dims, InputMetaData* meta_data);
 
     // See BackendContext::Run()
@@ -115,7 +115,7 @@ class LibTorchBackend : public InferenceBackend {
 
     Status GetOutputTensor(
         std::vector<torch::Tensor>* outputs_, const int& op_index,
-        const std::string& name, const DataType dtype, const char** content,
+        const std::string& name, const inference::DataType dtype, const char** content,
         size_t* byte_size, std::vector<int64_t>* content_shape);
 
     Status Execute(

--- a/src/backends/pytorch/libtorch_backend.h
+++ b/src/backends/pytorch/libtorch_backend.h
@@ -79,7 +79,8 @@ class LibTorchBackend : public InferenceBackend {
     Status ValidateInputs(
         const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status ValidateOutputs(
-        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>&
+            ios);
     Status ValidateControlInputs(const inference::ModelSequenceBatching& ios);
 
     // Set the meta data of an input from payloads.
@@ -115,8 +116,9 @@ class LibTorchBackend : public InferenceBackend {
 
     Status GetOutputTensor(
         std::vector<torch::Tensor>* outputs_, const int& op_index,
-        const std::string& name, const inference::DataType dtype, const char** content,
-        size_t* byte_size, std::vector<int64_t>* content_shape);
+        const std::string& name, const inference::DataType dtype,
+        const char** content, size_t* byte_size,
+        std::vector<int64_t>* content_shape);
 
     Status Execute(
         std::vector<torch::jit::IValue>* inputs_,

--- a/src/backends/pytorch/libtorch_backend_factory.cc
+++ b/src/backends/pytorch/libtorch_backend_factory.cc
@@ -53,7 +53,7 @@ LibTorchBackendFactory::Create(
 
 Status
 LibTorchBackendFactory::CreateBackend(
-    const std::string& path, const ModelConfig& model_config,
+    const std::string& path, const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/pytorch/libtorch_backend_factory.h
+++ b/src/backends/pytorch/libtorch_backend_factory.h
@@ -46,7 +46,7 @@ class LibTorchBackendFactory {
       std::unique_ptr<LibTorchBackendFactory>* factory);
 
   Status CreateBackend(
-      const std::string& path, const ModelConfig& model_config,
+      const std::string& path, const inference::ModelConfig& model_config,
       const double min_compute_capability,
       std::unique_ptr<InferenceBackend>* backend);
 

--- a/src/backends/tensorflow/autofill.cc
+++ b/src/backends/tensorflow/autofill.cc
@@ -49,7 +49,7 @@ class AutoFillSavedModelImpl : public AutoFill {
   {
   }
 
-  Status Fix(ModelConfig* config) override;
+  Status Fix(inference::ModelConfig* config) override;
 
  private:
   template <class ModelIO>
@@ -59,7 +59,7 @@ class AutoFillSavedModelImpl : public AutoFill {
   Status FixIOConfig(
       const TRTISTF_IOList* reference_list, IOList<IO>* mutable_list);
 
-  Status FixBatchingSupport(ModelConfig* config);
+  Status FixBatchingSupport(inference::ModelConfig* config);
 
   const std::string savedmodel_dirname_;
   std::unique_ptr<TRTISTF_Model, decltype(&TRTISTF_ModelDelete)> trtistf_model_;
@@ -67,7 +67,7 @@ class AutoFillSavedModelImpl : public AutoFill {
 };
 
 Status
-AutoFillSavedModelImpl::Fix(ModelConfig* config)
+AutoFillSavedModelImpl::Fix(inference::ModelConfig* config)
 {
   config->set_platform(kTensorFlowSavedModelPlatform);
 
@@ -94,7 +94,7 @@ AutoFillSavedModelImpl::Fix(ModelConfig* config)
 }
 
 Status
-AutoFillSavedModelImpl::FixBatchingSupport(ModelConfig* config)
+AutoFillSavedModelImpl::FixBatchingSupport(inference::ModelConfig* config)
 {
   const TRTISTF_IOList* inputs = TRTISTF_ModelInputs(trtistf_model_.get());
   const TRTISTF_IOList* outputs = TRTISTF_ModelOutputs(trtistf_model_.get());
@@ -224,7 +224,7 @@ AutoFillSavedModelImpl::FixIOConfig(
     config_io->set_name(io->name_);
 
     // only set type and shape if they are not set
-    if (config_io->data_type() == DataType::TYPE_INVALID) {
+    if (config_io->data_type() == inference::DataType::TYPE_INVALID) {
       config_io->set_data_type(ConvertDataType(io->data_type_));
     }
     if (config_io->dims_size() == 0) {
@@ -333,11 +333,11 @@ AutoFillSavedModel::Create(
 class AutoFillGraphDefImpl : public AutoFill {
  public:
   AutoFillGraphDefImpl(const std::string& model_name) : AutoFill(model_name) {}
-  Status Fix(ModelConfig* config) override;
+  Status Fix(inference::ModelConfig* config) override;
 };
 
 Status
-AutoFillGraphDefImpl::Fix(ModelConfig* config)
+AutoFillGraphDefImpl::Fix(inference::ModelConfig* config)
 {
   config->set_platform(kTensorFlowGraphDefPlatform);
 

--- a/src/backends/tensorflow/base_backend.h
+++ b/src/backends/tensorflow/base_backend.h
@@ -46,7 +46,7 @@ class BaseBackend : public InferenceBackend {
   BaseBackend(BaseBackend&&) = default;
 
   Status Init(
-      const std::string& path, const ModelConfig& model_config,
+      const std::string& path, const inference::ModelConfig& model_config,
       const GraphDefBackendFactory::Config* backend_config,
       const std::string& platform);
 
@@ -79,9 +79,9 @@ class BaseBackend : public InferenceBackend {
     DISALLOW_COPY_AND_ASSIGN(Context);
 
     Status ValidateInputs(
-        const ::google::protobuf::RepeatedPtrField<ModelInput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status ValidateOutputs(
-        const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
 
     // See BackendContext::Run()
     void Run(

--- a/src/backends/tensorflow/base_backend.h
+++ b/src/backends/tensorflow/base_backend.h
@@ -81,7 +81,8 @@ class BaseBackend : public InferenceBackend {
     Status ValidateInputs(
         const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status ValidateOutputs(
-        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>&
+            ios);
 
     // See BackendContext::Run()
     void Run(

--- a/src/backends/tensorflow/graphdef_backend.cc
+++ b/src/backends/tensorflow/graphdef_backend.cc
@@ -83,17 +83,17 @@ GraphDefBackend::CreateTRTISTFModel(
   // inputs are present in the model
   if (Config().has_sequence_batching()) {
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, inputs,
-        false /* required */));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
+        inputs, false /* required */));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
         inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, inputs,
         false /* required */));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, inputs,
-        false /* required */));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY,
+        inputs, false /* required */));
     RETURN_IF_ERROR(ValidateTypedSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, inputs,
-        false /* required */));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID,
+        inputs, false /* required */));
   }
 
   for (const auto& io : Config().input()) {

--- a/src/backends/tensorflow/graphdef_backend.cc
+++ b/src/backends/tensorflow/graphdef_backend.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -83,16 +83,16 @@ GraphDefBackend::CreateTRTISTFModel(
   // inputs are present in the model
   if (Config().has_sequence_batching()) {
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, inputs,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, inputs,
         false /* required */));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, inputs,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, inputs,
         false /* required */));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, inputs,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, inputs,
         false /* required */));
     RETURN_IF_ERROR(ValidateTypedSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, inputs,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, inputs,
         false /* required */));
   }
 
@@ -108,7 +108,7 @@ GraphDefBackend::CreateTRTISTFModel(
 
 Status
 GraphDefBackend::ValidateBooleanSequenceControl(
-    const ModelSequenceBatching::Control::Kind control_kind,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
     const TRTISTF_IOList* inputs, bool required)
 {
   std::string tensor_name;
@@ -130,7 +130,7 @@ GraphDefBackend::ValidateBooleanSequenceControl(
 
 Status
 GraphDefBackend::ValidateTypedSequenceControl(
-    const ModelSequenceBatching::Control::Kind control_kind,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
     const TRTISTF_IOList* inputs, bool required)
 {
   std::string tensor_name;

--- a/src/backends/tensorflow/graphdef_backend.h
+++ b/src/backends/tensorflow/graphdef_backend.h
@@ -50,10 +50,10 @@ class GraphDefBackend : public BaseBackend {
   DISALLOW_COPY_AND_ASSIGN(GraphDefBackend);
 
   Status ValidateBooleanSequenceControl(
-      const ModelSequenceBatching::Control::Kind control_kind,
+      const inference::ModelSequenceBatching::Control::Kind control_kind,
       const TRTISTF_IOList* inputs, bool required);
   Status ValidateTypedSequenceControl(
-      const ModelSequenceBatching::Control::Kind control_kind,
+      const inference::ModelSequenceBatching::Control::Kind control_kind,
       const TRTISTF_IOList* inputs, bool required);
 };
 

--- a/src/backends/tensorflow/graphdef_backend_factory.cc
+++ b/src/backends/tensorflow/graphdef_backend_factory.cc
@@ -59,7 +59,8 @@ GraphDefBackendFactory::Create(
 
 Status
 GraphDefBackendFactory::CreateBackend(
-    const std::string& nonlocal_path, const inference::ModelConfig& model_config,
+    const std::string& nonlocal_path,
+    const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/tensorflow/graphdef_backend_factory.cc
+++ b/src/backends/tensorflow/graphdef_backend_factory.cc
@@ -59,7 +59,7 @@ GraphDefBackendFactory::Create(
 
 Status
 GraphDefBackendFactory::CreateBackend(
-    const std::string& nonlocal_path, const ModelConfig& model_config,
+    const std::string& nonlocal_path, const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/tensorflow/graphdef_backend_factory.h
+++ b/src/backends/tensorflow/graphdef_backend_factory.h
@@ -53,7 +53,7 @@ class GraphDefBackendFactory {
       std::unique_ptr<GraphDefBackendFactory>* factory);
 
   Status CreateBackend(
-      const std::string& path, const ModelConfig& model_config,
+      const std::string& path, const inference::ModelConfig& model_config,
       const double min_compute_capability,
       std::unique_ptr<InferenceBackend>* backend);
 

--- a/src/backends/tensorflow/savedmodel_backend.cc
+++ b/src/backends/tensorflow/savedmodel_backend.cc
@@ -80,16 +80,16 @@ SavedModelBackend::CreateTRTISTFModel(
   if (Config().has_sequence_batching()) {
     bool have_start, have_end, have_ready, have_corrid;
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, inputs,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, inputs,
         false /* required */, &have_start));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, inputs,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, inputs,
         false /* required */, &have_end));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, inputs,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, inputs,
         false /* required */, &have_ready));
     RETURN_IF_ERROR(ValidateTypedSequenceControl(
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, inputs,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, inputs,
         false /* required */, &have_corrid));
     if (have_start) {
       expected_input_cnt += 1;
@@ -153,9 +153,9 @@ SavedModelBackend::CreateTRTISTFModel(
           Status::Code::INVALID_ARG,
           "unable to load model '" + Name() + "', input '" + io.name() +
               "' data-type " +
-              DataType_Name(ConvertDataType(input->data_type_)) +
+              inference::DataType_Name(ConvertDataType(input->data_type_)) +
               " doesn't match configuration data-type " +
-              DataType_Name(io.data_type()));
+              inference::DataType_Name(io.data_type()));
     }
   }
 
@@ -196,9 +196,9 @@ SavedModelBackend::CreateTRTISTFModel(
           Status::Code::INVALID_ARG,
           "unable to load model '" + Name() + "', output '" + io.name() +
               "' data-type " +
-              DataType_Name(ConvertDataType(output->data_type_)) +
+              inference::DataType_Name(ConvertDataType(output->data_type_)) +
               " doesn't match configuration data-type " +
-              DataType_Name(io.data_type()));
+              inference::DataType_Name(io.data_type()));
     }
   }
 
@@ -207,11 +207,11 @@ SavedModelBackend::CreateTRTISTFModel(
 
 Status
 SavedModelBackend::ValidateBooleanSequenceControl(
-    const ModelSequenceBatching::Control::Kind control_kind,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
     const TRTISTF_IOList* inputs, bool required, bool* have_control)
 {
   std::string tensor_name;
-  DataType tensor_datatype;
+  inference::DataType tensor_datatype;
   RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
       Config().sequence_batching(), Name(), control_kind, required,
       &tensor_name, &tensor_datatype, nullptr, nullptr, nullptr, nullptr));
@@ -244,9 +244,9 @@ SavedModelBackend::ValidateBooleanSequenceControl(
           Status::Code::INVALID_ARG,
           "unable to load model '" + Name() + "', sequence control '" +
               tensor_name + "': the model expects data-type " +
-              DataType_Name(ConvertDataType(input->data_type_)) +
+              inference::DataType_Name(ConvertDataType(input->data_type_)) +
               " but the model configuration specifies data-type " +
-              DataType_Name(tensor_datatype));
+              inference::DataType_Name(tensor_datatype));
     }
   }
 
@@ -255,11 +255,11 @@ SavedModelBackend::ValidateBooleanSequenceControl(
 
 Status
 SavedModelBackend::ValidateTypedSequenceControl(
-    const ModelSequenceBatching::Control::Kind control_kind,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
     const TRTISTF_IOList* inputs, bool required, bool* have_control)
 {
   std::string tensor_name;
-  DataType tensor_datatype;
+  inference::DataType tensor_datatype;
   RETURN_IF_ERROR(GetTypedSequenceControlProperties(
       Config().sequence_batching(), Name(), control_kind, required,
       &tensor_name, &tensor_datatype));
@@ -292,9 +292,9 @@ SavedModelBackend::ValidateTypedSequenceControl(
           Status::Code::INVALID_ARG,
           "unable to load model '" + Name() + "', sequence control '" +
               tensor_name + "', the model expects data-type " +
-              DataType_Name(ConvertDataType(input->data_type_)) +
+              inference::DataType_Name(ConvertDataType(input->data_type_)) +
               " but the model configuration specifies data-type " +
-              DataType_Name(tensor_datatype));
+              inference::DataType_Name(tensor_datatype));
     }
   }
 

--- a/src/backends/tensorflow/savedmodel_backend.cc
+++ b/src/backends/tensorflow/savedmodel_backend.cc
@@ -80,17 +80,17 @@ SavedModelBackend::CreateTRTISTFModel(
   if (Config().has_sequence_batching()) {
     bool have_start, have_end, have_ready, have_corrid;
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START, inputs,
-        false /* required */, &have_start));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
+        inputs, false /* required */, &have_start));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
         inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END, inputs,
         false /* required */, &have_end));
     RETURN_IF_ERROR(ValidateBooleanSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY, inputs,
-        false /* required */, &have_ready));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY,
+        inputs, false /* required */, &have_ready));
     RETURN_IF_ERROR(ValidateTypedSequenceControl(
-        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID, inputs,
-        false /* required */, &have_corrid));
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID,
+        inputs, false /* required */, &have_corrid));
     if (have_start) {
       expected_input_cnt += 1;
     }

--- a/src/backends/tensorflow/savedmodel_backend.h
+++ b/src/backends/tensorflow/savedmodel_backend.h
@@ -48,10 +48,10 @@ class SavedModelBackend : public BaseBackend {
 
  private:
   Status ValidateBooleanSequenceControl(
-      const ModelSequenceBatching::Control::Kind control_kind,
+      const inference::ModelSequenceBatching::Control::Kind control_kind,
       const TRTISTF_IOList* inputs, bool required, bool* have_control);
   Status ValidateTypedSequenceControl(
-      const ModelSequenceBatching::Control::Kind control_kind,
+      const inference::ModelSequenceBatching::Control::Kind control_kind,
       const TRTISTF_IOList* inputs, bool required, bool* have_control);
 
   DISALLOW_COPY_AND_ASSIGN(SavedModelBackend);

--- a/src/backends/tensorflow/savedmodel_backend_factory.cc
+++ b/src/backends/tensorflow/savedmodel_backend_factory.cc
@@ -59,7 +59,7 @@ SavedModelBackendFactory::Create(
 
 Status
 SavedModelBackendFactory::CreateBackend(
-    const std::string& nonlocal_path, const ModelConfig& model_config,
+    const std::string& nonlocal_path, const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/tensorflow/savedmodel_backend_factory.cc
+++ b/src/backends/tensorflow/savedmodel_backend_factory.cc
@@ -59,7 +59,8 @@ SavedModelBackendFactory::Create(
 
 Status
 SavedModelBackendFactory::CreateBackend(
-    const std::string& nonlocal_path, const inference::ModelConfig& model_config,
+    const std::string& nonlocal_path,
+    const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/tensorflow/savedmodel_backend_factory.h
+++ b/src/backends/tensorflow/savedmodel_backend_factory.h
@@ -39,7 +39,7 @@ class SavedModelBackendFactory {
       std::unique_ptr<SavedModelBackendFactory>* factory);
 
   Status CreateBackend(
-      const std::string& path, const ModelConfig& model_config,
+      const std::string& path, const inference::ModelConfig& model_config,
       const double min_compute_capability,
       std::unique_ptr<InferenceBackend>* backend);
 

--- a/src/backends/tensorflow/tf_utils.cc
+++ b/src/backends/tensorflow/tf_utils.cc
@@ -132,86 +132,86 @@ ShapeToString(const TRTISTF_Shape* shape, const size_t start_idx)
 }
 
 bool
-CompareDataType(TRTISTF_DataType model_dtype, DataType dtype)
+CompareDataType(TRTISTF_DataType model_dtype, inference::DataType dtype)
 {
-  DataType cdtype = ConvertDataType(model_dtype);
-  if (cdtype == DataType::TYPE_INVALID) {
+  inference::DataType cdtype = ConvertDataType(model_dtype);
+  if (cdtype == inference::DataType::TYPE_INVALID) {
     return false;
   }
 
   return dtype == cdtype;
 }
 
-DataType
+inference::DataType
 ConvertDataType(TRTISTF_DataType dtype)
 {
   switch (dtype) {
     case TRTISTF_DataType::TRTISTF_TYPE_INVALID:
-      return DataType::TYPE_INVALID;
+      return inference::DataType::TYPE_INVALID;
     case TRTISTF_DataType::TRTISTF_TYPE_BOOL:
-      return DataType::TYPE_BOOL;
+      return inference::DataType::TYPE_BOOL;
     case TRTISTF_DataType::TRTISTF_TYPE_UINT8:
-      return DataType::TYPE_UINT8;
+      return inference::DataType::TYPE_UINT8;
     case TRTISTF_DataType::TRTISTF_TYPE_UINT16:
-      return DataType::TYPE_UINT16;
+      return inference::DataType::TYPE_UINT16;
     case TRTISTF_DataType::TRTISTF_TYPE_UINT32:
-      return DataType::TYPE_UINT32;
+      return inference::DataType::TYPE_UINT32;
     case TRTISTF_DataType::TRTISTF_TYPE_UINT64:
-      return DataType::TYPE_UINT64;
+      return inference::DataType::TYPE_UINT64;
     case TRTISTF_DataType::TRTISTF_TYPE_INT8:
-      return DataType::TYPE_INT8;
+      return inference::DataType::TYPE_INT8;
     case TRTISTF_DataType::TRTISTF_TYPE_INT16:
-      return DataType::TYPE_INT16;
+      return inference::DataType::TYPE_INT16;
     case TRTISTF_DataType::TRTISTF_TYPE_INT32:
-      return DataType::TYPE_INT32;
+      return inference::DataType::TYPE_INT32;
     case TRTISTF_DataType::TRTISTF_TYPE_INT64:
-      return DataType::TYPE_INT64;
+      return inference::DataType::TYPE_INT64;
     case TRTISTF_DataType::TRTISTF_TYPE_FP16:
-      return DataType::TYPE_FP16;
+      return inference::DataType::TYPE_FP16;
     case TRTISTF_DataType::TRTISTF_TYPE_FP32:
-      return DataType::TYPE_FP32;
+      return inference::DataType::TYPE_FP32;
     case TRTISTF_DataType::TRTISTF_TYPE_FP64:
-      return DataType::TYPE_FP64;
+      return inference::DataType::TYPE_FP64;
     case TRTISTF_DataType::TRTISTF_TYPE_STRING:
-      return DataType::TYPE_STRING;
+      return inference::DataType::TYPE_STRING;
     default:
       break;
   }
 
-  return DataType::TYPE_INVALID;
+  return inference::DataType::TYPE_INVALID;
 }
 
 TRTISTF_DataType
-ConvertDataType(DataType dtype)
+ConvertDataType(inference::DataType dtype)
 {
   switch (dtype) {
-    case DataType::TYPE_INVALID:
+    case inference::DataType::TYPE_INVALID:
       return TRTISTF_DataType::TRTISTF_TYPE_INVALID;
-    case DataType::TYPE_BOOL:
+    case inference::DataType::TYPE_BOOL:
       return TRTISTF_DataType::TRTISTF_TYPE_BOOL;
-    case DataType::TYPE_UINT8:
+    case inference::DataType::TYPE_UINT8:
       return TRTISTF_DataType::TRTISTF_TYPE_UINT8;
-    case DataType::TYPE_UINT16:
+    case inference::DataType::TYPE_UINT16:
       return TRTISTF_DataType::TRTISTF_TYPE_UINT16;
-    case DataType::TYPE_UINT32:
+    case inference::DataType::TYPE_UINT32:
       return TRTISTF_DataType::TRTISTF_TYPE_UINT32;
-    case DataType::TYPE_UINT64:
+    case inference::DataType::TYPE_UINT64:
       return TRTISTF_DataType::TRTISTF_TYPE_UINT64;
-    case DataType::TYPE_INT8:
+    case inference::DataType::TYPE_INT8:
       return TRTISTF_DataType::TRTISTF_TYPE_INT8;
-    case DataType::TYPE_INT16:
+    case inference::DataType::TYPE_INT16:
       return TRTISTF_DataType::TRTISTF_TYPE_INT16;
-    case DataType::TYPE_INT32:
+    case inference::DataType::TYPE_INT32:
       return TRTISTF_DataType::TRTISTF_TYPE_INT32;
-    case DataType::TYPE_INT64:
+    case inference::DataType::TYPE_INT64:
       return TRTISTF_DataType::TRTISTF_TYPE_INT64;
-    case DataType::TYPE_FP16:
+    case inference::DataType::TYPE_FP16:
       return TRTISTF_DataType::TRTISTF_TYPE_FP16;
-    case DataType::TYPE_FP32:
+    case inference::DataType::TYPE_FP32:
       return TRTISTF_DataType::TRTISTF_TYPE_FP32;
-    case DataType::TYPE_FP64:
+    case inference::DataType::TYPE_FP64:
       return TRTISTF_DataType::TRTISTF_TYPE_FP64;
-    case DataType::TYPE_STRING:
+    case inference::DataType::TYPE_STRING:
       return TRTISTF_DataType::TRTISTF_TYPE_STRING;
     default:
       break;

--- a/src/backends/tensorflow/tf_utils.h
+++ b/src/backends/tensorflow/tf_utils.h
@@ -60,15 +60,15 @@ std::string ShapeToString(
 
 /// \return true if a TF data-type matches a model configuration
 /// data-type.
-bool CompareDataType(TRTISTF_DataType model_dtype, DataType dtype);
+bool CompareDataType(TRTISTF_DataType model_dtype, inference::DataType dtype);
 
 /// \return the model configuration data-type that corresponds to a
 /// TRTISTF data-type.
-DataType ConvertDataType(TRTISTF_DataType dtype);
+inference::DataType ConvertDataType(TRTISTF_DataType dtype);
 
 /// \return the TRTISTF data-type corresponding to a model
 /// configuration data-type.
-TRTISTF_DataType ConvertDataType(DataType dtype);
+TRTISTF_DataType ConvertDataType(inference::DataType dtype);
 
 // If TRTISTF Error is non-OK, return the equivalent TRTIS status.
 #define RETURN_IF_TRTISTF_ERROR(TFWS)                              \

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -229,7 +229,7 @@ PlanBackend::CreateExecutionContexts(
   // access to the same GPU.
   for (const auto& group : Config().instance_group()) {
     // TensorRT requires that every context have a GPU.
-    if ((group.kind() != ModelInstanceGroup::KIND_GPU) ||
+    if ((group.kind() != inference::ModelInstanceGroup::KIND_GPU) ||
         (group.gpus().size() == 0)) {
       return Status(
           Status::Code::INVALID_ARG,
@@ -655,14 +655,14 @@ PlanBackend::CreateExecutionContext(
 
 Status
 PlanBackend::Context::ValidateInputs(
-    const ::google::protobuf::RepeatedPtrField<ModelInput>& ios,
+    const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios,
     const std::set<std::string>& allowed_shape_tensors)
 {
   for (const auto& io : ios) {
     if (!ConvertDataTypeToTrtType(io.data_type()).first) {
       return Status(
           Status::Code::INTERNAL,
-          "unsupported datatype " + DataType_Name(io.data_type()) +
+          "unsupported datatype " + inference::DataType_Name(io.data_type()) +
               " for input '" + io.name() + "' for model '" + name_ + "'");
     }
 
@@ -692,14 +692,14 @@ PlanBackend::Context::ValidateInputs(
 
 Status
 PlanBackend::Context::ValidateOutputs(
-    const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios,
+    const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios,
     const std::set<std::string>& allowed_shape_tensors)
 {
   for (const auto& io : ios) {
     if (!ConvertDataTypeToTrtType(io.data_type()).first) {
       return Status(
           Status::Code::INTERNAL,
-          "unsupported datatype " + DataType_Name(io.data_type()) +
+          "unsupported datatype " + inference::DataType_Name(io.data_type()) +
               " for output '" + io.name() + "' for model '" + name_ + "'");
     }
 
@@ -728,7 +728,7 @@ PlanBackend::Context::ValidateOutputs(
 
 Status
 PlanBackend::Context::InitializeShapeInputBinding(
-    const std::string& input_name, const DataType input_datatype,
+    const std::string& input_name, const inference::DataType input_datatype,
     const DimsList& model_config_dims)
 {
   // the maximum byte sizes across all profiles
@@ -766,22 +766,22 @@ PlanBackend::Context::InitializeShapeInputBinding(
     // The presence of shape binding indicates the dynamic model plan
     is_dynamic_ = true;
 
-    if (input_datatype != TYPE_INT32) {
+    if (input_datatype != inference::DataType::TYPE_INT32) {
       return Status(
           Status::Code::INVALID_ARG,
-          "unexpected datatype " + DataType_Name(input_datatype) +
+          "unexpected datatype " + inference::DataType_Name(input_datatype) +
               "  in model configuration for shape input '" + input_name +
-              "', expecting " + DataType_Name(TYPE_INT32) + " for " + name_);
+              "', expecting " + inference::DataType_Name(inference::DataType::TYPE_INT32) + " for " + name_);
     }
 
-    DataType dt =
+    inference::DataType dt =
         ConvertTrtTypeToDataType(engine_->getBindingDataType(binding_index));
     if (dt != input_datatype) {
       return Status(
           Status::Code::INVALID_ARG,
-          "unexpected datatype " + DataType_Name(dt) +
+          "unexpected datatype " + inference::DataType_Name(dt) +
               " in engine for shape input '" + input_name + "', expecting " +
-              DataType_Name(input_datatype) + " for " + name_);
+              inference::DataType_Name(input_datatype) + " for " + name_);
     }
 
     MemoryFormat fmt =
@@ -871,7 +871,7 @@ PlanBackend::Context::InitializeShapeInputBinding(
 
 Status
 PlanBackend::Context::InitializeExecuteInputBinding(
-    const std::string& input_name, const DataType input_datatype,
+    const std::string& input_name, const inference::DataType input_datatype,
     const DimsList& model_config_dims, const bool is_control)
 {
   // the maximum byte sizes across all profiles
@@ -906,13 +906,13 @@ PlanBackend::Context::InitializeExecuteInputBinding(
               "' is expected to be an output in model for " + name_);
     }
 
-    DataType dt =
+    inference::DataType dt =
         ConvertTrtTypeToDataType(engine_->getBindingDataType(binding_index));
     if (dt != input_datatype) {
       return Status(
           Status::Code::INVALID_ARG,
-          "unexpected datatype " + DataType_Name(dt) + " for input '" +
-              input_name + "', expecting " + DataType_Name(input_datatype) +
+          "unexpected datatype " + inference::DataType_Name(dt) + " for input '" +
+              input_name + "', expecting " + inference::DataType_Name(input_datatype) +
               " for " + name_);
     }
 
@@ -1035,20 +1035,20 @@ PlanBackend::Context::InitializeExecuteInputBinding(
 
 Status
 PlanBackend::Context::InitializeSequenceControlInputBindings(
-    const ModelConfig& config)
+    const inference::ModelConfig& config)
 {
   if (config.has_sequence_batching()) {
-    std::vector<ModelSequenceBatching::Control::Kind> boolean_kinds{
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_END,
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY};
+    std::vector<inference::ModelSequenceBatching::Control::Kind> boolean_kinds{
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY};
 
-    for (const ModelSequenceBatching::Control::Kind control_kind :
+    for (const inference::ModelSequenceBatching::Control::Kind control_kind :
          boolean_kinds) {
       const bool required = false;
 
       std::string tensor_name;
-      DataType tensor_datatype;
+      inference::DataType tensor_datatype;
       RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
           config.sequence_batching(), config.name(), control_kind, required,
           &tensor_name, &tensor_datatype, nullptr, nullptr, nullptr, nullptr));
@@ -1062,15 +1062,15 @@ PlanBackend::Context::InitializeSequenceControlInputBindings(
       }
     }
 
-    std::vector<ModelSequenceBatching::Control::Kind> typdef_kinds{
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID};
+    std::vector<inference::ModelSequenceBatching::Control::Kind> typdef_kinds{
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID};
 
-    for (const ModelSequenceBatching::Control::Kind control_kind :
+    for (const inference::ModelSequenceBatching::Control::Kind control_kind :
          typdef_kinds) {
       const bool required = false;
 
       std::string tensor_name;
-      DataType tensor_datatype;
+      inference::DataType tensor_datatype;
       RETURN_IF_ERROR(GetTypedSequenceControlProperties(
           config.sequence_batching(), config.name(), control_kind, required,
           &tensor_name, &tensor_datatype));
@@ -1090,7 +1090,7 @@ PlanBackend::Context::InitializeSequenceControlInputBindings(
 
 Status
 PlanBackend::Context::InitializeConfigShapeInputBindings(
-    const ::google::protobuf::RepeatedPtrField<ModelInput>& ios)
+    const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios)
 {
   for (const auto& io : ios) {
     const DimsList& model_config_dims =
@@ -1104,7 +1104,7 @@ PlanBackend::Context::InitializeConfigShapeInputBindings(
 
 Status
 PlanBackend::Context::InitializeConfigExecuteInputBindings(
-    const ::google::protobuf::RepeatedPtrField<ModelInput>& ios)
+    const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios)
 {
   for (const auto& io : ios) {
     const DimsList& model_config_dims =
@@ -1118,7 +1118,7 @@ PlanBackend::Context::InitializeConfigExecuteInputBindings(
 
 Status
 PlanBackend::Context::InitializeConfigShapeOutputBindings(
-    const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios)
+    const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios)
 {
   for (const auto& io : ios) {
     // the maximum byte sizes across all profiles
@@ -1155,22 +1155,22 @@ PlanBackend::Context::InitializeConfigShapeOutputBindings(
                 "' is expected to be an input in model for " + name_);
       }
 
-      if (io.data_type() != TYPE_INT32) {
+      if (io.data_type() != inference::DataType::TYPE_INT32) {
         return Status(
             Status::Code::INVALID_ARG,
-            "unexpected datatype " + DataType_Name(io.data_type()) +
+            "unexpected datatype " + inference::DataType_Name(io.data_type()) +
                 "  in model configuration for shape output '" + io.name() +
-                "', expecting " + DataType_Name(TYPE_INT32) + " for " + name_);
+                "', expecting " + inference::DataType_Name(inference::DataType::TYPE_INT32) + " for " + name_);
       }
 
-      DataType dt =
+      inference::DataType dt =
           ConvertTrtTypeToDataType(engine_->getBindingDataType(binding_index));
       if (dt != io.data_type()) {
         return Status(
             Status::Code::INVALID_ARG,
-            "unexpected datatype " + DataType_Name(dt) +
+            "unexpected datatype " + inference::DataType_Name(dt) +
                 " for inference output '" + io.name() + "', expecting " +
-                DataType_Name(io.data_type()) + " for " + name_);
+                inference::DataType_Name(io.data_type()) + " for " + name_);
       }
 
       MemoryFormat fmt =
@@ -1233,7 +1233,7 @@ PlanBackend::Context::InitializeConfigShapeOutputBindings(
 
 Status
 PlanBackend::Context::InitializeConfigExecuteOutputBindings(
-    const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios)
+    const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios)
 {
   for (const auto& io : ios) {
     // the maximum byte sizes across all profiles
@@ -1267,14 +1267,14 @@ PlanBackend::Context::InitializeConfigExecuteOutputBindings(
                 "' is expected to be an input in model for " + name_);
       }
 
-      DataType dt =
+      inference::DataType dt =
           ConvertTrtTypeToDataType(engine_->getBindingDataType(binding_index));
       if (dt != io.data_type()) {
         return Status(
             Status::Code::INVALID_ARG,
-            "unexpected datatype " + DataType_Name(dt) +
+            "unexpected datatype " + inference::DataType_Name(dt) +
                 " for inference output '" + io.name() + "', expecting " +
-                DataType_Name(io.data_type()) + " for " + name_);
+                inference::DataType_Name(io.data_type()) + " for " + name_);
       }
 
       MemoryFormat fmt =
@@ -1809,7 +1809,7 @@ PlanBackend::Context::Run(
     }
     batchn_shape.insert(
         batchn_shape.end(), batch1_shape.begin(), batch1_shape.end());
-    const DataType datatype = repr_input->DType();
+    const inference::DataType datatype = repr_input->DType();
 
     const size_t total_byte_size = GetByteSize(datatype, batchn_shape);
 
@@ -2039,7 +2039,7 @@ PlanBackend::Context::Run(
 
           const size_t tensor_element_cnt = GetElementCount(batchn_shape);
 
-          DataType dt = ConvertTrtTypeToDataType(
+          inference::DataType dt = ConvertTrtTypeToDataType(
               engine_->getBindingDataType(binding_offset + bindex));
 
           // Only need an response tensor for requested outputs.
@@ -2067,7 +2067,7 @@ PlanBackend::Context::Run(
         batchn_shape.push_back(dims.d[i]);
       }
 
-      DataType dt = ConvertTrtTypeToDataType(
+      inference::DataType dt = ConvertTrtTypeToDataType(
           engine_->getBindingDataType(binding_offset + bindex));
 
       size_t batch1_byte_size = GetByteSize(dt, batchn_shape);
@@ -2273,7 +2273,7 @@ PlanBackend::Context::GetRequestShapeValues(
       // Shape tensors datatype is INT32.
       const int64_t element_cnt = GetElementCount(batch1_shape);
       const size_t expected_byte_size =
-          element_cnt * GetDataTypeByteSize(DataType::TYPE_INT32);
+          element_cnt * GetDataTypeByteSize(inference::DataType::TYPE_INT32);
 
       if (expected_byte_size != data_byte_size) {
         return Status(

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -771,7 +771,9 @@ PlanBackend::Context::InitializeShapeInputBinding(
           Status::Code::INVALID_ARG,
           "unexpected datatype " + inference::DataType_Name(input_datatype) +
               "  in model configuration for shape input '" + input_name +
-              "', expecting " + inference::DataType_Name(inference::DataType::TYPE_INT32) + " for " + name_);
+              "', expecting " +
+              inference::DataType_Name(inference::DataType::TYPE_INT32) +
+              " for " + name_);
     }
 
     inference::DataType dt =
@@ -911,9 +913,9 @@ PlanBackend::Context::InitializeExecuteInputBinding(
     if (dt != input_datatype) {
       return Status(
           Status::Code::INVALID_ARG,
-          "unexpected datatype " + inference::DataType_Name(dt) + " for input '" +
-              input_name + "', expecting " + inference::DataType_Name(input_datatype) +
-              " for " + name_);
+          "unexpected datatype " + inference::DataType_Name(dt) +
+              " for input '" + input_name + "', expecting " +
+              inference::DataType_Name(input_datatype) + " for " + name_);
     }
 
     MemoryFormat fmt =
@@ -1160,7 +1162,9 @@ PlanBackend::Context::InitializeConfigShapeOutputBindings(
             Status::Code::INVALID_ARG,
             "unexpected datatype " + inference::DataType_Name(io.data_type()) +
                 "  in model configuration for shape output '" + io.name() +
-                "', expecting " + inference::DataType_Name(inference::DataType::TYPE_INT32) + " for " + name_);
+                "', expecting " +
+                inference::DataType_Name(inference::DataType::TYPE_INT32) +
+                " for " + name_);
       }
 
       inference::DataType dt =

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -86,27 +86,27 @@ class PlanBackend : public InferenceBackend {
     struct TensorRTContext;
 
     Status ValidateInputs(
-        const ::google::protobuf::RepeatedPtrField<ModelInput>& ios,
+        const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios,
         const std::set<std::string>& allowed_shape_tensors);
     Status ValidateOutputs(
-        const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios,
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios,
         const std::set<std::string>& allowed_shape_tensors);
 
     Status InitializeExecuteInputBinding(
-        const std::string& input_name, const DataType input_datatype,
+        const std::string& input_name, const inference::DataType input_datatype,
         const DimsList& input_dims, const bool is_control = false);
     Status InitializeShapeInputBinding(
-        const std::string& input_name, const DataType input_datatype,
+        const std::string& input_name, const inference::DataType input_datatype,
         const DimsList& input_dims);
-    Status InitializeSequenceControlInputBindings(const ModelConfig& config);
+    Status InitializeSequenceControlInputBindings(const inference::ModelConfig& config);
     Status InitializeConfigExecuteInputBindings(
-        const ::google::protobuf::RepeatedPtrField<ModelInput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status InitializeConfigShapeInputBindings(
-        const ::google::protobuf::RepeatedPtrField<ModelInput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status InitializeConfigExecuteOutputBindings(
-        const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
     Status InitializeConfigShapeOutputBindings(
-        const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
     bool BuildCudaGraph(TensorRTContext* trt_context, const int batch_size);
 
     Status InitOptimizationProfiles(

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -98,15 +98,18 @@ class PlanBackend : public InferenceBackend {
     Status InitializeShapeInputBinding(
         const std::string& input_name, const inference::DataType input_datatype,
         const DimsList& input_dims);
-    Status InitializeSequenceControlInputBindings(const inference::ModelConfig& config);
+    Status InitializeSequenceControlInputBindings(
+        const inference::ModelConfig& config);
     Status InitializeConfigExecuteInputBindings(
         const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status InitializeConfigShapeInputBindings(
         const ::google::protobuf::RepeatedPtrField<inference::ModelInput>& ios);
     Status InitializeConfigExecuteOutputBindings(
-        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>&
+            ios);
     Status InitializeConfigShapeOutputBindings(
-        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>& ios);
+        const ::google::protobuf::RepeatedPtrField<inference::ModelOutput>&
+            ios);
     bool BuildCudaGraph(TensorRTContext* trt_context, const int batch_size);
 
     Status InitOptimizationProfiles(

--- a/src/backends/tensorrt/plan_backend_factory.cc
+++ b/src/backends/tensorrt/plan_backend_factory.cc
@@ -68,7 +68,7 @@ PlanBackendFactory::Create(
 
 Status
 PlanBackendFactory::CreateBackend(
-    const std::string& path, const ModelConfig& model_config,
+    const std::string& path, const inference::ModelConfig& model_config,
     const double min_compute_capability,
     std::unique_ptr<InferenceBackend>* backend)
 {

--- a/src/backends/tensorrt/plan_backend_factory.h
+++ b/src/backends/tensorrt/plan_backend_factory.h
@@ -45,7 +45,7 @@ class PlanBackendFactory {
       std::unique_ptr<PlanBackendFactory>* factory);
 
   Status CreateBackend(
-      const std::string& path, const ModelConfig& model_config,
+      const std::string& path, const inference::ModelConfig& model_config,
       const double min_compute_capability,
       std::unique_ptr<InferenceBackend>* backend);
 

--- a/src/backends/tensorrt/plan_utils.cc
+++ b/src/backends/tensorrt/plan_utils.cc
@@ -28,23 +28,23 @@
 
 namespace nvidia { namespace inferenceserver {
 
-DataType
+inference::DataType
 ConvertTrtTypeToDataType(nvinfer1::DataType trt_type)
 {
   switch (trt_type) {
     case nvinfer1::DataType::kFLOAT:
-      return TYPE_FP32;
+      return inference::DataType::TYPE_FP32;
     case nvinfer1::DataType::kHALF:
-      return TYPE_FP16;
+      return inference::DataType::TYPE_FP16;
     case nvinfer1::DataType::kINT8:
-      return TYPE_INT8;
+      return inference::DataType::TYPE_INT8;
     case nvinfer1::DataType::kINT32:
-      return TYPE_INT32;
+      return inference::DataType::TYPE_INT32;
     case nvinfer1::DataType::kBOOL:
-      return TYPE_BOOL;
+      return inference::DataType::TYPE_BOOL;
   }
 
-  return TYPE_INVALID;
+  return inference::DataType::TYPE_INVALID;
 }
 
 MemoryFormat
@@ -92,23 +92,23 @@ MemoryFormat_Name(MemoryFormat fmt)
 }
 
 std::pair<bool, nvinfer1::DataType>
-ConvertDataTypeToTrtType(const DataType& dtype)
+ConvertDataTypeToTrtType(const inference::DataType& dtype)
 {
   nvinfer1::DataType trt_type = nvinfer1::DataType::kFLOAT;
   switch (dtype) {
-    case TYPE_FP32:
+    case inference::DataType::TYPE_FP32:
       trt_type = nvinfer1::DataType::kFLOAT;
       break;
-    case TYPE_FP16:
+    case inference::DataType::TYPE_FP16:
       trt_type = nvinfer1::DataType::kHALF;
       break;
-    case TYPE_INT8:
+    case inference::DataType::TYPE_INT8:
       trt_type = nvinfer1::DataType::kINT8;
       break;
-    case TYPE_INT32:
+    case inference::DataType::TYPE_INT32:
       trt_type = nvinfer1::DataType::kINT32;
       break;
-    case TYPE_BOOL:
+    case inference::DataType::TYPE_BOOL:
       trt_type = nvinfer1::DataType::kBOOL;
       break;
     default:

--- a/src/backends/tensorrt/plan_utils.h
+++ b/src/backends/tensorrt/plan_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -54,10 +54,10 @@ MemoryFormat ConvertTrtFmtToFmt(nvinfer1::TensorFormat trt_fmt);
 
 const std::string MemoryFormat_Name(MemoryFormat fmt);
 
-DataType ConvertTrtTypeToDataType(nvinfer1::DataType trt_type);
+inference::DataType ConvertTrtTypeToDataType(nvinfer1::DataType trt_type);
 
 std::pair<bool, nvinfer1::DataType> ConvertDataTypeToTrtType(
-    const DataType& dtype);
+    const inference::DataType& dtype);
 
 bool CompareDims(const nvinfer1::Dims& model_dims, const DimsList& dims);
 

--- a/src/clients/c++/examples/ensemble_image_client.cc
+++ b/src/clients/c++/examples/ensemble_image_client.cc
@@ -298,7 +298,7 @@ main(int argc, char** argv)
       batch_size = bs_itr->value.GetInt();
     }
   } else {
-    ni::ModelConfigResponse model_config;
+    inference::ModelConfigResponse model_config;
     err = triton_client.grpc_client_->ModelConfig(&model_config, model_name);
     if (!err.IsOk()) {
       std::cerr << "error: failed to get model config: " << err << std::endl;

--- a/src/clients/c++/examples/image_client.cc
+++ b/src/clients/c++/examples/image_client.cc
@@ -409,8 +409,8 @@ ParseType(const std::string& dtype, int* type1, int* type3)
 
 void
 ParseModelGrpc(
-    const ni::ModelMetadataResponse& model_metadata,
-    const ni::ModelConfigResponse& model_config, const size_t batch_size,
+    const inference::ModelMetadataResponse& model_metadata,
+    const inference::ModelConfigResponse& model_config, const size_t batch_size,
     ModelInfo* model_info)
 {
   if (model_metadata.inputs().size() != 1) {
@@ -495,14 +495,14 @@ ParseModelGrpc(
     exit(1);
   }
 
-  if ((input_config.format() != ni::ModelInput::FORMAT_NCHW) &&
-      (input_config.format() != ni::ModelInput::FORMAT_NHWC)) {
+  if ((input_config.format() != inference::ModelInput::FORMAT_NCHW) &&
+      (input_config.format() != inference::ModelInput::FORMAT_NHWC)) {
     std::cerr << "unexpected input format "
-              << ni::ModelInput_Format_Name(input_config.format())
+              << inference::ModelInput_Format_Name(input_config.format())
               << ", expecting "
-              << ni::ModelInput_Format_Name(ni::ModelInput::FORMAT_NHWC)
+              << inference::ModelInput_Format_Name(inference::ModelInput::FORMAT_NHWC)
               << " or "
-              << ni::ModelInput_Format_Name(ni::ModelInput::FORMAT_NCHW)
+              << inference::ModelInput_Format_Name(inference::ModelInput::FORMAT_NCHW)
               << std::endl;
     exit(1);
   }
@@ -511,7 +511,7 @@ ParseModelGrpc(
   model_info->input_name_ = input_metadata.name();
   model_info->input_datatype_ = input_metadata.datatype();
 
-  if (input_config.format() == ni::ModelInput::FORMAT_NHWC) {
+  if (input_config.format() == inference::ModelInput::FORMAT_NHWC) {
     model_info->input_format_ = "FORMAT_NHWC";
     model_info->input_h_ = input_metadata.shape(input_batch_dim ? 1 : 0);
     model_info->input_w_ = input_metadata.shape(input_batch_dim ? 2 : 1);
@@ -889,13 +889,13 @@ main(int argc, char** argv)
     ParseModelHttp(
         model_metadata_json, model_config_json, batch_size, &model_info);
   } else {
-    ni::ModelMetadataResponse model_metadata;
+    inference::ModelMetadataResponse model_metadata;
     err = triton_client.grpc_client_->ModelMetadata(
         &model_metadata, model_name, model_version, http_headers);
     if (!err.IsOk()) {
       std::cerr << "error: failed to get model metadata: " << err << std::endl;
     }
-    ni::ModelConfigResponse model_config;
+    inference::ModelConfigResponse model_config;
     err = triton_client.grpc_client_->ModelConfig(
         &model_config, model_name, model_version, http_headers);
     if (!err.IsOk()) {

--- a/src/clients/c++/examples/image_client.cc
+++ b/src/clients/c++/examples/image_client.cc
@@ -497,13 +497,14 @@ ParseModelGrpc(
 
   if ((input_config.format() != inference::ModelInput::FORMAT_NCHW) &&
       (input_config.format() != inference::ModelInput::FORMAT_NHWC)) {
-    std::cerr << "unexpected input format "
-              << inference::ModelInput_Format_Name(input_config.format())
-              << ", expecting "
-              << inference::ModelInput_Format_Name(inference::ModelInput::FORMAT_NHWC)
-              << " or "
-              << inference::ModelInput_Format_Name(inference::ModelInput::FORMAT_NCHW)
-              << std::endl;
+    std::cerr
+        << "unexpected input format "
+        << inference::ModelInput_Format_Name(input_config.format())
+        << ", expecting "
+        << inference::ModelInput_Format_Name(inference::ModelInput::FORMAT_NHWC)
+        << " or "
+        << inference::ModelInput_Format_Name(inference::ModelInput::FORMAT_NCHW)
+        << std::endl;
     exit(1);
   }
 

--- a/src/clients/c++/examples/simple_grpc_cudashm_client.cc
+++ b/src/clients/c++/examples/simple_grpc_cudashm_client.cc
@@ -300,7 +300,7 @@ main(int argc, char** argv)
   }
 
   // Get shared memory regions active/registered within triton
-  ni::CudaSharedMemoryStatusResponse status;
+  inference::CudaSharedMemoryStatusResponse status;
   FAIL_IF_ERR(
       client->CudaSharedMemoryStatus(&status),
       "failed to get shared memory status");

--- a/src/clients/c++/examples/simple_grpc_health_metadata.cc
+++ b/src/clients/c++/examples/simple_grpc_health_metadata.cc
@@ -135,7 +135,7 @@ main(int argc, char** argv)
     exit(1);
   }
 
-  ni::ServerMetadataResponse server_metadata;
+  inference::ServerMetadataResponse server_metadata;
   FAIL_IF_ERR(
       client->ServerMetadata(&server_metadata, http_headers),
       "unable to get server metadata");
@@ -145,7 +145,7 @@ main(int argc, char** argv)
     exit(1);
   }
 
-  ni::ModelMetadataResponse model_metadata;
+  inference::ModelMetadataResponse model_metadata;
   FAIL_IF_ERR(
       client->ModelMetadata(
           &model_metadata, model_name, model_version, http_headers),
@@ -156,7 +156,7 @@ main(int argc, char** argv)
     exit(1);
   }
 
-  ni::ModelConfigResponse model_config;
+  inference::ModelConfigResponse model_config;
   FAIL_IF_ERR(
       client->ModelConfig(
           &model_config, model_name, model_version, http_headers),

--- a/src/clients/c++/examples/simple_grpc_infer_client.cc
+++ b/src/clients/c++/examples/simple_grpc_infer_client.cc
@@ -306,7 +306,7 @@ main(int argc, char** argv)
   std::cout << "cumulative_receive_time_ns "
             << infer_stat.cumulative_receive_time_ns << std::endl;
 
-  ni::ModelStatisticsResponse model_stat;
+  inference::ModelStatisticsResponse model_stat;
   client->ModelInferenceStatistics(&model_stat, model_name);
   std::cout << "======Model Statistics======" << std::endl;
   std::cout << model_stat.DebugString() << std::endl;

--- a/src/clients/c++/examples/simple_grpc_model_control.cc
+++ b/src/clients/c++/examples/simple_grpc_model_control.cc
@@ -102,7 +102,7 @@ main(int argc, char** argv)
       nic::InferenceServerGrpcClient::Create(&client, url, verbose),
       "unable to create grpc client");
 
-  ni::RepositoryIndexResponse repository_index;
+  inference::RepositoryIndexResponse repository_index;
   FAIL_IF_ERR(
       client->ModelRepositoryIndex(&repository_index, http_headers),
       "Failed to get repository index");

--- a/src/clients/c++/examples/simple_grpc_shm_client.cc
+++ b/src/clients/c++/examples/simple_grpc_shm_client.cc
@@ -274,7 +274,7 @@ main(int argc, char** argv)
   }
 
   // Get shared memory regions active/registered within triton
-  ni::SystemSharedMemoryStatusResponse status;
+  inference::SystemSharedMemoryStatusResponse status;
   FAIL_IF_ERR(
       client->SystemSharedMemoryStatus(&status),
       "failed to get shared memory status");

--- a/src/clients/c++/library/grpc_client.h
+++ b/src/clients/c++/library/grpc_client.h
@@ -124,7 +124,7 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \return Error object indicating success or failure of the request.
   Error ServerMetadata(
-      ServerMetadataResponse* server_metadata,
+      inference::ServerMetadataResponse* server_metadata,
       const Headers& headers = Headers());
 
   /// Contact the inference server and get the metadata of specified model.
@@ -138,8 +138,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \return Error object indicating success or failure of the request.
   Error ModelMetadata(
-      ModelMetadataResponse* model_metadata, const std::string& model_name,
-      const std::string& model_version = "",
+      inference::ModelMetadataResponse* model_metadata,
+      const std::string& model_name, const std::string& model_version = "",
       const Headers& headers = Headers());
 
   /// Contact the inference server and get the configuration of specified model.
@@ -153,8 +153,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \return Error object indicating success or failure of the request.
   Error ModelConfig(
-      ModelConfigResponse* model_config, const std::string& model_name,
-      const std::string& model_version = "",
+      inference::ModelConfigResponse* model_config,
+      const std::string& model_name, const std::string& model_version = "",
       const Headers& headers = Headers());
 
   /// Contact the inference server and get the index of model repository
@@ -165,7 +165,7 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \return Error object indicating success or failure of the request.
   Error ModelRepositoryIndex(
-      RepositoryIndexResponse* repository_index,
+      inference::RepositoryIndexResponse* repository_index,
       const Headers& headers = Headers());
 
   /// Request the inference server to load or reload specified model.
@@ -198,8 +198,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \return Error object indicating success or failure of the request.
   Error ModelInferenceStatistics(
-      ModelStatisticsResponse* infer_stat, const std::string& model_name = "",
-      const std::string& model_version = "",
+      inference::ModelStatisticsResponse* infer_stat,
+      const std::string& model_name = "", const std::string& model_version = "",
       const Headers& headers = Headers());
 
   /// Contact the inference server and get the status for requested system
@@ -213,7 +213,7 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \return Error object indicating success or failure of the request.
   Error SystemSharedMemoryStatus(
-      SystemSharedMemoryStatusResponse* status,
+      inference::SystemSharedMemoryStatusResponse* status,
       const std::string& region_name = "", const Headers& headers = Headers());
 
   /// Request the server to register a system shared memory with the provided
@@ -253,7 +253,7 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// in the metadata of gRPC request.
   /// \return Error object indicating success or failure of the request.
   Error CudaSharedMemoryStatus(
-      CudaSharedMemoryStatusResponse* status,
+      inference::CudaSharedMemoryStatusResponse* status,
       const std::string& region_name = "", const Headers& headers = Headers());
 
   /// Request the server to register a CUDA shared memory with the provided
@@ -380,8 +380,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   // Required to support the grpc bi-directional streaming API.
   InferenceServerClient::OnCompleteFn stream_callback_;
   std::thread stream_worker_;
-  std::shared_ptr<
-      grpc::ClientReaderWriter<ModelInferRequest, ModelStreamInferResponse>>
+  std::shared_ptr<grpc::ClientReaderWriter<
+      inference::ModelInferRequest, inference::ModelStreamInferResponse>>
       grpc_stream_;
   grpc::ClientContext grpc_context_;
 
@@ -390,10 +390,10 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   std::mutex stream_mutex_;
 
   // GRPC end point.
-  std::unique_ptr<GRPCInferenceService::Stub> stub_;
+  std::unique_ptr<inference::GRPCInferenceService::Stub> stub_;
   // request for GRPC call, one request object can be used for multiple calls
   // since it can be overwritten as soon as the GRPC send finishes.
-  ModelInferRequest infer_request_;
+  inference::ModelInferRequest infer_request_;
 };
 
 

--- a/src/clients/c++/perf_client/inference_profiler.cc
+++ b/src/clients/c++/perf_client/inference_profiler.cc
@@ -711,7 +711,7 @@ InferenceProfiler::SummarizeClientStat(
   summary.client_stats.delayed_request_count = delayed_request_count;
   summary.client_stats.duration_ns = duration_ns;
   float client_duration_sec =
-      (float)summary.client_stats.duration_ns / ni::NANOS_PER_SECOND;
+      (float)summary.client_stats.duration_ns / inference::NANOS_PER_SECOND;
   summary.client_stats.sequence_per_sec =
       valid_sequence_count / client_duration_sec;
   summary.client_stats.infer_per_sec =

--- a/src/clients/c++/perf_client/inference_profiler.cc
+++ b/src/clients/c++/perf_client/inference_profiler.cc
@@ -710,8 +710,8 @@ InferenceProfiler::SummarizeClientStat(
   summary.client_stats.sequence_count = valid_sequence_count;
   summary.client_stats.delayed_request_count = delayed_request_count;
   summary.client_stats.duration_ns = duration_ns;
-  float client_duration_sec =
-      (float)summary.client_stats.duration_ns / inference::NANOS_PER_SECOND;
+  float client_duration_sec = (float)summary.client_stats.duration_ns /
+                              nvidia::inferenceserver::NANOS_PER_SECOND;
   summary.client_stats.sequence_per_sec =
       valid_sequence_count / client_duration_sec;
   summary.client_stats.infer_per_sec =

--- a/src/clients/c++/perf_client/model_parser.cc
+++ b/src/clients/c++/perf_client/model_parser.cc
@@ -28,7 +28,7 @@
 
 nic::Error
 ModelParser::Init(
-    const ni::ModelMetadataResponse& metadata, const ni::ModelConfig& config,
+    const inference::ModelMetadataResponse& metadata, const inference::ModelConfig& config,
     const std::string& model_version,
     const std::unordered_map<std::string, std::vector<int64_t>>& input_shapes,
     std::unique_ptr<TritonClientWrapper>& client_wrapper)
@@ -129,7 +129,7 @@ ModelParser::Init(
 
 nic::Error
 ModelParser::GetEnsembleSchedulerType(
-    const ni::ModelConfig& config, const std::string& model_version,
+    const inference::ModelConfig& config, const std::string& model_version,
     std::unique_ptr<TritonClientWrapper>& client_wrapper, bool* is_sequential)
 {
   if (config.has_sequence_batching()) {
@@ -138,7 +138,7 @@ ModelParser::GetEnsembleSchedulerType(
 
   if (config.platform() == "ensemble") {
     for (const auto& step : config.ensemble_scheduling().step()) {
-      ni::ModelConfigResponse model_config;
+      inference::ModelConfigResponse model_config;
       std::string step_version;
       if (step.model_version() != -1) {
         step_version = std::to_string(step.model_version());

--- a/src/clients/c++/perf_client/model_parser.cc
+++ b/src/clients/c++/perf_client/model_parser.cc
@@ -28,8 +28,8 @@
 
 nic::Error
 ModelParser::Init(
-    const inference::ModelMetadataResponse& metadata, const inference::ModelConfig& config,
-    const std::string& model_version,
+    const inference::ModelMetadataResponse& metadata,
+    const inference::ModelConfig& config, const std::string& model_version,
     const std::unordered_map<std::string, std::vector<int64_t>>& input_shapes,
     std::unique_ptr<TritonClientWrapper>& client_wrapper)
 {

--- a/src/clients/c++/perf_client/model_parser.h
+++ b/src/clients/c++/perf_client/model_parser.h
@@ -74,7 +74,7 @@ class ModelParser {
   /// \param client_wrapper The wrapped triton client object.
   /// \return Error object indicating success or failure.
   nic::Error Init(
-      const ni::ModelMetadataResponse& metadata, const ni::ModelConfig& config,
+      const inference::ModelMetadataResponse& metadata, const inference::ModelConfig& config,
       const std::string& model_version,
       const std::unordered_map<std::string, std::vector<int64_t>>& input_shapes,
       std::unique_ptr<TritonClientWrapper>& client_wrapper);
@@ -135,7 +135,7 @@ class ModelParser {
 
  private:
   nic::Error GetEnsembleSchedulerType(
-      const ni::ModelConfig& config, const std::string& model_version,
+      const inference::ModelConfig& config, const std::string& model_version,
       std::unique_ptr<TritonClientWrapper>& client_wrapper,
       bool* is_sequential);
 

--- a/src/clients/c++/perf_client/model_parser.h
+++ b/src/clients/c++/perf_client/model_parser.h
@@ -74,8 +74,8 @@ class ModelParser {
   /// \param client_wrapper The wrapped triton client object.
   /// \return Error object indicating success or failure.
   nic::Error Init(
-      const inference::ModelMetadataResponse& metadata, const inference::ModelConfig& config,
-      const std::string& model_version,
+      const inference::ModelMetadataResponse& metadata,
+      const inference::ModelConfig& config, const std::string& model_version,
       const std::unordered_map<std::string, std::vector<int64_t>>& input_shapes,
       std::unique_ptr<TritonClientWrapper>& client_wrapper);
 

--- a/src/clients/c++/perf_client/perf_client.cc
+++ b/src/clients/c++/perf_client/perf_client.cc
@@ -1061,13 +1061,13 @@ main(int argc, char** argv)
             triton_client_wrapper),
         "failed to create model parser");
   } else {
-    ni::ModelMetadataResponse model_metadata;
+    inference::ModelMetadataResponse model_metadata;
     FAIL_IF_ERR(
         triton_client_wrapper->ModelMetadata(
             &model_metadata, model_name, model_version),
         "failed to get model metadata");
 
-    ni::ModelConfigResponse model_config;
+    inference::ModelConfigResponse model_config;
     FAIL_IF_ERR(
         triton_client_wrapper->ModelConfig(
             &model_config, model_name, model_version),

--- a/src/clients/c++/perf_client/triton_client_wrapper.cc
+++ b/src/clients/c++/perf_client/triton_client_wrapper.cc
@@ -87,7 +87,7 @@ TritonClientWrapper::ModelMetadata(
 
 nic::Error
 TritonClientWrapper::ModelMetadata(
-    ni::ModelMetadataResponse* model_metadata, const std::string& model_name,
+    inference::ModelMetadataResponse* model_metadata, const std::string& model_name,
     const std::string& model_version)
 {
   if (protocol_ == ProtocolType::GRPC) {
@@ -119,7 +119,7 @@ TritonClientWrapper::ModelConfig(
 
 nic::Error
 TritonClientWrapper::ModelConfig(
-    ni::ModelConfigResponse* model_config, const std::string& model_name,
+    inference::ModelConfigResponse* model_config, const std::string& model_name,
     const std::string& model_version)
 {
   if (protocol_ == ProtocolType::GRPC) {
@@ -213,7 +213,7 @@ TritonClientWrapper::ModelInferenceStatistics(
     const std::string& model_name, const std::string& model_version)
 {
   if (protocol_ == ProtocolType::GRPC) {
-    ni::ModelStatisticsResponse infer_stat;
+    inference::ModelStatisticsResponse infer_stat;
     RETURN_IF_ERROR(client_.grpc_client_->ModelInferenceStatistics(
         &infer_stat, model_name, model_version, *http_headers_));
     ParseStatistics(infer_stat, model_stats);
@@ -282,7 +282,7 @@ TritonClientWrapper::RegisterCudaSharedMemory(
 
 void
 TritonClientWrapper::ParseStatistics(
-    ni::ModelStatisticsResponse& infer_stat,
+    inference::ModelStatisticsResponse& infer_stat,
     std::map<ModelIdentifier, ModelStatistics>* model_stats)
 {
   model_stats->clear();

--- a/src/clients/c++/perf_client/triton_client_wrapper.cc
+++ b/src/clients/c++/perf_client/triton_client_wrapper.cc
@@ -87,8 +87,8 @@ TritonClientWrapper::ModelMetadata(
 
 nic::Error
 TritonClientWrapper::ModelMetadata(
-    inference::ModelMetadataResponse* model_metadata, const std::string& model_name,
-    const std::string& model_version)
+    inference::ModelMetadataResponse* model_metadata,
+    const std::string& model_name, const std::string& model_version)
 {
   if (protocol_ == ProtocolType::GRPC) {
     RETURN_IF_ERROR(client_.grpc_client_->ModelMetadata(

--- a/src/clients/c++/perf_client/triton_client_wrapper.h
+++ b/src/clients/c++/perf_client/triton_client_wrapper.h
@@ -70,7 +70,7 @@ class TritonClientWrapper {
   /// Get the model metadata from the server for specified name and
   /// version as message.
   nic::Error ModelMetadata(
-      ni::ModelMetadataResponse* model_metadata, const std::string& model_name,
+      inference::ModelMetadataResponse* model_metadata, const std::string& model_name,
       const std::string& model_version);
 
   /// Get the model config from the server for specified name and
@@ -82,7 +82,7 @@ class TritonClientWrapper {
   /// Get the model config from the server for specified name and
   /// version as message.
   nic::Error ModelConfig(
-      ni::ModelConfigResponse* model_config, const std::string& model_name,
+      inference::ModelConfigResponse* model_config, const std::string& model_name,
       const std::string& model_version);
 
   /// Issues a synchronous inference request to the server.
@@ -137,7 +137,7 @@ class TritonClientWrapper {
   }
 
   void ParseStatistics(
-      ni::ModelStatisticsResponse& infer_stat,
+      inference::ModelStatisticsResponse& infer_stat,
       std::map<ModelIdentifier, ModelStatistics>* model_stats);
 
   void ParseStatistics(

--- a/src/clients/c++/perf_client/triton_client_wrapper.h
+++ b/src/clients/c++/perf_client/triton_client_wrapper.h
@@ -70,8 +70,8 @@ class TritonClientWrapper {
   /// Get the model metadata from the server for specified name and
   /// version as message.
   nic::Error ModelMetadata(
-      inference::ModelMetadataResponse* model_metadata, const std::string& model_name,
-      const std::string& model_version);
+      inference::ModelMetadataResponse* model_metadata,
+      const std::string& model_name, const std::string& model_version);
 
   /// Get the model config from the server for specified name and
   /// version as rapidjson DOM object.
@@ -82,8 +82,8 @@ class TritonClientWrapper {
   /// Get the model config from the server for specified name and
   /// version as message.
   nic::Error ModelConfig(
-      inference::ModelConfigResponse* model_config, const std::string& model_name,
-      const std::string& model_version);
+      inference::ModelConfigResponse* model_config,
+      const std::string& model_name, const std::string& model_version);
 
   /// Issues a synchronous inference request to the server.
   nic::Error Infer(

--- a/src/core/autofill.cc
+++ b/src/core/autofill.cc
@@ -53,7 +53,7 @@ namespace nvidia { namespace inferenceserver {
 class AutoFillNull : public AutoFill {
  public:
   static Status Create(std::unique_ptr<AutoFill>* autofill);
-  Status Fix(ModelConfig* config);
+  Status Fix(inference::ModelConfig* config);
 
  private:
   AutoFillNull() : AutoFill(std::string()) {}
@@ -67,7 +67,7 @@ AutoFillNull::Create(std::unique_ptr<AutoFill>* autofill)
 }
 
 Status
-AutoFillNull::Fix(ModelConfig* config)
+AutoFillNull::Fix(inference::ModelConfig* config)
 {
   return Status::Success;
 }
@@ -79,7 +79,7 @@ class AutoFillSimple : public AutoFill {
  public:
   static Status Create(
       const std::string& model_name, std::unique_ptr<AutoFill>* autofill);
-  Status Fix(ModelConfig* config);
+  Status Fix(inference::ModelConfig* config);
 
  private:
   AutoFillSimple(const std::string& model_name) : AutoFill(model_name) {}
@@ -94,7 +94,7 @@ AutoFillSimple::Create(
 }
 
 Status
-AutoFillSimple::Fix(ModelConfig* config)
+AutoFillSimple::Fix(inference::ModelConfig* config)
 {
   // Set name if not already set.
   if (config->name().empty()) {
@@ -110,7 +110,7 @@ AutoFillSimple::Fix(ModelConfig* config)
 Status
 AutoFill::Create(
     const std::string& model_name, const BackendConfigMap& backend_config_map,
-    const std::string& model_path, const ModelConfig& config,
+    const std::string& model_path, const inference::ModelConfig& config,
     std::unique_ptr<AutoFill>* autofill)
 {
   autofill->reset();

--- a/src/core/autofill.h
+++ b/src/core/autofill.h
@@ -37,11 +37,11 @@ class AutoFill {
   /// Create an AutoFill object for a specific model.
   static Status Create(
       const std::string& model_name, const BackendConfigMap& backend_config_map,
-      const std::string& model_path, const ModelConfig& config,
+      const std::string& model_path, const inference::ModelConfig& config,
       std::unique_ptr<AutoFill>* autofill);
 
   /// Autofill settings in a configuration.
-  virtual Status Fix(ModelConfig* config) = 0;
+  virtual Status Fix(inference::ModelConfig* config) = 0;
 
  protected:
   AutoFill(const std::string& model_name) : model_name_(model_name) {}

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -106,7 +106,7 @@ WarmupRequestComplete(
 
 Status
 InferenceBackend::GetInput(
-    const std::string& name, const ModelInput** input) const
+    const std::string& name, const inference::ModelInput** input) const
 {
   const auto itr = input_map_.find(name);
   if (itr == input_map_.end()) {
@@ -121,7 +121,7 @@ InferenceBackend::GetInput(
 
 Status
 InferenceBackend::GetOutput(
-    const std::string& name, const ModelOutput** output) const
+    const std::string& name, const inference::ModelOutput** output) const
 {
   const auto itr = output_map_.find(name);
   if (itr == output_map_.end()) {
@@ -136,7 +136,7 @@ InferenceBackend::GetOutput(
 
 Status
 InferenceBackend::SetModelConfig(
-    const std::string& path, const ModelConfig& config)
+    const std::string& path, const inference::ModelConfig& config)
 {
   config_ = config;
   RETURN_IF_ERROR(GetModelVersionFromPath(path, &version_));
@@ -285,7 +285,7 @@ InferenceBackend::SetConfiguredScheduler(
 
 Status
 InferenceBackend::Init(
-    const std::string& path, const ModelConfig& config,
+    const std::string& path, const inference::ModelConfig& config,
     const std::string& platform)
 {
   RETURN_IF_ERROR(
@@ -366,11 +366,11 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
       }
 
       switch (input_meta.second.input_data_type_case()) {
-        case ModelWarmup_Input::InputDataTypeCase::kZeroData:
+        case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
           max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
           break;
-        case ModelWarmup_Input::InputDataTypeCase::kRandomData: {
-          if (input_meta.second.data_type() == DataType::TYPE_STRING) {
+        case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
+          if (input_meta.second.data_type() == inference::DataType::TYPE_STRING) {
             max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
           } else {
             max_random_byte_size =
@@ -421,18 +421,18 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
 
         const char* allocated_ptr;
         switch (input_meta.second.input_data_type_case()) {
-          case ModelWarmup_Input::InputDataTypeCase::kZeroData:
+          case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
             allocated_ptr = zero_buffer;
             break;
-          case ModelWarmup_Input::InputDataTypeCase::kRandomData: {
-            if (input_meta.second.data_type() == DataType::TYPE_STRING) {
+          case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
+            if (input_meta.second.data_type() == inference::DataType::TYPE_STRING) {
               allocated_ptr = zero_buffer;
             } else {
               allocated_ptr = random_buffer;
             }
             break;
           }
-          case ModelWarmup_Input::InputDataTypeCase::kInputDataFile: {
+          case inference::ModelWarmup_Input::InputDataTypeCase::kInputDataFile: {
             // For data provided from file, we can set buffer in first pass
             warmup_data.provided_data_.emplace_back(new std::string());
             auto input_data = warmup_data.provided_data_.back().get();
@@ -440,7 +440,7 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
                 JoinPath({model_dir_, kWarmupDataFolder,
                           input_meta.second.input_data_file()}),
                 input_data));
-            if (input_meta.second.data_type() == DataType::TYPE_STRING) {
+            if (input_meta.second.data_type() == inference::DataType::TYPE_STRING) {
               batch_byte_size = input_data->size();
             } else if (((size_t)batch_byte_size) > input_data->size()) {
               return Status(
@@ -461,7 +461,7 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
                                                "' to have input_data_type set");
         }
 
-        const ModelInput* input_config;
+        const inference::ModelInput* input_config;
         bool is_original_input =
             GetInput(input_meta.first, &input_config).IsOk();
         InferenceRequest::Input* input = nullptr;

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -370,7 +370,8 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
           max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
           break;
         case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
-          if (input_meta.second.data_type() == inference::DataType::TYPE_STRING) {
+          if (input_meta.second.data_type() ==
+              inference::DataType::TYPE_STRING) {
             max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
           } else {
             max_random_byte_size =
@@ -425,14 +426,16 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
             allocated_ptr = zero_buffer;
             break;
           case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
-            if (input_meta.second.data_type() == inference::DataType::TYPE_STRING) {
+            if (input_meta.second.data_type() ==
+                inference::DataType::TYPE_STRING) {
               allocated_ptr = zero_buffer;
             } else {
               allocated_ptr = random_buffer;
             }
             break;
           }
-          case inference::ModelWarmup_Input::InputDataTypeCase::kInputDataFile: {
+          case inference::ModelWarmup_Input::InputDataTypeCase::
+              kInputDataFile: {
             // For data provided from file, we can set buffer in first pass
             warmup_data.provided_data_.emplace_back(new std::string());
             auto input_data = warmup_data.provided_data_.back().get();
@@ -440,7 +443,8 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
                 JoinPath({model_dir_, kWarmupDataFolder,
                           input_meta.second.input_data_file()}),
                 input_data));
-            if (input_meta.second.data_type() == inference::DataType::TYPE_STRING) {
+            if (input_meta.second.data_type() ==
+                inference::DataType::TYPE_STRING) {
               batch_byte_size = input_data->size();
             } else if (((size_t)batch_byte_size) > input_data->size()) {
               return Status(

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -97,7 +97,7 @@ class InferenceBackend {
   int64_t Version() const { return version_; }
 
   // Get the configuration of model being served.
-  const ModelConfig& Config() const { return config_; }
+  const inference::ModelConfig& Config() const { return config_; }
 
   // Get the stats collector for the model being served.
   InferenceStatsAggregator* MutableStatsAggregator()
@@ -110,10 +110,10 @@ class InferenceBackend {
   }
 
   // Get the model configuration for a named input.
-  Status GetInput(const std::string& name, const ModelInput** input) const;
+  Status GetInput(const std::string& name, const inference::ModelInput** input) const;
 
   // Get the model configuration for a named output.
-  Status GetOutput(const std::string& name, const ModelOutput** output) const;
+  Status GetOutput(const std::string& name, const inference::ModelOutput** output) const;
 
   // Get a label provider for the model.
   const std::shared_ptr<LabelProvider>& GetLabelProvider() const
@@ -122,7 +122,7 @@ class InferenceBackend {
   }
 
   Status Init(
-      const std::string& path, const ModelConfig& config,
+      const std::string& path, const inference::ModelConfig& config,
       const std::string& platform);
 
   // Enqueue a request for execution. If Status::Success is returned
@@ -163,7 +163,7 @@ class InferenceBackend {
   virtual void WarmUp(uint32_t runner_idx, WarmupData& sample);
 
   // Set the configuration of the model being served.
-  Status SetModelConfig(const std::string& path, const ModelConfig& config);
+  Status SetModelConfig(const std::string& path, const inference::ModelConfig& config);
 
   // Explicitly set the scheduler to use for inference requests to the
   // model. The scheduler can only be set once for a backend.
@@ -188,7 +188,7 @@ class InferenceBackend {
   const double min_compute_capability_;
 
   // Configuration of the model that this backend represents.
-  ModelConfig config_;
+  inference::ModelConfig config_;
 
   // Version of the model that this backend represents.
   int64_t version_;
@@ -203,10 +203,10 @@ class InferenceBackend {
   std::unique_ptr<Scheduler> scheduler_;
 
   // Map from input name to the model configuration for that input.
-  std::unordered_map<std::string, ModelInput> input_map_;
+  std::unordered_map<std::string, inference::ModelInput> input_map_;
 
   // Map from output name to the model configuration for that output.
-  std::unordered_map<std::string, ModelOutput> output_map_;
+  std::unordered_map<std::string, inference::ModelOutput> output_map_;
 
   // Path to model
   std::string model_dir_;

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -110,10 +110,12 @@ class InferenceBackend {
   }
 
   // Get the model configuration for a named input.
-  Status GetInput(const std::string& name, const inference::ModelInput** input) const;
+  Status GetInput(
+      const std::string& name, const inference::ModelInput** input) const;
 
   // Get the model configuration for a named output.
-  Status GetOutput(const std::string& name, const inference::ModelOutput** output) const;
+  Status GetOutput(
+      const std::string& name, const inference::ModelOutput** output) const;
 
   // Get a label provider for the model.
   const std::shared_ptr<LabelProvider>& GetLabelProvider() const
@@ -163,7 +165,8 @@ class InferenceBackend {
   virtual void WarmUp(uint32_t runner_idx, WarmupData& sample);
 
   // Set the configuration of the model being served.
-  Status SetModelConfig(const std::string& path, const inference::ModelConfig& config);
+  Status SetModelConfig(
+      const std::string& path, const inference::ModelConfig& config);
 
   // Explicitly set the scheduler to use for inference requests to the
   // model. The scheduler can only be set once for a backend.

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -189,7 +189,7 @@ BackendContext::CompareOutputDims(
 //
 void
 BackendResponder::ProcessTensor(
-    const std::string& name, const DataType datatype,
+    const std::string& name, const inference::DataType datatype,
     std::vector<int64_t>& batchn_shape, const char* buffer,
     const TRITONSERVER_MemoryType memory_type, const int64_t memory_type_id)
 {
@@ -548,7 +548,7 @@ BackendResponder::FlushPendingPinned(
 //
 void
 BackendInputCollector::ProcessTensor(
-    const std::string& name, const DataType datatype,
+    const std::string& name, const inference::DataType datatype,
     const std::vector<int64_t>& batch1_shape, char* buffer,
     const size_t buffer_byte_size, const TRITONSERVER_MemoryType memory_type,
     const int64_t memory_type_id)

--- a/src/core/backend_context.h
+++ b/src/core/backend_context.h
@@ -141,7 +141,7 @@ class BackendResponder {
 
   // Process all responses for a named output tensor.
   void ProcessTensor(
-      const std::string& name, const DataType datatype,
+      const std::string& name, const inference::DataType datatype,
       std::vector<int64_t>& batchn_shape, const char* buffer,
       const TRITONSERVER_MemoryType memory_type, const int64_t memory_type_id);
 
@@ -221,7 +221,7 @@ class BackendInputCollector {
 
   // Process all requests for a named input tensor.
   void ProcessTensor(
-      const std::string& name, const DataType datatype,
+      const std::string& name, const inference::DataType datatype,
       const std::vector<int64_t>& batch1_shape, char* buffer,
       const size_t buffer_byte_size, const TRITONSERVER_MemoryType memory_type,
       const int64_t memory_type_id);

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -46,7 +46,7 @@ DynamicBatchScheduler::DynamicBatchScheduler(
     const bool preserve_ordering,
     const std::set<int32_t>& preferred_batch_sizes,
     const uint64_t max_queue_delay_microseconds,
-    const ModelQueuePolicy& default_queue_policy,
+    const inference::ModelQueuePolicy& default_queue_policy,
     const uint32_t priority_levels, const ModelQueuePolicyMap& queue_policy_map)
     : OnInit_(OnInit), OnWarmup_(OnWarmup), OnSchedule_(OnSchedule),
       dynamic_batching_enabled_(dynamic_batching_enabled),
@@ -80,7 +80,7 @@ DynamicBatchScheduler::Create(
   return Create(
       runner_id_start, runner_cnt, nice, OnInit, OnWarmup, OnSchedule,
       dynamic_batching_enabled, enforce_equal_shape_tensors, preserve_ordering,
-      preferred_batch_sizes, max_queue_delay_microseconds, ModelQueuePolicy(),
+      preferred_batch_sizes, max_queue_delay_microseconds, inference::ModelQueuePolicy(),
       0, ModelQueuePolicyMap(), scheduler);
 }
 
@@ -93,7 +93,7 @@ DynamicBatchScheduler::Create(
     const bool preserve_ordering,
     const std::set<int32_t>& preferred_batch_sizes,
     const uint64_t max_queue_delay_microseconds,
-    const ModelQueuePolicy& default_queue_policy,
+    const inference::ModelQueuePolicy& default_queue_policy,
     const uint32_t priority_levels, const ModelQueuePolicyMap& queue_policy_map,
     std::unique_ptr<Scheduler>* scheduler)
 {

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -80,8 +80,8 @@ DynamicBatchScheduler::Create(
   return Create(
       runner_id_start, runner_cnt, nice, OnInit, OnWarmup, OnSchedule,
       dynamic_batching_enabled, enforce_equal_shape_tensors, preserve_ordering,
-      preferred_batch_sizes, max_queue_delay_microseconds, inference::ModelQueuePolicy(),
-      0, ModelQueuePolicyMap(), scheduler);
+      preferred_batch_sizes, max_queue_delay_microseconds,
+      inference::ModelQueuePolicy(), 0, ModelQueuePolicyMap(), scheduler);
 }
 
 Status

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -68,7 +68,7 @@ class DynamicBatchScheduler : public Scheduler {
       const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
       const uint64_t max_queue_delay_microseconds,
-      const ModelQueuePolicy& default_queue_policy,
+      const inference::ModelQueuePolicy& default_queue_policy,
       const uint32_t priority_level,
       const ModelQueuePolicyMap& queue_policy_map,
       std::unique_ptr<Scheduler>* scheduler);
@@ -87,7 +87,7 @@ class DynamicBatchScheduler : public Scheduler {
       const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
       const uint64_t max_queue_delay_microseconds,
-      const ModelQueuePolicy& default_queue_policy,
+      const inference::ModelQueuePolicy& default_queue_policy,
       const uint32_t priority_levels,
       const ModelQueuePolicyMap& queue_policy_map);
   void SchedulerThread(

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -839,7 +839,7 @@ EnsembleContext::InitStep(
 
     // If the actual shape and config shape agree with each other without
     // considering batch size, non-batch / batch conversion are not required.
-    const ModelInput* input_config;
+    const inference::ModelInput* input_config;
     backend->GetInput(pair.first, &input_config);
     auto shape = ReshapeTensorDims(
         input_config->dims(), allow_batching, tensor_data.batch_size_,
@@ -1167,7 +1167,7 @@ EnsembleContext::ScheduleSteps(
 Status
 EnsembleScheduler::Create(
     InferenceStatsAggregator* const stats_aggregator,
-    InferenceServer* const server, const ModelConfig& config,
+    InferenceServer* const server, const inference::ModelConfig& config,
     std::unique_ptr<Scheduler>* scheduler)
 {
   scheduler->reset(new EnsembleScheduler(stats_aggregator, server, config));
@@ -1186,7 +1186,7 @@ EnsembleScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
 
 EnsembleScheduler::EnsembleScheduler(
     InferenceStatsAggregator* const stats_aggregator,
-    InferenceServer* const server, const ModelConfig& config)
+    InferenceServer* const server, const inference::ModelConfig& config)
     : stats_aggregator_(stats_aggregator), is_(server), stream_(nullptr)
 {
 #ifdef TRITON_ENABLE_GPU

--- a/src/core/ensemble_scheduler.h
+++ b/src/core/ensemble_scheduler.h
@@ -82,7 +82,7 @@ class EnsembleScheduler : public Scheduler {
   // to dispatch requests to models in ensemble internally.
   static Status Create(
       InferenceStatsAggregator* const stats_aggregator,
-      InferenceServer* const server, const ModelConfig& config,
+      InferenceServer* const server, const inference::ModelConfig& config,
       std::unique_ptr<Scheduler>* scheduler);
 
   ~EnsembleScheduler();
@@ -93,7 +93,7 @@ class EnsembleScheduler : public Scheduler {
  private:
   EnsembleScheduler(
       InferenceStatsAggregator* const stats_aggregator,
-      InferenceServer* const server, const ModelConfig& config);
+      InferenceServer* const server, const inference::ModelConfig& config);
 
   std::unique_ptr<MetricModelReporter> metric_reporter_;
   InferenceStatsAggregator* const stats_aggregator_;

--- a/src/core/ensemble_utils.cc
+++ b/src/core/ensemble_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -41,7 +41,7 @@ namespace {
 /// of the ensemble tensor and which model they are inferred from.
 struct TensorNode {
   TensorNode(
-      const std::string& model_name, const bool batching, const DataType& type,
+      const std::string& model_name, const bool batching, const inference::DataType& type,
       const DimsList& dims)
       : model_name_(model_name), type_(type), dims_(dims), is_decoupled_(false),
         decouple_label_(0), visited_(false)
@@ -61,7 +61,7 @@ struct TensorNode {
   }
 
   std::string model_name_;
-  DataType type_;
+  inference::DataType type_;
   DimsList dims_;
   DimsList full_dims_;
   bool is_decoupled_;
@@ -89,9 +89,9 @@ ValidateTensorConsistency(
   if (lhs.type_ != rhs.type_) {
     return Status(
         Status::Code::INVALID_ARG,
-        message + "inconsistent data type: " + DataType_Name(lhs.type_) +
+        message + "inconsistent data type: " + inference::DataType_Name(lhs.type_) +
             " is inferred from model " + lhs.model_name_ + " while " +
-            DataType_Name(rhs.type_) + " is inferred from model " +
+            inference::DataType_Name(rhs.type_) + " is inferred from model " +
             rhs.model_name_);
   }
 
@@ -116,8 +116,8 @@ ValidateTensorConsistency(
 
 Status
 ValidateTensorMapping(
-    const std::string& ensemble, const ModelEnsembling::Step& step,
-    const ModelConfig& model_config,
+    const std::string& ensemble, const inference::ModelEnsembling::Step& step,
+    const inference::ModelConfig& model_config,
     std::unordered_map<std::string, TensorNode>* ensemble_tensors)
 {
   const bool batching = (model_config.max_batch_size() > 0);
@@ -279,7 +279,7 @@ ValidateEnsembleConfig(
 
   for (const auto& step : ensemble_config.ensemble_scheduling().step()) {
     const auto& model_name = step.model_name();
-    ModelConfig model_config;
+    inference::ModelConfig model_config;
     for (auto& node : ensemble->upstreams_) {
       if (model_name == node.first->model_name_) {
         model_config = node.first->model_config_;

--- a/src/core/ensemble_utils.cc
+++ b/src/core/ensemble_utils.cc
@@ -41,8 +41,8 @@ namespace {
 /// of the ensemble tensor and which model they are inferred from.
 struct TensorNode {
   TensorNode(
-      const std::string& model_name, const bool batching, const inference::DataType& type,
-      const DimsList& dims)
+      const std::string& model_name, const bool batching,
+      const inference::DataType& type, const DimsList& dims)
       : model_name_(model_name), type_(type), dims_(dims), is_decoupled_(false),
         decouple_label_(0), visited_(false)
   {
@@ -89,10 +89,10 @@ ValidateTensorConsistency(
   if (lhs.type_ != rhs.type_) {
     return Status(
         Status::Code::INVALID_ARG,
-        message + "inconsistent data type: " + inference::DataType_Name(lhs.type_) +
-            " is inferred from model " + lhs.model_name_ + " while " +
-            inference::DataType_Name(rhs.type_) + " is inferred from model " +
-            rhs.model_name_);
+        message + "inconsistent data type: " +
+            inference::DataType_Name(lhs.type_) + " is inferred from model " +
+            lhs.model_name_ + " while " + inference::DataType_Name(rhs.type_) +
+            " is inferred from model " + rhs.model_name_);
   }
 
   // Shapes must match or either one uses variable size shape, if one uses

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -26,9 +26,9 @@
 
 syntax = "proto3";
 
-package nvidia.inferenceserver;
+package inference;
 
-//@@.. cpp:namespace:: nvidia::inferenceserver
+//@@.. cpp:namespace:: inference
 
 import "model_config.proto";
 

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -346,7 +346,7 @@ InferenceRequest::ImmutableInput(
 
 Status
 InferenceRequest::AddOriginalInput(
-    const std::string& name, const DataType datatype, const int64_t* shape,
+    const std::string& name, const inference::DataType datatype, const int64_t* shape,
     const uint64_t dim_count, InferenceRequest::Input** input)
 {
   const auto& pr = original_inputs_.emplace(
@@ -370,7 +370,7 @@ InferenceRequest::AddOriginalInput(
 
 Status
 InferenceRequest::AddOriginalInput(
-    const std::string& name, const DataType datatype,
+    const std::string& name, const inference::DataType datatype,
     const std::vector<int64_t>& shape, InferenceRequest::Input** input)
 {
   return AddOriginalInput(name, datatype, &shape[0], shape.size(), input);
@@ -399,7 +399,7 @@ InferenceRequest::RemoveAllOriginalInputs()
 
 Status
 InferenceRequest::AddOverrideInput(
-    const std::string& name, const DataType datatype, const int64_t batch_size,
+    const std::string& name, const inference::DataType datatype,const int64_t batch_size,
     const std::vector<int64_t>& shape,
     std::shared_ptr<InferenceRequest::Input>* input)
 {
@@ -507,7 +507,7 @@ InferenceRequest::PrepareForInference()
 Status
 InferenceRequest::Normalize()
 {
-  const ModelConfig& model_config = backend_raw_->Config();
+  const inference::ModelConfig& model_config = backend_raw_->Config();
 
   // Initialize the requested outputs to be used during inference. If
   // original_requested_outputs_ is empty assume all outputs specified
@@ -521,7 +521,7 @@ InferenceRequest::Normalize()
     // Validate if the original requested output name exists in the
     // model configuration.
     for (const auto& output_name : original_requested_outputs_) {
-      const ModelOutput* output_config;
+      const inference::ModelOutput* output_config;
       RETURN_IF_ERROR(backend_raw_->GetOutput(output_name, &output_config));
     }
   }
@@ -556,7 +556,7 @@ InferenceRequest::Normalize()
 
       // For a shape tensor, keep the tensor's shape as it is and mark
       // that the input is a shape tensor.
-      const ModelInput* input_config;
+      const inference::ModelInput* input_config;
       RETURN_IF_ERROR(backend_raw_->GetInput(pr.first, &input_config));
       if (input_config->is_shape_tensor()) {
         *input.MutableShape() = input.OriginalShape();
@@ -600,7 +600,7 @@ InferenceRequest::Normalize()
   // Verify that each input shape is valid for the model, make
   // adjustments for reshapes and find the total tensor size.
   for (auto& pr : original_inputs_) {
-    const ModelInput* input_config;
+    const inference::ModelInput* input_config;
     RETURN_IF_ERROR(backend_raw_->GetInput(pr.first, &input_config));
 
     auto& input = pr.second;
@@ -748,7 +748,7 @@ InferenceRequest::ReportStatisticsWithDuration(
 InferenceRequest::Input::Input() : data_(new MemoryReference) {}
 
 InferenceRequest::Input::Input(
-    const std::string& name, const DataType datatype, const int64_t* shape,
+    const std::string& name, const inference::DataType datatype, const int64_t* shape,
     const uint64_t dim_count)
     : name_(name), datatype_(datatype),
       original_shape_(shape, shape + dim_count), is_shape_tensor_(false),
@@ -757,7 +757,7 @@ InferenceRequest::Input::Input(
 }
 
 InferenceRequest::Input::Input(
-    const std::string& name, const DataType datatype,
+    const std::string& name, const inference::DataType datatype,
     const std::vector<int64_t>& shape)
     : name_(name), datatype_(datatype), original_shape_(shape),
       is_shape_tensor_(false), data_(new MemoryReference)

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -400,8 +400,8 @@ InferenceRequest::RemoveAllOriginalInputs()
 
 Status
 InferenceRequest::AddOverrideInput(
-    const std::string& name, const inference::DataType datatype,const int64_t batch_size,
-    const std::vector<int64_t>& shape,
+    const std::string& name, const inference::DataType datatype,
+    const int64_t batch_size, const std::vector<int64_t>& shape,
     std::shared_ptr<InferenceRequest::Input>* input)
 {
   std::shared_ptr<Input> i = std::make_shared<Input>(name, datatype, shape);

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -346,8 +346,9 @@ InferenceRequest::ImmutableInput(
 
 Status
 InferenceRequest::AddOriginalInput(
-    const std::string& name, const inference::DataType datatype, const int64_t* shape,
-    const uint64_t dim_count, InferenceRequest::Input** input)
+    const std::string& name, const inference::DataType datatype,
+    const int64_t* shape, const uint64_t dim_count,
+    InferenceRequest::Input** input)
 {
   const auto& pr = original_inputs_.emplace(
       std::piecewise_construct, std::forward_as_tuple(name),
@@ -748,8 +749,8 @@ InferenceRequest::ReportStatisticsWithDuration(
 InferenceRequest::Input::Input() : data_(new MemoryReference) {}
 
 InferenceRequest::Input::Input(
-    const std::string& name, const inference::DataType datatype, const int64_t* shape,
-    const uint64_t dim_count)
+    const std::string& name, const inference::DataType datatype,
+    const int64_t* shape, const uint64_t dim_count)
     : name_(name), datatype_(datatype),
       original_shape_(shape, shape + dim_count), is_shape_tensor_(false),
       data_(new MemoryReference)

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -62,8 +62,8 @@ class InferenceRequest {
         const std::string& name, const inference::DataType datatype,
         const std::vector<int64_t>& shape);
     Input(
-        const std::string& name, const inference::DataType datatype, const int64_t* shape,
-        const uint64_t dim_count);
+        const std::string& name, const inference::DataType datatype,
+        const int64_t* shape, const uint64_t dim_count);
 
     // The name of the input tensor. There is no mutable operator for
     // the name because it is used in a InferenceRequest map and a
@@ -292,8 +292,8 @@ class InferenceRequest {
   // Add an original input to the request. If 'input' is non-null
   // return a pointer to the newly added input.
   Status AddOriginalInput(
-      const std::string& name, const inference::DataType datatype, const int64_t* shape,
-      const uint64_t dim_count, Input** input = nullptr);
+      const std::string& name, const inference::DataType datatype,
+      const int64_t* shape, const uint64_t dim_count, Input** input = nullptr);
   Status AddOriginalInput(
       const std::string& name, const inference::DataType datatype,
       const std::vector<int64_t>& shape, Input** input = nullptr);

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -309,8 +309,8 @@ class InferenceRequest {
   // backends that implemented w/o backend API (which need correct
   // input.Shape()), but backend API uses input.ShapeWithBatchDim().
   Status AddOverrideInput(
-      const std::string& name, const inference::DataType datatype, const int64_t batch_size,
-      const std::vector<int64_t>& shape,
+      const std::string& name, const inference::DataType datatype,
+      const int64_t batch_size, const std::vector<int64_t>& shape,
       std::shared_ptr<Input>* input = nullptr);
 
   // Add an override input to the request.

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -59,10 +59,10 @@ class InferenceRequest {
    public:
     Input();
     Input(
-        const std::string& name, const DataType datatype,
+        const std::string& name, const inference::DataType datatype,
         const std::vector<int64_t>& shape);
     Input(
-        const std::string& name, const DataType datatype, const int64_t* shape,
+        const std::string& name, const inference::DataType datatype, const int64_t* shape,
         const uint64_t dim_count);
 
     // The name of the input tensor. There is no mutable operator for
@@ -71,7 +71,7 @@ class InferenceRequest {
     const std::string& Name() const { return name_; }
 
     // Data type of the input tensor.
-    DataType DType() const { return datatype_; }
+    inference::DataType DType() const { return datatype_; }
 
     // The original shape of the input tensor.
     const std::vector<int64_t>& OriginalShape() const
@@ -143,7 +143,7 @@ class InferenceRequest {
         std::ostream& out, const InferenceRequest::Input& input);
 
     std::string name_;
-    DataType datatype_;
+    inference::DataType datatype_;
     std::vector<int64_t> original_shape_;
     std::vector<int64_t> shape_;
     std::vector<int64_t> shape_with_batch_dim_;
@@ -292,10 +292,10 @@ class InferenceRequest {
   // Add an original input to the request. If 'input' is non-null
   // return a pointer to the newly added input.
   Status AddOriginalInput(
-      const std::string& name, const DataType datatype, const int64_t* shape,
+      const std::string& name, const inference::DataType datatype, const int64_t* shape,
       const uint64_t dim_count, Input** input = nullptr);
   Status AddOriginalInput(
-      const std::string& name, const DataType datatype,
+      const std::string& name, const inference::DataType datatype,
       const std::vector<int64_t>& shape, Input** input = nullptr);
 
   // Remove a single original input or all inputs.
@@ -309,8 +309,8 @@ class InferenceRequest {
   // backends that implemented w/o backend API (which need correct
   // input.Shape()), but backend API uses input.ShapeWithBatchDim().
   Status AddOverrideInput(
-      const std::string& name, const DataType datatype,
-      const int64_t batch_size, const std::vector<int64_t>& shape,
+      const std::string& name, const inference::DataType datatype, const int64_t batch_size,
+      const std::vector<int64_t>& shape,
       std::shared_ptr<Input>* input = nullptr);
 
   // Add an override input to the request.

--- a/src/core/infer_response.cc
+++ b/src/core/infer_response.cc
@@ -131,7 +131,7 @@ InferenceResponse::AddParameter(const char* name, const bool value)
 
 Status
 InferenceResponse::AddOutput(
-    const std::string& name, const DataType datatype,
+    const std::string& name, const inference::DataType datatype,
     const std::vector<int64_t>& shape, InferenceResponse::Output** output)
 {
   outputs_.emplace_back(name, datatype, shape, allocator_, alloc_userp_);
@@ -139,7 +139,7 @@ InferenceResponse::AddOutput(
   LOG_VERBOSE(1) << "add response output: " << outputs_.back();
 
   if (backend_ != nullptr) {
-    const ModelOutput* output_config;
+    const inference::ModelOutput* output_config;
     RETURN_IF_ERROR(backend_->GetOutput(name, &output_config));
     if (output_config->has_reshape()) {
       const bool has_batch_dim = (backend_->Config().max_batch_size() > 0);
@@ -156,7 +156,7 @@ InferenceResponse::AddOutput(
 
 Status
 InferenceResponse::AddOutput(
-    const std::string& name, const DataType datatype,
+    const std::string& name, const inference::DataType datatype,
     std::vector<int64_t>&& shape, InferenceResponse::Output** output)
 {
   outputs_.emplace_back(
@@ -165,7 +165,7 @@ InferenceResponse::AddOutput(
   LOG_VERBOSE(1) << "add response output: " << outputs_.back();
 
   if (backend_ != nullptr) {
-    const ModelOutput* output_config;
+    const inference::ModelOutput* output_config;
     RETURN_IF_ERROR(backend_->GetOutput(name, &output_config));
     if (output_config->has_reshape()) {
       const bool has_batch_dim = (backend_->Config().max_batch_size() > 0);
@@ -239,7 +239,7 @@ InferenceResponse::Output::~Output()
 
 void
 InferenceResponse::Output::Reshape(
-    const bool has_batch_dim, const ModelOutput* output_config)
+    const bool has_batch_dim, const inference::ModelOutput* output_config)
 {
   std::deque<int64_t> variable_size_values;
 

--- a/src/core/infer_response.h
+++ b/src/core/infer_response.h
@@ -145,7 +145,8 @@ class InferenceResponse {
     // Reshape the output tensor. This function must only be called
     // for outputs that have respace specified in the model
     // configuration.
-    void Reshape(const bool has_batch_dim, const inference::ModelOutput* output_config);
+    void Reshape(
+        const bool has_batch_dim, const inference::ModelOutput* output_config);
 
     // Get information about the buffer allocated for this output
     // tensor's data. If no buffer is allocated 'buffer' will return

--- a/src/core/infer_response.h
+++ b/src/core/infer_response.h
@@ -113,7 +113,7 @@ class InferenceResponse {
   class Output {
    public:
     Output(
-        const std::string& name, const DataType datatype,
+        const std::string& name, const inference::DataType datatype,
         const std::vector<int64_t>& shape, const ResponseAllocator* allocator,
         void* alloc_userp)
         : name_(name), datatype_(datatype), shape_(shape),
@@ -122,7 +122,7 @@ class InferenceResponse {
     {
     }
     Output(
-        const std::string& name, const DataType datatype,
+        const std::string& name, const inference::DataType datatype,
         std::vector<int64_t>&& shape, const ResponseAllocator* allocator,
         void* alloc_userp)
         : name_(name), datatype_(datatype), shape_(std::move(shape)),
@@ -137,7 +137,7 @@ class InferenceResponse {
     const std::string& Name() const { return name_; }
 
     // Data type of the output tensor.
-    DataType DType() const { return datatype_; }
+    inference::DataType DType() const { return datatype_; }
 
     // The shape of the output tensor.
     const std::vector<int64_t>& Shape() const { return shape_; }
@@ -145,7 +145,7 @@ class InferenceResponse {
     // Reshape the output tensor. This function must only be called
     // for outputs that have respace specified in the model
     // configuration.
-    void Reshape(const bool has_batch_dim, const ModelOutput* output_config);
+    void Reshape(const bool has_batch_dim, const inference::ModelOutput* output_config);
 
     // Get information about the buffer allocated for this output
     // tensor's data. If no buffer is allocated 'buffer' will return
@@ -181,7 +181,7 @@ class InferenceResponse {
         std::ostream& out, const InferenceResponse::Output& output);
 
     std::string name_;
-    DataType datatype_;
+    inference::DataType datatype_;
     std::vector<int64_t> shape_;
 
     // The response allocator and user pointer.
@@ -237,10 +237,10 @@ class InferenceResponse {
   // Add an output to the response. If 'output' is non-null
   // return a pointer to the newly added output.
   Status AddOutput(
-      const std::string& name, const DataType datatype,
+      const std::string& name, const inference::DataType datatype,
       const std::vector<int64_t>& shape, Output** output = nullptr);
   Status AddOutput(
-      const std::string& name, const DataType datatype,
+      const std::string& name, const inference::DataType datatype,
       std::vector<int64_t>&& shape, Output** output = nullptr);
 
   // Get the classification label associated with an output. Return

--- a/src/core/model_config.cc
+++ b/src/core/model_config.cc
@@ -160,7 +160,9 @@ GetByteSize(const inference::DataType& dtype, const std::vector<int64_t>& dims)
 }
 
 int64_t
-GetByteSize(const int batch_size, const inference::DataType& dtype, const DimsList& dims)
+GetByteSize(
+    const int batch_size, const inference::DataType& dtype,
+    const DimsList& dims)
 {
   if (dims.size() == 0) {
     return batch_size * GetDataTypeByteSize(dtype);

--- a/src/core/model_config.cc
+++ b/src/core/model_config.cc
@@ -31,40 +31,40 @@
 namespace nvidia { namespace inferenceserver {
 
 bool
-IsFixedSizeDataType(const DataType dtype)
+IsFixedSizeDataType(const inference::DataType dtype)
 {
-  return dtype != TYPE_STRING;
+  return dtype != inference::DataType::TYPE_STRING;
 }
 
 size_t
-GetDataTypeByteSize(const DataType dtype)
+GetDataTypeByteSize(const inference::DataType dtype)
 {
   switch (dtype) {
-    case TYPE_BOOL:
+    case inference::DataType::TYPE_BOOL:
       return 1;
-    case TYPE_UINT8:
+    case inference::DataType::TYPE_UINT8:
       return 1;
-    case TYPE_UINT16:
+    case inference::DataType::TYPE_UINT16:
       return 2;
-    case TYPE_UINT32:
+    case inference::DataType::TYPE_UINT32:
       return 4;
-    case TYPE_UINT64:
+    case inference::DataType::TYPE_UINT64:
       return 8;
-    case TYPE_INT8:
+    case inference::DataType::TYPE_INT8:
       return 1;
-    case TYPE_INT16:
+    case inference::DataType::TYPE_INT16:
       return 2;
-    case TYPE_INT32:
+    case inference::DataType::TYPE_INT32:
       return 4;
-    case TYPE_INT64:
+    case inference::DataType::TYPE_INT64:
       return 8;
-    case TYPE_FP16:
+    case inference::DataType::TYPE_FP16:
       return 2;
-    case TYPE_FP32:
+    case inference::DataType::TYPE_FP32:
       return 4;
-    case TYPE_FP64:
+    case inference::DataType::TYPE_FP64:
       return 8;
-    case TYPE_STRING:
+    case inference::DataType::TYPE_STRING:
       return 0;
     default:
       break;
@@ -116,19 +116,19 @@ GetElementCount(const std::vector<int64_t>& dims)
 }
 
 int64_t
-GetElementCount(const ModelInput& mio)
+GetElementCount(const inference::ModelInput& mio)
 {
   return GetElementCount(mio.dims());
 }
 
 int64_t
-GetElementCount(const ModelOutput& mio)
+GetElementCount(const inference::ModelOutput& mio)
 {
   return GetElementCount(mio.dims());
 }
 
 int64_t
-GetByteSize(const DataType& dtype, const DimsList& dims)
+GetByteSize(const inference::DataType& dtype, const DimsList& dims)
 {
   size_t dt_size = GetDataTypeByteSize(dtype);
   if (dt_size == 0) {
@@ -144,7 +144,7 @@ GetByteSize(const DataType& dtype, const DimsList& dims)
 }
 
 int64_t
-GetByteSize(const DataType& dtype, const std::vector<int64_t>& dims)
+GetByteSize(const inference::DataType& dtype, const std::vector<int64_t>& dims)
 {
   size_t dt_size = GetDataTypeByteSize(dtype);
   if (dt_size == 0) {
@@ -160,7 +160,7 @@ GetByteSize(const DataType& dtype, const std::vector<int64_t>& dims)
 }
 
 int64_t
-GetByteSize(const int batch_size, const DataType& dtype, const DimsList& dims)
+GetByteSize(const int batch_size, const inference::DataType& dtype, const DimsList& dims)
 {
   if (dims.size() == 0) {
     return batch_size * GetDataTypeByteSize(dtype);
@@ -176,7 +176,7 @@ GetByteSize(const int batch_size, const DataType& dtype, const DimsList& dims)
 
 int64_t
 GetByteSize(
-    const int batch_size, const DataType& dtype,
+    const int batch_size, const inference::DataType& dtype,
     const std::vector<int64_t>& dims)
 {
   if (dims.size() == 0) {
@@ -192,13 +192,13 @@ GetByteSize(
 }
 
 int64_t
-GetByteSize(const ModelInput& mio)
+GetByteSize(const inference::ModelInput& mio)
 {
   return GetByteSize(mio.data_type(), mio.dims());
 }
 
 int64_t
-GetByteSize(const ModelOutput& mio)
+GetByteSize(const inference::ModelOutput& mio)
 {
   return GetByteSize(mio.data_type(), mio.dims());
 }
@@ -320,15 +320,15 @@ GetBackendType(const std::string& backend_name)
 }
 
 int
-GetCpuNiceLevel(const ModelConfig& config)
+GetCpuNiceLevel(const inference::ModelConfig& config)
 {
   int nice = SCHEDULER_DEFAULT_NICE;
   if (config.has_optimization()) {
     switch (config.optimization().priority()) {
-      case ModelOptimizationPolicy::PRIORITY_MAX:
+      case inference::ModelOptimizationPolicy::PRIORITY_MAX:
         nice = 0;
         break;
-      case ModelOptimizationPolicy::PRIORITY_MIN:
+      case inference::ModelOptimizationPolicy::PRIORITY_MIN:
         nice = 19;
         break;
       default:
@@ -448,34 +448,34 @@ DimsListToString(const std::vector<int64_t>& dims, const int start_idx)
 }
 
 const char*
-DataTypeToProtocolString(const DataType dtype)
+DataTypeToProtocolString(const inference::DataType dtype)
 {
   switch (dtype) {
-    case TYPE_BOOL:
+    case inference::DataType::TYPE_BOOL:
       return "BOOL";
-    case TYPE_UINT8:
+    case inference::DataType::TYPE_UINT8:
       return "UINT8";
-    case TYPE_UINT16:
+    case inference::DataType::TYPE_UINT16:
       return "UINT16";
-    case TYPE_UINT32:
+    case inference::DataType::TYPE_UINT32:
       return "UINT32";
-    case TYPE_UINT64:
+    case inference::DataType::TYPE_UINT64:
       return "UINT64";
-    case TYPE_INT8:
+    case inference::DataType::TYPE_INT8:
       return "INT8";
-    case TYPE_INT16:
+    case inference::DataType::TYPE_INT16:
       return "INT16";
-    case TYPE_INT32:
+    case inference::DataType::TYPE_INT32:
       return "INT32";
-    case TYPE_INT64:
+    case inference::DataType::TYPE_INT64:
       return "INT64";
-    case TYPE_FP16:
+    case inference::DataType::TYPE_FP16:
       return "FP16";
-    case TYPE_FP32:
+    case inference::DataType::TYPE_FP32:
       return "FP32";
-    case TYPE_FP64:
+    case inference::DataType::TYPE_FP64:
       return "FP64";
-    case TYPE_STRING:
+    case inference::DataType::TYPE_STRING:
       return "BYTES";
     default:
       break;
@@ -484,93 +484,93 @@ DataTypeToProtocolString(const DataType dtype)
   return "<invalid>";
 }
 
-DataType
+inference::DataType
 ProtocolStringToDataType(const std::string& dtype)
 {
   return ProtocolStringToDataType(dtype.c_str(), dtype.size());
 }
 
-DataType
+inference::DataType
 ProtocolStringToDataType(const char* dtype, size_t len)
 {
   if (len < 4 || len > 6) {
-    return TYPE_INVALID;
+    return inference::DataType::TYPE_INVALID;
   }
 
   if ((*dtype == 'I') && (len != 6)) {
     if ((dtype[1] == 'N') && (dtype[2] == 'T')) {
       if ((dtype[3] == '8') && (len == 4)) {
-        return TYPE_INT8;
+        return inference::DataType::TYPE_INT8;
       } else if ((dtype[3] == '1') && (dtype[4] == '6')) {
-        return TYPE_INT16;
+        return inference::DataType::TYPE_INT16;
       } else if ((dtype[3] == '3') && (dtype[4] == '2')) {
-        return TYPE_INT32;
+        return inference::DataType::TYPE_INT32;
       } else if ((dtype[3] == '6') && (dtype[4] == '4')) {
-        return TYPE_INT64;
+        return inference::DataType::TYPE_INT64;
       }
     }
   } else if ((*dtype == 'U') && (len != 4)) {
     if ((dtype[1] == 'I') && (dtype[2] == 'N') && (dtype[3] == 'T')) {
       if ((dtype[4] == '8') && (len == 5)) {
-        return TYPE_UINT8;
+        return inference::DataType::TYPE_UINT8;
       } else if ((dtype[4] == '1') && (dtype[5] == '6')) {
-        return TYPE_UINT16;
+        return inference::DataType::TYPE_UINT16;
       } else if ((dtype[4] == '3') && (dtype[5] == '2')) {
-        return TYPE_UINT32;
+        return inference::DataType::TYPE_UINT32;
       } else if ((dtype[4] == '6') && (dtype[5] == '4')) {
-        return TYPE_UINT64;
+        return inference::DataType::TYPE_UINT64;
       }
     }
   } else if ((*dtype == 'F') && (dtype[1] == 'P') && (len == 4)) {
     if ((dtype[2] == '1') && (dtype[3] == '6')) {
-      return TYPE_FP16;
+      return inference::DataType::TYPE_FP16;
     } else if ((dtype[2] == '3') && (dtype[3] == '2')) {
-      return TYPE_FP32;
+      return inference::DataType::TYPE_FP32;
     } else if ((dtype[2] == '6') && (dtype[3] == '4')) {
-      return TYPE_FP64;
+      return inference::DataType::TYPE_FP64;
     }
   } else if (*dtype == 'B') {
     if (dtype[1] == 'Y') {
       if (!strcmp(dtype + 2, "TES")) {
-        return TYPE_STRING;
+        return inference::DataType::TYPE_STRING;
       }
     } else if (!strcmp(dtype + 1, "OOL")) {
-      return TYPE_BOOL;
+      return inference::DataType::TYPE_BOOL;
     }
   }
 
-  return TYPE_INVALID;
+  return inference::DataType::TYPE_INVALID;
 }
 
 TRITONSERVER_DataType
-DataTypeToTriton(const DataType dtype)
+DataTypeToTriton(const inference::DataType dtype)
 {
   switch (dtype) {
-    case DataType::TYPE_BOOL:
+    case inference::DataType::TYPE_BOOL:
       return TRITONSERVER_TYPE_BOOL;
-    case DataType::TYPE_UINT8:
+    case inference::DataType::TYPE_UINT8:
       return TRITONSERVER_TYPE_UINT8;
-    case DataType::TYPE_UINT16:
+    case inference::DataType::TYPE_UINT16:
       return TRITONSERVER_TYPE_UINT16;
-    case DataType::TYPE_UINT32:
+    case inference::DataType::TYPE_UINT32:
       return TRITONSERVER_TYPE_UINT32;
-    case DataType::TYPE_UINT64:
+    case inference::DataType::TYPE_UINT64:
       return TRITONSERVER_TYPE_UINT64;
-    case DataType::TYPE_INT8:
+    case inference::DataType::TYPE_INT8:
       return TRITONSERVER_TYPE_INT8;
-    case DataType::TYPE_INT16:
+    case inference::DataType::TYPE_INT16:
       return TRITONSERVER_TYPE_INT16;
-    case DataType::TYPE_INT32:
+    case inference::DataType::TYPE_INT32:
       return TRITONSERVER_TYPE_INT32;
-    case DataType::TYPE_INT64:
+    case inference::DataType::TYPE_INT64:
       return TRITONSERVER_TYPE_INT64;
-    case DataType::TYPE_FP16:
+    case inference::DataType::TYPE_FP16:
       return TRITONSERVER_TYPE_FP16;
-    case DataType::TYPE_FP32:
+    case inference::DataType::TYPE_FP32:
       return TRITONSERVER_TYPE_FP32;
-    case DataType::TYPE_FP64:
+    case inference::DataType::TYPE_FP64:
       return TRITONSERVER_TYPE_FP64;
-    case DataType::TYPE_STRING:
+    case inference::DataType::TYPE_STRING:
       return TRITONSERVER_TYPE_BYTES;
     default:
       break;
@@ -579,41 +579,41 @@ DataTypeToTriton(const DataType dtype)
   return TRITONSERVER_TYPE_INVALID;
 }
 
-DataType
+inference::DataType
 TritonToDataType(const TRITONSERVER_DataType dtype)
 {
   switch (dtype) {
     case TRITONSERVER_TYPE_BOOL:
-      return DataType::TYPE_BOOL;
+      return inference::DataType::TYPE_BOOL;
     case TRITONSERVER_TYPE_UINT8:
-      return DataType::TYPE_UINT8;
+      return inference::DataType::TYPE_UINT8;
     case TRITONSERVER_TYPE_UINT16:
-      return DataType::TYPE_UINT16;
+      return inference::DataType::TYPE_UINT16;
     case TRITONSERVER_TYPE_UINT32:
-      return DataType::TYPE_UINT32;
+      return inference::DataType::TYPE_UINT32;
     case TRITONSERVER_TYPE_UINT64:
-      return DataType::TYPE_UINT64;
+      return inference::DataType::TYPE_UINT64;
     case TRITONSERVER_TYPE_INT8:
-      return DataType::TYPE_INT8;
+      return inference::DataType::TYPE_INT8;
     case TRITONSERVER_TYPE_INT16:
-      return DataType::TYPE_INT16;
+      return inference::DataType::TYPE_INT16;
     case TRITONSERVER_TYPE_INT32:
-      return DataType::TYPE_INT32;
+      return inference::DataType::TYPE_INT32;
     case TRITONSERVER_TYPE_INT64:
-      return DataType::TYPE_INT64;
+      return inference::DataType::TYPE_INT64;
     case TRITONSERVER_TYPE_FP16:
-      return DataType::TYPE_FP16;
+      return inference::DataType::TYPE_FP16;
     case TRITONSERVER_TYPE_FP32:
-      return DataType::TYPE_FP32;
+      return inference::DataType::TYPE_FP32;
     case TRITONSERVER_TYPE_FP64:
-      return DataType::TYPE_FP64;
+      return inference::DataType::TYPE_FP64;
     case TRITONSERVER_TYPE_BYTES:
-      return DataType::TYPE_STRING;
+      return inference::DataType::TYPE_STRING;
     default:
       break;
   }
 
-  return DataType::TYPE_INVALID;
+  return inference::DataType::TYPE_INVALID;
 }
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/model_config.h
+++ b/src/core/model_config.h
@@ -121,20 +121,20 @@ int64_t GetElementCount(const std::vector<int64_t>& dims);
 /// \return The number of elements, or -1 if the number of elements
 /// cannot be determined because the shape contains one or more
 /// wilcard dimensions.
-int64_t GetElementCount(const ModelInput& mio);
+int64_t GetElementCount(const inference::ModelInput& mio);
 
 /// Get the number of elements in the shape of a model output.
 /// \param mio The model output.
 /// \return The number of elements, or -1 if the number of elements
 /// cannot be determined because the shape contains one or more
 /// wilcard dimensions.
-int64_t GetElementCount(const ModelOutput& mio);
+int64_t GetElementCount(const inference::ModelOutput& mio);
 
 /// Are values of a datatype fixed-size, or variable-sized.
 /// \param dtype The data-type.
 /// \return True if datatype values are fixed-sized, false if
 /// variable-sized.
-bool IsFixedSizeDataType(const DataType dtype);
+bool IsFixedSizeDataType(const inference::DataType dtype);
 
 /// Get the size of objects of a given datatype in bytes.
 /// \param dtype The data-type.
@@ -142,7 +142,7 @@ bool IsFixedSizeDataType(const DataType dtype);
 /// size cannot be determine (for example, values of type TYPE_STRING
 /// have variable length and so size cannot be determine just from the
 /// type).
-size_t GetDataTypeByteSize(const DataType dtype);
+size_t GetDataTypeByteSize(const inference::DataType dtype);
 
 /// Get the size, in bytes, of a tensor based on datatype and
 /// shape.
@@ -150,7 +150,7 @@ size_t GetDataTypeByteSize(const DataType dtype);
 /// \param dims The shape.
 /// \return The size, in bytes, of the corresponding tensor, or -1 if
 /// unable to determine the size.
-int64_t GetByteSize(const DataType& dtype, const DimsList& dims);
+int64_t GetByteSize(const inference::DataType& dtype, const DimsList& dims);
 
 /// Get the size, in bytes, of a tensor based on datatype and
 /// shape.
@@ -158,7 +158,7 @@ int64_t GetByteSize(const DataType& dtype, const DimsList& dims);
 /// \param dims The shape.
 /// \return The size, in bytes, of the corresponding tensor, or -1 if
 /// unable to determine the size.
-int64_t GetByteSize(const DataType& dtype, const std::vector<int64_t>& dims);
+int64_t GetByteSize(const inference::DataType& dtype, const std::vector<int64_t>& dims);
 
 /// Get the size, in bytes, of a tensor based on batch-size, datatype
 /// and shape. A tensor that has empty shape [] and non-zero
@@ -170,7 +170,7 @@ int64_t GetByteSize(const DataType& dtype, const std::vector<int64_t>& dims);
 /// \return The size, in bytes, of the corresponding tensor, or -1 if
 /// unable to determine the size.
 int64_t GetByteSize(
-    const int batch_size, const DataType& dtype, const DimsList& dims);
+    const int batch_size, const inference::DataType& dtype, const DimsList& dims);
 
 /// Get the size, in bytes, of a tensor based on batch-size, datatype
 /// and shape. A tensor that has empty shape [] and non-zero
@@ -182,20 +182,20 @@ int64_t GetByteSize(
 /// \return The size, in bytes, of the corresponding tensor, or -1 if
 /// unable to determine the size.
 int64_t GetByteSize(
-    const int batch_size, const DataType& dtype,
+    const int batch_size, const inference::DataType& dtype,
     const std::vector<int64_t>& dims);
 
 /// Get the size, in bytes, of a tensor based on ModelInput.
 /// \param mio The ModelInput protobuf.
 /// \return The size, in bytes, of the corresponding tensor, or -1 if
 /// unable to determine the size.
-int64_t GetByteSize(const ModelInput& mio);
+int64_t GetByteSize(const inference::ModelInput& mio);
 
 /// Get the size, in bytes, of a tensor based on ModelOutput.
 /// \param mio The ModelOutput protobuf.
 /// \return The size, in bytes, of the corresponding tensor, or -1 if
 /// unable to determine the size.
-int64_t GetByteSize(const ModelOutput& mio);
+int64_t GetByteSize(const inference::ModelOutput& mio);
 
 /// Get the Platform value for a platform name.
 /// \param platform_name The platform name.
@@ -219,7 +219,7 @@ BackendType GetBackendType(const std::string& backend_name);
 /// configuration's priority.
 /// \param config The model configuration.
 /// \return The nice level.
-int GetCpuNiceLevel(const ModelConfig& config);
+int GetCpuNiceLevel(const inference::ModelConfig& config);
 
 /// Compare two model configuration shapes for equality. Wildcard
 /// dimensions (that is, dimensions with size WILDCARD_DIM) are
@@ -277,29 +277,29 @@ std::string DimsListToString(
 /// Get the server protocol string representation of a datatype.
 /// \param dtype The data type.
 /// \return The string representation.
-const char* DataTypeToProtocolString(const DataType dtype);
+const char* DataTypeToProtocolString(const inference::DataType dtype);
 
 /// Get the datatype corresponding to a server protocol string
 /// representation of a datatype.
 /// \param dtype string representation.
 /// \return The data type.
-DataType ProtocolStringToDataType(const std::string& dtype);
+inference::DataType ProtocolStringToDataType(const std::string& dtype);
 
 /// Get the datatype corresponding to a server protocol string
 /// representation of a datatype.
 /// \param dtype Pointer to string.
 /// \param len Length of the string.
 /// \return The data type.
-DataType ProtocolStringToDataType(const char* dtype, size_t len);
+inference::DataType ProtocolStringToDataType(const char* dtype, size_t len);
 
 /// Get the Triton server data type corresponding to a data type.
 /// \param dtype The data type.
 /// \return The Triton server data type.
-TRITONSERVER_DataType DataTypeToTriton(const DataType dtype);
+TRITONSERVER_DataType DataTypeToTriton(const inference::DataType dtype);
 
 /// Get the data type corresponding to a Triton server data type.
 /// \param dtype The Triton server data type.
 /// \return The data type.
-DataType TritonToDataType(const TRITONSERVER_DataType dtype);
+inference::DataType TritonToDataType(const TRITONSERVER_DataType dtype);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/model_config.h
+++ b/src/core/model_config.h
@@ -158,7 +158,8 @@ int64_t GetByteSize(const inference::DataType& dtype, const DimsList& dims);
 /// \param dims The shape.
 /// \return The size, in bytes, of the corresponding tensor, or -1 if
 /// unable to determine the size.
-int64_t GetByteSize(const inference::DataType& dtype, const std::vector<int64_t>& dims);
+int64_t GetByteSize(
+    const inference::DataType& dtype, const std::vector<int64_t>& dims);
 
 /// Get the size, in bytes, of a tensor based on batch-size, datatype
 /// and shape. A tensor that has empty shape [] and non-zero
@@ -170,7 +171,8 @@ int64_t GetByteSize(const inference::DataType& dtype, const std::vector<int64_t>
 /// \return The size, in bytes, of the corresponding tensor, or -1 if
 /// unable to determine the size.
 int64_t GetByteSize(
-    const int batch_size, const inference::DataType& dtype, const DimsList& dims);
+    const int batch_size, const inference::DataType& dtype,
+    const DimsList& dims);
 
 /// Get the size, in bytes, of a tensor based on batch-size, datatype
 /// and shape. A tensor that has empty shape [] and non-zero

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -28,9 +28,9 @@
 
 syntax = "proto3";
 
-package nvidia.inferenceserver;
+package inference;
 
-//@@.. cpp:namespace:: nvidia::inferenceserver
+//@@.. cpp:namespace:: inference
 
 //@@
 //@@.. cpp:enum:: DataType

--- a/src/core/model_config_cuda.cc
+++ b/src/core/model_config_cuda.cc
@@ -31,7 +31,8 @@
 namespace nvidia { namespace inferenceserver {
 
 int
-GetCudaStreamPriority(inference::ModelOptimizationPolicy::ModelPriority priority)
+GetCudaStreamPriority(
+    inference::ModelOptimizationPolicy::ModelPriority priority)
 {
   // Default priority is 0
   int cuda_stream_priority = 0;

--- a/src/core/model_config_cuda.cc
+++ b/src/core/model_config_cuda.cc
@@ -31,7 +31,7 @@
 namespace nvidia { namespace inferenceserver {
 
 int
-GetCudaStreamPriority(ModelOptimizationPolicy::ModelPriority priority)
+GetCudaStreamPriority(inference::ModelOptimizationPolicy::ModelPriority priority)
 {
   // Default priority is 0
   int cuda_stream_priority = 0;
@@ -43,10 +43,10 @@ GetCudaStreamPriority(ModelOptimizationPolicy::ModelPriority priority)
   }
 
   switch (priority) {
-    case ModelOptimizationPolicy::PRIORITY_MAX:
+    case inference::ModelOptimizationPolicy::PRIORITY_MAX:
       cuda_stream_priority = max;
       break;
-    case ModelOptimizationPolicy::PRIORITY_MIN:
+    case inference::ModelOptimizationPolicy::PRIORITY_MIN:
       cuda_stream_priority = min;
       break;
     default:

--- a/src/core/model_config_cuda.h
+++ b/src/core/model_config_cuda.h
@@ -31,9 +31,9 @@
 namespace nvidia { namespace inferenceserver {
 
 /// Get the CUDA stream priority for a given ModelPriority
-/// \param priority The ModelOptimizationPolicy::ModelPriority priority.
+/// \param priority The inference::ModelOptimizationPolicy::ModelPriority priority.
 /// \param cuda_stream_priority Returns the CUDA stream priority.
 /// \return The error status.
-int GetCudaStreamPriority(ModelOptimizationPolicy::ModelPriority priority);
+int GetCudaStreamPriority(inference::ModelOptimizationPolicy::ModelPriority priority);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/model_config_cuda.h
+++ b/src/core/model_config_cuda.h
@@ -31,9 +31,10 @@
 namespace nvidia { namespace inferenceserver {
 
 /// Get the CUDA stream priority for a given ModelPriority
-/// \param priority The inference::ModelOptimizationPolicy::ModelPriority priority.
-/// \param cuda_stream_priority Returns the CUDA stream priority.
+/// \param priority The inference::ModelOptimizationPolicy::ModelPriority
+/// priority. \param cuda_stream_priority Returns the CUDA stream priority.
 /// \return The error status.
-int GetCudaStreamPriority(inference::ModelOptimizationPolicy::ModelPriority priority);
+int GetCudaStreamPriority(
+    inference::ModelOptimizationPolicy::ModelPriority priority);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -69,7 +69,7 @@ struct EnsembleTensor {
 /// the ensemble configuration is not valid.
 Status
 BuildEnsembleGraph(
-    const ModelConfig& config,
+    const inference::ModelConfig& config,
     std::unordered_map<std::string, EnsembleTensor>& keyed_ensemble_graph)
 {
   keyed_ensemble_graph.clear();
@@ -149,7 +149,7 @@ BuildEnsembleGraph(
 }
 
 Status
-ValidateEnsembleSchedulingConfig(const ModelConfig& config)
+ValidateEnsembleSchedulingConfig(const inference::ModelConfig& config)
 {
   if (config.platform() != kEnsemblePlatform) {
     return Status(
@@ -268,7 +268,7 @@ ValidateIOShape(
         Status::Code::INVALID_ARG, message_prefix + "must specify 'name'");
   }
 
-  if (io.data_type() == DataType::TYPE_INVALID) {
+  if (io.data_type() == inference::DataType::TYPE_INVALID) {
     return Status(
         Status::Code::INVALID_ARG, "model output must specify 'data_type'");
   }
@@ -396,9 +396,9 @@ GetModelVersionFromPath(const std::string& path, int64_t* version)
 
 Status
 GetBooleanSequenceControlProperties(
-    const ModelSequenceBatching& batcher, const std::string& model_name,
-    const ModelSequenceBatching::Control::Kind control_kind,
-    const bool required, std::string* tensor_name, DataType* tensor_datatype,
+    const inference::ModelSequenceBatching& batcher, const std::string& model_name,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
+    const bool required, std::string* tensor_name, inference::DataType* tensor_datatype,
     float* fp32_false_value, float* fp32_true_value, int32_t* int32_false_value,
     int32_t* int32_true_value)
 {
@@ -431,7 +431,7 @@ GetBooleanSequenceControlProperties(
           return Status(
               Status::Code::INVALID_ARG,
               "sequence batching specifies multiple " +
-                  ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                  inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
                   " tensors for " + model_name);
         }
 
@@ -444,7 +444,7 @@ GetBooleanSequenceControlProperties(
                 Status::Code::INVALID_ARG,
                 "sequence batching specifies both 'int32_false_true' and "
                 "'fp32_false_true' for " +
-                    ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                    inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
                     " for " + model_name);
           }
 
@@ -453,12 +453,12 @@ GetBooleanSequenceControlProperties(
                 Status::Code::INVALID_ARG,
                 "sequence batching control 'int32_false_true' must have "
                 "exactly 2 entries for " +
-                    ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                    inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
                     " for " + model_name);
           }
 
           if (tensor_datatype != nullptr) {
-            *tensor_datatype = DataType::TYPE_INT32;
+            *tensor_datatype = inference::DataType::TYPE_INT32;
           }
           if (int32_false_value != nullptr) {
             *int32_false_value = c.int32_false_true(0);
@@ -472,7 +472,7 @@ GetBooleanSequenceControlProperties(
                 Status::Code::INVALID_ARG,
                 "sequence batching must specify either 'int32_false_true' or "
                 "'fp32_false_true' for " +
-                    ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                    inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
                     " for " + model_name);
           }
 
@@ -481,12 +481,12 @@ GetBooleanSequenceControlProperties(
                 Status::Code::INVALID_ARG,
                 "sequence batching control 'fp32_false_true' must have exactly "
                 "2 entries for " +
-                    ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                    inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
                     " for " + model_name);
           }
 
           if (tensor_datatype != nullptr) {
-            *tensor_datatype = DataType::TYPE_FP32;
+            *tensor_datatype = inference::DataType::TYPE_FP32;
           }
           if (fp32_false_value != nullptr) {
             *fp32_false_value = c.fp32_false_true(0);
@@ -504,7 +504,7 @@ GetBooleanSequenceControlProperties(
       return Status(
           Status::Code::INVALID_ARG,
           "sequence batching control tensor must specify a " +
-              ModelSequenceBatching_Control_Kind_Name(control_kind) +
+              inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
               " value for " + model_name);
     }
 
@@ -516,9 +516,9 @@ GetBooleanSequenceControlProperties(
 
 Status
 GetTypedSequenceControlProperties(
-    const ModelSequenceBatching& batcher, const std::string& model_name,
-    const ModelSequenceBatching::Control::Kind control_kind,
-    const bool required, std::string* tensor_name, DataType* tensor_datatype)
+    const inference::ModelSequenceBatching& batcher, const std::string& model_name,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
+    const bool required, std::string* tensor_name, inference::DataType* tensor_datatype)
 {
   // Make sure same tensor is not configured for multiple controls
   std::set<std::string> seen_tensors;
@@ -549,7 +549,7 @@ GetTypedSequenceControlProperties(
           return Status(
               Status::Code::INVALID_ARG,
               "sequence batching specifies multiple " +
-                  ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                  inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
                   " tensors for " + model_name);
         }
 
@@ -565,7 +565,7 @@ GetTypedSequenceControlProperties(
               Status::Code::INVALID_ARG,
               "sequence batching must not specify either 'int32_false_true' "
               "nor 'fp32_false_true' for " +
-                  ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                  inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
                   " for " + model_name);
         }
       }
@@ -577,7 +577,7 @@ GetTypedSequenceControlProperties(
       return Status(
           Status::Code::INVALID_ARG,
           "sequence batching control tensor must specify a " +
-              ModelSequenceBatching_Control_Kind_Name(control_kind) +
+              inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
               " value for " + model_name);
     }
 
@@ -591,7 +591,7 @@ Status
 GetNormalizedModelConfig(
     const std::string& path, const BackendConfigMap& backend_config_map,
     const bool autofill, const double min_compute_capability,
-    ModelConfig* config)
+    inference::ModelConfig* config)
 {
   // If 'autofill' then the configuration file can be empty.
   const auto config_path = JoinPath({path, kModelConfigPbTxt});
@@ -684,7 +684,7 @@ GetNormalizedModelConfig(
 
   // If version_policy is not specified, default to Latest 1 version.
   if (!config->has_version_policy()) {
-    ModelVersionPolicy::Latest latest;
+    inference::ModelVersionPolicy::Latest latest;
     latest.set_num_versions(1);
     config->mutable_version_policy()->mutable_latest()->CopyFrom(latest);
   }
@@ -728,7 +728,7 @@ GetNormalizedModelConfig(
 
     // Make sure there is at least one instance_group.
     if (config->instance_group().size() == 0) {
-      ModelInstanceGroup* group = config->add_instance_group();
+      inference::ModelInstanceGroup* group = config->add_instance_group();
       group->set_name(config->name());
     }
 
@@ -756,20 +756,20 @@ GetNormalizedModelConfig(
 
       // For KIND_AUTO... if there are no GPUs or if any of the listed
       // 'gpu's are not present, then use KIND_CPU.
-      if (group.kind() == ModelInstanceGroup::KIND_AUTO) {
+      if (group.kind() == inference::ModelInstanceGroup::KIND_AUTO) {
         if (supported_gpus.empty()) {
-          group.set_kind(ModelInstanceGroup::KIND_CPU);
+          group.set_kind(inference::ModelInstanceGroup::KIND_CPU);
         } else {
           for (const int32_t gid : group.gpus()) {
             if (supported_gpus.find(gid) == supported_gpus.end()) {
-              group.set_kind(ModelInstanceGroup::KIND_CPU);
+              group.set_kind(inference::ModelInstanceGroup::KIND_CPU);
               break;
             }
           }
         }
 
-        if (group.kind() == ModelInstanceGroup::KIND_AUTO) {
-          group.set_kind(ModelInstanceGroup::KIND_GPU);
+        if (group.kind() == inference::ModelInstanceGroup::KIND_AUTO) {
+          group.set_kind(inference::ModelInstanceGroup::KIND_GPU);
         }
       }
 
@@ -779,7 +779,7 @@ GetNormalizedModelConfig(
       }
 
       // GPUs
-      if ((group.kind() == ModelInstanceGroup::KIND_GPU) &&
+      if ((group.kind() == inference::ModelInstanceGroup::KIND_GPU) &&
           (group.gpus().size() == 0)) {
         for (auto d : supported_gpus) {
           group.add_gpus(d);
@@ -793,7 +793,7 @@ GetNormalizedModelConfig(
 
 Status
 ValidateModelConfig(
-    const ModelConfig& config, const std::string& expected_platform,
+    const inference::ModelConfig& config, const std::string& expected_platform,
     const double min_compute_capability)
 {
   if (config.name().empty()) {
@@ -932,7 +932,7 @@ ValidateModelConfig(
       const auto& default_policy =
           config.dynamic_batching().default_queue_policy();
       if ((default_policy.default_timeout_microseconds() != 0) &&
-          (default_policy.timeout_action() == ModelQueuePolicy::DELAY)) {
+          (default_policy.timeout_action() == inference::ModelQueuePolicy::DELAY)) {
         return Status(
             Status::Code::INVALID_ARG,
             "Queue policy can not have DELAY as timeout action when "
@@ -944,7 +944,7 @@ ValidateModelConfig(
       for (const auto& policy :
            config.dynamic_batching().priority_queue_policy()) {
         if ((policy.second.default_timeout_microseconds() != 0) &&
-            (policy.second.timeout_action() == ModelQueuePolicy::DELAY)) {
+            (policy.second.timeout_action() == inference::ModelQueuePolicy::DELAY)) {
           return Status(
               Status::Code::INVALID_ARG,
               "Queue policy can not have DELAY as timeout action when "
@@ -964,34 +964,34 @@ ValidateModelConfig(
     std::string tensor_name;
     RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
         batcher, config.name(),
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
         false /* required */, &tensor_name, nullptr, nullptr, nullptr, nullptr,
         nullptr));
     RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
         batcher, config.name(),
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_END,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END,
         false /* required */, &tensor_name, nullptr, nullptr, nullptr, nullptr,
         nullptr));
     RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
         batcher, config.name(),
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY,
         false /* required */, &tensor_name, nullptr, nullptr, nullptr, nullptr,
         nullptr));
 
     // Check CORRID control and make sure it is one of the allowed types.
-    DataType tensor_datatype;
+    inference::DataType tensor_datatype;
     RETURN_IF_ERROR(GetTypedSequenceControlProperties(
         batcher, config.name(),
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID,
         false /* required */, &tensor_name, &tensor_datatype));
     if (!tensor_name.empty()) {
-      if ((tensor_datatype != TYPE_UINT64) && (tensor_datatype != TYPE_INT64) &&
-          (tensor_datatype != TYPE_UINT32) && (tensor_datatype != TYPE_INT32)) {
+      if ((tensor_datatype != inference::DataType::TYPE_UINT64) && (tensor_datatype != inference::DataType::TYPE_INT64) &&
+          (tensor_datatype != inference::DataType::TYPE_UINT32) && (tensor_datatype != inference::DataType::TYPE_INT32)) {
         return Status(
             Status::Code::INVALID_ARG,
             "unexpected data type for control " +
-                ModelSequenceBatching_Control_Kind_Name(
-                    ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID) +
+                inference::ModelSequenceBatching_Control_Kind_Name(
+                    inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID) +
                 " for " + config.name() +
                 ". Allowed data types are TYPE_UINT64, TYPE_INT64, TYPE_UINT32 "
                 "and TYPE_INT32");
@@ -1058,7 +1058,7 @@ ValidateModelConfig(
 
     for (const auto& group : config.instance_group()) {
       // KIND_MODEL is supported only on TensorFlow.
-      if (group.kind() == ModelInstanceGroup::KIND_MODEL) {
+      if (group.kind() == inference::ModelInstanceGroup::KIND_MODEL) {
         if (group.gpus().size() > 0) {
           return Status(
               Status::Code::INVALID_ARG,
@@ -1077,7 +1077,7 @@ ValidateModelConfig(
                   " has kind KIND_MODEL which is supported only on TensorFlow "
                   "models");
         }
-      } else if (group.kind() == ModelInstanceGroup::KIND_GPU) {
+      } else if (group.kind() == inference::ModelInstanceGroup::KIND_GPU) {
 #ifndef TRITON_ENABLE_GPU
         return Status(
             Status::Code::INVALID_ARG,
@@ -1121,7 +1121,7 @@ ValidateModelConfig(
           }
         }
 #endif  // !TRITON_ENABLE_GPU
-      } else if (group.kind() == ModelInstanceGroup::KIND_CPU) {
+      } else if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
         if (group.gpus().size() > 0) {
           return Status(
               Status::Code::INVALID_ARG,
@@ -1169,12 +1169,12 @@ ValidateModelConfig(
 
 Status
 ValidateModelInput(
-    const ModelInput& io, int32_t max_batch_size, const std::string& platform)
+    const inference::ModelInput& io, int32_t max_batch_size, const std::string& platform)
 {
   RETURN_IF_ERROR(ValidateIOShape(io, max_batch_size, "model input "));
 
-  if (((io.format() == ModelInput::FORMAT_NHWC) ||
-       (io.format() == ModelInput::FORMAT_NCHW)) &&
+  if (((io.format() == inference::ModelInput::FORMAT_NHWC) ||
+       (io.format() == inference::ModelInput::FORMAT_NCHW)) &&
       (io.dims_size() != 3)) {
     return Status(
         Status::Code::INVALID_ARG, "model input NHWC/NCHW require 3 dims");
@@ -1205,7 +1205,7 @@ ValidateModelInput(
 
 Status
 CheckAllowedModelInput(
-    const ModelInput& io, const std::set<std::string>& allowed)
+    const inference::ModelInput& io, const std::set<std::string>& allowed)
 {
   if (allowed.find(io.name()) == allowed.end()) {
     std::string astr;
@@ -1225,7 +1225,7 @@ CheckAllowedModelInput(
 
 Status
 ValidateModelOutput(
-    const ModelOutput& io, int32_t max_batch_size, const std::string& platform)
+    const inference::ModelOutput& io, int32_t max_batch_size, const std::string& platform)
 {
   RETURN_IF_ERROR(ValidateIOShape(io, max_batch_size, "model output "));
 
@@ -1244,7 +1244,7 @@ ValidateModelOutput(
 
 Status
 CheckAllowedModelOutput(
-    const ModelOutput& io, const std::set<std::string>& allowed)
+    const inference::ModelOutput& io, const std::set<std::string>& allowed)
 {
   if (allowed.find(io.name()) == allowed.end()) {
     std::string astr;
@@ -1372,7 +1372,7 @@ ValidateModelConfigInt64()
 {
   // Must initialize a dummy ModelConfig so that all fields are
   // visited.
-  ModelConfig config;
+  inference::ModelConfig config;
 
   std::set<std::string> int64_fields;
   RETURN_IF_ERROR(CollectInt64Fields(&config, "ModelConfig", &int64_fields));
@@ -1489,7 +1489,7 @@ FixObjectArray(
 
 Status
 ModelConfigToJson(
-    const ModelConfig& config, const uint32_t config_version,
+    const inference::ModelConfig& config, const uint32_t config_version,
     std::string* json_str)
 {
   // Currently only support 'config_version' 1, which is the json

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -396,10 +396,12 @@ GetModelVersionFromPath(const std::string& path, int64_t* version)
 
 Status
 GetBooleanSequenceControlProperties(
-    const inference::ModelSequenceBatching& batcher, const std::string& model_name,
+    const inference::ModelSequenceBatching& batcher,
+    const std::string& model_name,
     const inference::ModelSequenceBatching::Control::Kind control_kind,
-    const bool required, std::string* tensor_name, inference::DataType* tensor_datatype,
-    float* fp32_false_value, float* fp32_true_value, int32_t* int32_false_value,
+    const bool required, std::string* tensor_name,
+    inference::DataType* tensor_datatype, float* fp32_false_value,
+    float* fp32_true_value, int32_t* int32_false_value,
     int32_t* int32_true_value)
 {
   // Make sure same tensor is not configured for multiple controls
@@ -431,7 +433,8 @@ GetBooleanSequenceControlProperties(
           return Status(
               Status::Code::INVALID_ARG,
               "sequence batching specifies multiple " +
-                  inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                  inference::ModelSequenceBatching_Control_Kind_Name(
+                      control_kind) +
                   " tensors for " + model_name);
         }
 
@@ -444,7 +447,8 @@ GetBooleanSequenceControlProperties(
                 Status::Code::INVALID_ARG,
                 "sequence batching specifies both 'int32_false_true' and "
                 "'fp32_false_true' for " +
-                    inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                    inference::ModelSequenceBatching_Control_Kind_Name(
+                        control_kind) +
                     " for " + model_name);
           }
 
@@ -453,7 +457,8 @@ GetBooleanSequenceControlProperties(
                 Status::Code::INVALID_ARG,
                 "sequence batching control 'int32_false_true' must have "
                 "exactly 2 entries for " +
-                    inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                    inference::ModelSequenceBatching_Control_Kind_Name(
+                        control_kind) +
                     " for " + model_name);
           }
 
@@ -472,7 +477,8 @@ GetBooleanSequenceControlProperties(
                 Status::Code::INVALID_ARG,
                 "sequence batching must specify either 'int32_false_true' or "
                 "'fp32_false_true' for " +
-                    inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                    inference::ModelSequenceBatching_Control_Kind_Name(
+                        control_kind) +
                     " for " + model_name);
           }
 
@@ -481,7 +487,8 @@ GetBooleanSequenceControlProperties(
                 Status::Code::INVALID_ARG,
                 "sequence batching control 'fp32_false_true' must have exactly "
                 "2 entries for " +
-                    inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                    inference::ModelSequenceBatching_Control_Kind_Name(
+                        control_kind) +
                     " for " + model_name);
           }
 
@@ -516,9 +523,11 @@ GetBooleanSequenceControlProperties(
 
 Status
 GetTypedSequenceControlProperties(
-    const inference::ModelSequenceBatching& batcher, const std::string& model_name,
+    const inference::ModelSequenceBatching& batcher,
+    const std::string& model_name,
     const inference::ModelSequenceBatching::Control::Kind control_kind,
-    const bool required, std::string* tensor_name, inference::DataType* tensor_datatype)
+    const bool required, std::string* tensor_name,
+    inference::DataType* tensor_datatype)
 {
   // Make sure same tensor is not configured for multiple controls
   std::set<std::string> seen_tensors;
@@ -549,7 +558,8 @@ GetTypedSequenceControlProperties(
           return Status(
               Status::Code::INVALID_ARG,
               "sequence batching specifies multiple " +
-                  inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                  inference::ModelSequenceBatching_Control_Kind_Name(
+                      control_kind) +
                   " tensors for " + model_name);
         }
 
@@ -565,7 +575,8 @@ GetTypedSequenceControlProperties(
               Status::Code::INVALID_ARG,
               "sequence batching must not specify either 'int32_false_true' "
               "nor 'fp32_false_true' for " +
-                  inference::ModelSequenceBatching_Control_Kind_Name(control_kind) +
+                  inference::ModelSequenceBatching_Control_Kind_Name(
+                      control_kind) +
                   " for " + model_name);
         }
       }
@@ -932,7 +943,8 @@ ValidateModelConfig(
       const auto& default_policy =
           config.dynamic_batching().default_queue_policy();
       if ((default_policy.default_timeout_microseconds() != 0) &&
-          (default_policy.timeout_action() == inference::ModelQueuePolicy::DELAY)) {
+          (default_policy.timeout_action() ==
+           inference::ModelQueuePolicy::DELAY)) {
         return Status(
             Status::Code::INVALID_ARG,
             "Queue policy can not have DELAY as timeout action when "
@@ -944,7 +956,8 @@ ValidateModelConfig(
       for (const auto& policy :
            config.dynamic_batching().priority_queue_policy()) {
         if ((policy.second.default_timeout_microseconds() != 0) &&
-            (policy.second.timeout_action() == inference::ModelQueuePolicy::DELAY)) {
+            (policy.second.timeout_action() ==
+             inference::ModelQueuePolicy::DELAY)) {
           return Status(
               Status::Code::INVALID_ARG,
               "Queue policy can not have DELAY as timeout action when "
@@ -985,13 +998,16 @@ ValidateModelConfig(
         inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID,
         false /* required */, &tensor_name, &tensor_datatype));
     if (!tensor_name.empty()) {
-      if ((tensor_datatype != inference::DataType::TYPE_UINT64) && (tensor_datatype != inference::DataType::TYPE_INT64) &&
-          (tensor_datatype != inference::DataType::TYPE_UINT32) && (tensor_datatype != inference::DataType::TYPE_INT32)) {
+      if ((tensor_datatype != inference::DataType::TYPE_UINT64) &&
+          (tensor_datatype != inference::DataType::TYPE_INT64) &&
+          (tensor_datatype != inference::DataType::TYPE_UINT32) &&
+          (tensor_datatype != inference::DataType::TYPE_INT32)) {
         return Status(
             Status::Code::INVALID_ARG,
             "unexpected data type for control " +
                 inference::ModelSequenceBatching_Control_Kind_Name(
-                    inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID) +
+                    inference::ModelSequenceBatching::Control::
+                        CONTROL_SEQUENCE_CORRID) +
                 " for " + config.name() +
                 ". Allowed data types are TYPE_UINT64, TYPE_INT64, TYPE_UINT32 "
                 "and TYPE_INT32");
@@ -1169,7 +1185,8 @@ ValidateModelConfig(
 
 Status
 ValidateModelInput(
-    const inference::ModelInput& io, int32_t max_batch_size, const std::string& platform)
+    const inference::ModelInput& io, int32_t max_batch_size,
+    const std::string& platform)
 {
   RETURN_IF_ERROR(ValidateIOShape(io, max_batch_size, "model input "));
 
@@ -1225,7 +1242,8 @@ CheckAllowedModelInput(
 
 Status
 ValidateModelOutput(
-    const inference::ModelOutput& io, int32_t max_batch_size, const std::string& platform)
+    const inference::ModelOutput& io, int32_t max_batch_size,
+    const std::string& platform)
 {
   RETURN_IF_ERROR(ValidateIOShape(io, max_batch_size, "model output "));
 

--- a/src/core/model_config_utils.h
+++ b/src/core/model_config_utils.h
@@ -44,10 +44,12 @@ Status GetModelVersionFromPath(const std::string& path, int64_t* version);
 /// 'tensor_name' as empty-string if the control is not mapped to any
 /// tensor.
 Status GetBooleanSequenceControlProperties(
-    const inference::ModelSequenceBatching& batcher, const std::string& model_name,
+    const inference::ModelSequenceBatching& batcher,
+    const std::string& model_name,
     const inference::ModelSequenceBatching::Control::Kind control_kind,
-    const bool required, std::string* tensor_name, inference::DataType* tensor_datatype,
-    float* fp32_false_value, float* fp32_true_value, int32_t* int32_false_value,
+    const bool required, std::string* tensor_name,
+    inference::DataType* tensor_datatype, float* fp32_false_value,
+    float* fp32_true_value, int32_t* int32_false_value,
     int32_t* int32_true_value);
 
 /// Get the tensor name and datatype for a non-boolean sequence
@@ -57,9 +59,11 @@ Status GetBooleanSequenceControlProperties(
 /// tensor. 'tensor_datatype' returns the required datatype for the
 /// control.
 Status GetTypedSequenceControlProperties(
-    const inference::ModelSequenceBatching& batcher, const std::string& model_name,
+    const inference::ModelSequenceBatching& batcher,
+    const std::string& model_name,
     const inference::ModelSequenceBatching::Control::Kind control_kind,
-    const bool required, std::string* tensor_name, inference::DataType* tensor_datatype);
+    const bool required, std::string* tensor_name,
+    inference::DataType* tensor_datatype);
 
 /// Read a ModelConfig and normalize it as expected by model backends.
 /// \param path The full-path to the directory containing the
@@ -97,7 +101,8 @@ Status ValidateModelConfig(
 /// \return The error status. A non-OK status indicates the input
 /// is not valid.
 Status ValidateModelInput(
-    const inference::ModelInput& io, int32_t max_batch_size, const std::string& platform);
+    const inference::ModelInput& io, int32_t max_batch_size,
+    const std::string& platform);
 
 /// Validate that an input matches one of the allowed input names.
 /// \param io The model input.
@@ -115,7 +120,8 @@ Status CheckAllowedModelInput(
 /// \return The error status. A non-OK status indicates the output
 /// is not valid.
 Status ValidateModelOutput(
-    const inference::ModelOutput& io, int32_t max_batch_size, const std::string& platform);
+    const inference::ModelOutput& io, int32_t max_batch_size,
+    const std::string& platform);
 
 /// Validate that an output matches one of the allowed output names.
 /// \param io The model output.

--- a/src/core/model_config_utils.h
+++ b/src/core/model_config_utils.h
@@ -44,9 +44,9 @@ Status GetModelVersionFromPath(const std::string& path, int64_t* version);
 /// 'tensor_name' as empty-string if the control is not mapped to any
 /// tensor.
 Status GetBooleanSequenceControlProperties(
-    const ModelSequenceBatching& batcher, const std::string& model_name,
-    const ModelSequenceBatching::Control::Kind control_kind,
-    const bool required, std::string* tensor_name, DataType* tensor_datatype,
+    const inference::ModelSequenceBatching& batcher, const std::string& model_name,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
+    const bool required, std::string* tensor_name, inference::DataType* tensor_datatype,
     float* fp32_false_value, float* fp32_true_value, int32_t* int32_false_value,
     int32_t* int32_true_value);
 
@@ -57,9 +57,9 @@ Status GetBooleanSequenceControlProperties(
 /// tensor. 'tensor_datatype' returns the required datatype for the
 /// control.
 Status GetTypedSequenceControlProperties(
-    const ModelSequenceBatching& batcher, const std::string& model_name,
-    const ModelSequenceBatching::Control::Kind control_kind,
-    const bool required, std::string* tensor_name, DataType* tensor_datatype);
+    const inference::ModelSequenceBatching& batcher, const std::string& model_name,
+    const inference::ModelSequenceBatching::Control::Kind control_kind,
+    const bool required, std::string* tensor_name, inference::DataType* tensor_datatype);
 
 /// Read a ModelConfig and normalize it as expected by model backends.
 /// \param path The full-path to the directory containing the
@@ -75,7 +75,7 @@ Status GetTypedSequenceControlProperties(
 Status GetNormalizedModelConfig(
     const std::string& path, const BackendConfigMap& backend_config_map,
     const bool autofill, const double min_compute_capability,
-    ModelConfig* config);
+    inference::ModelConfig* config);
 
 /// Validate that a model is specified correctly.
 /// \param config The model configuration to validate.
@@ -86,7 +86,7 @@ Status GetNormalizedModelConfig(
 /// \return The error status. A non-OK status indicates the configuration
 /// is not valid.
 Status ValidateModelConfig(
-    const ModelConfig& config, const std::string& expected_platform,
+    const inference::ModelConfig& config, const std::string& expected_platform,
     const double min_compute_capability);
 
 /// Validate that input is specified correctly in a model
@@ -97,7 +97,7 @@ Status ValidateModelConfig(
 /// \return The error status. A non-OK status indicates the input
 /// is not valid.
 Status ValidateModelInput(
-    const ModelInput& io, int32_t max_batch_size, const std::string& platform);
+    const inference::ModelInput& io, int32_t max_batch_size, const std::string& platform);
 
 /// Validate that an input matches one of the allowed input names.
 /// \param io The model input.
@@ -105,7 +105,7 @@ Status ValidateModelInput(
 /// \return The error status. A non-OK status indicates the input
 /// is not valid.
 Status CheckAllowedModelInput(
-    const ModelInput& io, const std::set<std::string>& allowed);
+    const inference::ModelInput& io, const std::set<std::string>& allowed);
 
 /// Validate that an output is specified correctly in a model
 /// configuration.
@@ -115,7 +115,7 @@ Status CheckAllowedModelInput(
 /// \return The error status. A non-OK status indicates the output
 /// is not valid.
 Status ValidateModelOutput(
-    const ModelOutput& io, int32_t max_batch_size, const std::string& platform);
+    const inference::ModelOutput& io, int32_t max_batch_size, const std::string& platform);
 
 /// Validate that an output matches one of the allowed output names.
 /// \param io The model output.
@@ -123,7 +123,7 @@ Status ValidateModelOutput(
 /// \return The error status. A non-OK status indicates the output
 /// is not valid.
 Status CheckAllowedModelOutput(
-    const ModelOutput& io, const std::set<std::string>& allowed);
+    const inference::ModelOutput& io, const std::set<std::string>& allowed);
 
 /// Parse the 'value' of the parameter 'key' into a boolean value.
 /// \param key The name of the parameter.
@@ -159,7 +159,7 @@ Status GetProfileIndex(const std::string& profile_name, int* profile_index);
 /// \param json Returns the equivalent JSON.
 /// \return The error status.
 Status ModelConfigToJson(
-    const ModelConfig& config, const uint32_t config_version,
+    const inference::ModelConfig& config, const uint32_t config_version,
     std::string* json_str);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -310,8 +310,8 @@ class ModelRepositoryManager::BackendLifeCycle {
   // be unloaded before loading the specified versions.
   Status AsyncLoad(
       const std::string& repository_path, const std::string& model_name,
-      const std::set<int64_t>& versions, const inference::ModelConfig& model_config,
-      bool force_unload = true,
+      const std::set<int64_t>& versions,
+      const inference::ModelConfig& model_config, bool force_unload = true,
       std::function<void(int64_t, ModelReadyState, size_t)> OnComplete =
           nullptr);
 
@@ -343,7 +343,8 @@ class ModelRepositoryManager::BackendLifeCycle {
   struct BackendInfo {
     BackendInfo(
         const std::string& repository_path, const ModelReadyState state,
-        const ActionType next_action, const inference::ModelConfig& model_config)
+        const ActionType next_action,
+        const inference::ModelConfig& model_config)
         : repository_path_(repository_path),
           platform_(GetPlatform(model_config.platform())), state_(state),
           next_action_(next_action), model_config_(model_config)
@@ -667,8 +668,8 @@ ModelRepositoryManager::BackendLifeCycle::GetInferenceBackend(
 Status
 ModelRepositoryManager::BackendLifeCycle::AsyncLoad(
     const std::string& repository_path, const std::string& model_name,
-    const std::set<int64_t>& versions, const inference::ModelConfig& model_config,
-    bool force_unload,
+    const std::set<int64_t>& versions,
+    const inference::ModelConfig& model_config, bool force_unload,
     std::function<void(int64_t, ModelReadyState, size_t)> OnComplete)
 {
   LOG_VERBOSE(1) << "AsyncLoad() '" << model_name << "'";

--- a/src/core/model_repository_manager.h
+++ b/src/core/model_repository_manager.h
@@ -107,7 +107,7 @@ class ModelRepositoryManager {
     std::string model_name_;
     Status status_;
     bool checked_;
-    ModelConfig model_config_;
+    inference::ModelConfig model_config_;
     std::set<int64_t> loaded_versions_;
     std::set<DependencyNode*> missing_upstreams_;
     std::unordered_map<DependencyNode*, std::set<int64_t>> upstreams_;
@@ -283,7 +283,7 @@ class ModelRepositoryManager {
   /// \param name The model name.
   /// \param model_config Returns the model configuration.
   /// \return OK if found, NOT_FOUND otherwise.
-  Status GetModelConfig(const std::string& name, ModelConfig* model_config);
+  Status GetModelConfig(const std::string& name, inference::ModelConfig* model_config);
 
   /// Get the models to be loaded / unloaded based on the model loaded in
   /// previous iteration.
@@ -311,7 +311,7 @@ class ModelRepositoryManager {
   /// \return The error status.
   Status VersionsToLoad(
       const std::string model_repository_path, const std::string& name,
-      const ModelConfig& model_config, std::set<int64_t>* versions);
+      const inference::ModelConfig& model_config, std::set<int64_t>* versions);
 
   const std::set<std::string> repository_paths_;
   const BackendConfigMap backend_config_map_;

--- a/src/core/model_repository_manager.h
+++ b/src/core/model_repository_manager.h
@@ -283,7 +283,8 @@ class ModelRepositoryManager {
   /// \param name The model name.
   /// \param model_config Returns the model configuration.
   /// \return OK if found, NOT_FOUND otherwise.
-  Status GetModelConfig(const std::string& name, inference::ModelConfig* model_config);
+  Status GetModelConfig(
+      const std::string& name, inference::ModelConfig* model_config);
 
   /// Get the models to be loaded / unloaded based on the model loaded in
   /// previous iteration.

--- a/src/core/scheduler_utils.cc
+++ b/src/core/scheduler_utils.cc
@@ -160,7 +160,7 @@ PriorityQueue::PolicyQueue::ApplyPolicy(
     while (curr_idx < queue_.size()) {
       if ((timeout_timestamp_ns_[curr_idx] != 0) &&
           (now_nanoseconds > timeout_timestamp_ns_[curr_idx])) {
-        if (timeout_action_ == ModelQueuePolicy::DELAY) {
+        if (timeout_action_ == inference::ModelQueuePolicy::DELAY) {
           delayed_queue_.emplace_back(std::move(queue_[curr_idx]));
         } else {
           rejected_queue_.emplace_back(std::move(queue_[curr_idx]));
@@ -225,14 +225,14 @@ PriorityQueue::PolicyQueue::TimeoutAt(size_t idx)
 PriorityQueue::PriorityQueue()
     : size_(0), front_priority_level_(0), last_priority_level_(0)
 {
-  ModelQueuePolicy default_policy;
+  inference::ModelQueuePolicy default_policy;
   queues_.emplace(0, PolicyQueue(default_policy));
   front_priority_level_ = queues_.begin()->first;
   ResetCursor();
 }
 
 PriorityQueue::PriorityQueue(
-    const ModelQueuePolicy& default_queue_policy, uint32_t priority_levels,
+    const inference::ModelQueuePolicy& default_queue_policy, uint32_t priority_levels,
     const ModelQueuePolicyMap queue_policy_map)
     : size_(0), last_priority_level_(priority_levels)
 {

--- a/src/core/scheduler_utils.cc
+++ b/src/core/scheduler_utils.cc
@@ -232,8 +232,8 @@ PriorityQueue::PriorityQueue()
 }
 
 PriorityQueue::PriorityQueue(
-    const inference::ModelQueuePolicy& default_queue_policy, uint32_t priority_levels,
-    const ModelQueuePolicyMap queue_policy_map)
+    const inference::ModelQueuePolicy& default_queue_policy,
+    uint32_t priority_levels, const ModelQueuePolicyMap queue_policy_map)
     : size_(0), last_priority_level_(priority_levels)
 {
   if (priority_levels == 0) {

--- a/src/core/scheduler_utils.h
+++ b/src/core/scheduler_utils.h
@@ -48,7 +48,7 @@ bool CompareWithRequiredEqualInputs(
 // PriorityQueue
 //
 using ModelQueuePolicyMap =
-    ::google::protobuf::Map<::google::protobuf::uint32, ModelQueuePolicy>;
+    ::google::protobuf::Map<::google::protobuf::uint32, inference::ModelQueuePolicy>;
 
 class PriorityQueue {
  public:
@@ -60,7 +60,7 @@ class PriorityQueue {
   // Different priority level may follow different queue policies given by
   // 'queue_policy_map', otherwise, the 'default_queue_policy' will be used.
   PriorityQueue(
-      const ModelQueuePolicy& default_queue_policy, uint32_t priority_levels,
+      const inference::ModelQueuePolicy& default_queue_policy, uint32_t priority_levels,
       const ModelQueuePolicyMap queue_policy_map);
 
   // Enqueue a request with priority set to 'priority_level'. If
@@ -144,13 +144,13 @@ class PriorityQueue {
     // Construct a policy queue with default policy, which will behave the same
     // as regular queue.
     PolicyQueue()
-        : timeout_action_(ModelQueuePolicy::REJECT), default_timeout_us_(0),
+        : timeout_action_(inference::ModelQueuePolicy::REJECT), default_timeout_us_(0),
           allow_timeout_override_(false), max_queue_size_(0)
     {
     }
 
     // Construct a policy queue with given 'policy'.
-    PolicyQueue(const ModelQueuePolicy& policy)
+    PolicyQueue(const inference::ModelQueuePolicy& policy)
         : timeout_action_(policy.timeout_action()),
           default_timeout_us_(policy.default_timeout_microseconds()),
           allow_timeout_override_(policy.allow_timeout_override()),
@@ -201,7 +201,7 @@ class PriorityQueue {
 
    private:
     // Variables that define the policy for the queue
-    const ModelQueuePolicy::TimeoutAction timeout_action_;
+    const inference::ModelQueuePolicy::TimeoutAction timeout_action_;
     const uint64_t default_timeout_us_;
     const bool allow_timeout_override_;
     const uint32_t max_queue_size_;

--- a/src/core/scheduler_utils.h
+++ b/src/core/scheduler_utils.h
@@ -47,8 +47,8 @@ bool CompareWithRequiredEqualInputs(
 //
 // PriorityQueue
 //
-using ModelQueuePolicyMap =
-    ::google::protobuf::Map<::google::protobuf::uint32, inference::ModelQueuePolicy>;
+using ModelQueuePolicyMap = ::google::protobuf::Map<
+    ::google::protobuf::uint32, inference::ModelQueuePolicy>;
 
 class PriorityQueue {
  public:
@@ -60,8 +60,8 @@ class PriorityQueue {
   // Different priority level may follow different queue policies given by
   // 'queue_policy_map', otherwise, the 'default_queue_policy' will be used.
   PriorityQueue(
-      const inference::ModelQueuePolicy& default_queue_policy, uint32_t priority_levels,
-      const ModelQueuePolicyMap queue_policy_map);
+      const inference::ModelQueuePolicy& default_queue_policy,
+      uint32_t priority_levels, const ModelQueuePolicyMap queue_policy_map);
 
   // Enqueue a request with priority set to 'priority_level'. If
   // Status::Success is returned then the queue has taken ownership of
@@ -144,8 +144,9 @@ class PriorityQueue {
     // Construct a policy queue with default policy, which will behave the same
     // as regular queue.
     PolicyQueue()
-        : timeout_action_(inference::ModelQueuePolicy::REJECT), default_timeout_us_(0),
-          allow_timeout_override_(false), max_queue_size_(0)
+        : timeout_action_(inference::ModelQueuePolicy::REJECT),
+          default_timeout_us_(0), allow_timeout_override_(false),
+          max_queue_size_(0)
     {
     }
 

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -150,9 +150,10 @@ namespace {
 
 Status
 GetBooleanOverrideInputs(
-    const std::string& tensor_name, const bool support_batching, const inference::DataType tensor_datatype,
-    const float fp32_false_value, const float fp32_true_value,
-    const int32_t int32_false_value, const int32_t int32_true_value,
+    const std::string& tensor_name, const bool support_batching,
+    const inference::DataType tensor_datatype, const float fp32_false_value,
+    const float fp32_true_value, const int32_t int32_false_value,
+    const int32_t int32_true_value,
     std::shared_ptr<InferenceRequest::Input>* true_override,
     std::shared_ptr<InferenceRequest::Input>* false_override)
 {

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -39,7 +39,7 @@ namespace nvidia { namespace inferenceserver {
 
 Status
 SequenceBatchScheduler::Create(
-    const ModelConfig& config, const uint32_t runner_cnt,
+    const inference::ModelConfig& config, const uint32_t runner_cnt,
     const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
     const StandardRunFunc& OnSchedule,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
@@ -150,10 +150,9 @@ namespace {
 
 Status
 GetBooleanOverrideInputs(
-    const std::string& tensor_name, const bool support_batching,
-    const DataType tensor_datatype, const float fp32_false_value,
-    const float fp32_true_value, const int32_t int32_false_value,
-    const int32_t int32_true_value,
+    const std::string& tensor_name, const bool support_batching, const inference::DataType tensor_datatype,
+    const float fp32_false_value, const float fp32_true_value,
+    const int32_t int32_false_value, const int32_t int32_true_value,
     std::shared_ptr<InferenceRequest::Input>* true_override,
     std::shared_ptr<InferenceRequest::Input>* false_override)
 {
@@ -191,7 +190,7 @@ GetBooleanOverrideInputs(
         "failed to allocate sequence control signal in CPU memory");
   }
 
-  if (tensor_datatype == DataType::TYPE_INT32) {
+  if (tensor_datatype == inference::DataType::TYPE_INT32) {
     *(reinterpret_cast<int32_t*>(true_p_ptr)) = int32_true_value;
     *(reinterpret_cast<int32_t*>(false_p_ptr)) = int32_false_value;
   } else {
@@ -221,7 +220,7 @@ GetBooleanOverrideInputs(
 
 Status
 SequenceBatchScheduler::CreateBooleanControlTensors(
-    const ModelConfig& config,
+    const inference::ModelConfig& config,
     std::shared_ptr<ControlInputs>* start_input_overrides,
     std::shared_ptr<ControlInputs>* end_input_overrides,
     std::shared_ptr<ControlInputs>* startend_input_overrides,
@@ -237,7 +236,7 @@ SequenceBatchScheduler::CreateBooleanControlTensors(
   *notready_input_overrides = std::make_shared<ControlInputs>();
 
   std::string tensor_name;
-  DataType tensor_datatype;
+  inference::DataType tensor_datatype;
   int32_t int32_false_value, int32_true_value;
   float fp32_false_value, fp32_true_value;
 
@@ -245,7 +244,7 @@ SequenceBatchScheduler::CreateBooleanControlTensors(
   {
     RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
         config.sequence_batching(), config.name(),
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_START,
         false /* required */, &tensor_name, &tensor_datatype, &fp32_false_value,
         &fp32_true_value, &int32_false_value, &int32_true_value));
     if (!tensor_name.empty()) {
@@ -269,7 +268,7 @@ SequenceBatchScheduler::CreateBooleanControlTensors(
   {
     RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
         config.sequence_batching(), config.name(),
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_END,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_END,
         false /* required */, &tensor_name, &tensor_datatype, &fp32_false_value,
         &fp32_true_value, &int32_false_value, &int32_true_value));
     if (!tensor_name.empty()) {
@@ -293,7 +292,7 @@ SequenceBatchScheduler::CreateBooleanControlTensors(
   {
     RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
         config.sequence_batching(), config.name(),
-        ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY,
+        inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_READY,
         false /* required */, &tensor_name, &tensor_datatype, &fp32_false_value,
         &fp32_true_value, &int32_false_value, &int32_true_value));
     if (!tensor_name.empty()) {
@@ -684,16 +683,16 @@ SequenceBatch::SequenceBatch(
 }
 
 bool
-SequenceBatch::CreateCorrelationIDControl(const ModelConfig& config)
+SequenceBatch::CreateCorrelationIDControl(const inference::ModelConfig& config)
 {
   // If model wants CORRID control then get the name of the input
   // tensor and initialize the override structure for each sequence
   // slot that is used to communicate the correlation ID.
   std::string correlation_id_tensor_name;
-  DataType correlation_id_datatype;
+  inference::DataType correlation_id_datatype;
   Status corrid_status = GetTypedSequenceControlProperties(
       config.sequence_batching(), config.name(),
-      ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID,
+      inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID,
       false /* required */, &correlation_id_tensor_name,
       &correlation_id_datatype);
   if (!corrid_status.IsOk()) {
@@ -704,14 +703,14 @@ SequenceBatch::CreateCorrelationIDControl(const ModelConfig& config)
   }
 
   if (!correlation_id_tensor_name.empty()) {
-    if ((correlation_id_datatype != TYPE_UINT64) &&
-        (correlation_id_datatype != TYPE_INT64) &&
-        (correlation_id_datatype != TYPE_UINT32) &&
-        (correlation_id_datatype != TYPE_INT32)) {
+    if ((correlation_id_datatype != inference::DataType::TYPE_UINT64) &&
+        (correlation_id_datatype != inference::DataType::TYPE_INT64) &&
+        (correlation_id_datatype != inference::DataType::TYPE_UINT32) &&
+        (correlation_id_datatype != inference::DataType::TYPE_INT32)) {
       LOG_ERROR << "unexpected control data type, expected TYPE_UINT64, "
                    "TYPE_INT64, TYPE_UINT32 or TYPE_INT32 for "
-                << ModelSequenceBatching_Control_Kind_Name(
-                       ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID)
+                << inference::ModelSequenceBatching_Control_Kind_Name(
+                       inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID)
                 << " for " << config.name();
       return false;
     }
@@ -805,7 +804,7 @@ SequenceBatch::SetControlTensors(
 
 DirectSequenceBatch::DirectSequenceBatch(
     SequenceBatchScheduler* base, const uint32_t batcher_idx,
-    const size_t seq_slot_cnt, const ModelConfig& config,
+    const size_t seq_slot_cnt, const inference::ModelConfig& config,
     const Scheduler::StandardInitFunc& OnInit,
     const Scheduler::StandardWarmupFunc& OnWarmup,
     const Scheduler::StandardRunFunc& OnSchedule,
@@ -1180,7 +1179,7 @@ DirectSequenceBatch::SchedulerThread(
 
 OldestSequenceBatch::OldestSequenceBatch(
     SequenceBatchScheduler* base, const uint32_t batcher_idx,
-    const size_t seq_slot_cnt, const ModelConfig& config,
+    const size_t seq_slot_cnt, const inference::ModelConfig& config,
     const Scheduler::StandardInitFunc& OnInit,
     const Scheduler::StandardWarmupFunc& OnWarmup,
     const Scheduler::StandardRunFunc& OnSchedule,

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -710,7 +710,8 @@ SequenceBatch::CreateCorrelationIDControl(const inference::ModelConfig& config)
       LOG_ERROR << "unexpected control data type, expected TYPE_UINT64, "
                    "TYPE_INT64, TYPE_UINT32 or TYPE_INT32 for "
                 << inference::ModelSequenceBatching_Control_Kind_Name(
-                       inference::ModelSequenceBatching::Control::CONTROL_SEQUENCE_CORRID)
+                       inference::ModelSequenceBatching::Control::
+                           CONTROL_SEQUENCE_CORRID)
                 << " for " << config.name();
       return false;
     }

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -56,7 +56,7 @@ class SequenceBatchScheduler : public Scheduler {
   // Create a scheduler to support a given number of runners and a run
   // function to call when a request is scheduled.
   static Status Create(
-      const ModelConfig& config, const uint32_t runner_cnt,
+      const inference::ModelConfig& config, const uint32_t runner_cnt,
       const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
       const StandardRunFunc& OnSchedule,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
@@ -90,7 +90,7 @@ class SequenceBatchScheduler : public Scheduler {
   void ReaperThread(const int nice);
 
   Status CreateBooleanControlTensors(
-      const ModelConfig& config,
+      const inference::ModelConfig& config,
       std::shared_ptr<ControlInputs>* start_input_overrides,
       std::shared_ptr<ControlInputs>* end_input_overrides,
       std::shared_ptr<ControlInputs>* startend_input_overrides,
@@ -182,7 +182,7 @@ class SequenceBatch {
       std::unique_ptr<InferenceRequest>& request) = 0;
 
  protected:
-  bool CreateCorrelationIDControl(const ModelConfig& config);
+  bool CreateCorrelationIDControl(const inference::ModelConfig& config);
   void SetControlTensors(
       std::unique_ptr<InferenceRequest>& irequest, const int32_t seq_slot,
       const uint64_t corr_id, const bool not_ready = false);
@@ -230,7 +230,7 @@ class DirectSequenceBatch : public SequenceBatch {
  public:
   DirectSequenceBatch(
       SequenceBatchScheduler* base, const uint32_t batcher_idx,
-      const size_t seq_slot_cnt, const ModelConfig& config,
+      const size_t seq_slot_cnt, const inference::ModelConfig& config,
       const Scheduler::StandardInitFunc& OnInit,
       const Scheduler::StandardWarmupFunc& OnWarmup,
       const Scheduler::StandardRunFunc& OnSchedule,
@@ -296,7 +296,7 @@ class OldestSequenceBatch : public SequenceBatch {
  public:
   OldestSequenceBatch(
       SequenceBatchScheduler* base, const uint32_t batcher_idx,
-      const size_t seq_slot_cnt, const ModelConfig& config,
+      const size_t seq_slot_cnt, const inference::ModelConfig& config,
       const Scheduler::StandardInitFunc& OnInit,
       const Scheduler::StandardWarmupFunc& OnWarmup,
       const Scheduler::StandardRunFunc& OnSchedule,

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -410,7 +410,7 @@ TRITONSERVER_DataType
 TRITONSERVER_StringToDataType(const char* dtype)
 {
   const size_t len = strlen(dtype);
-  return DataTypeToTriton(ni::ProtocolStringToDataType(dtype, len));
+  return ni::DataTypeToTriton(ni::ProtocolStringToDataType(dtype, len));
 }
 
 uint32_t
@@ -1436,7 +1436,7 @@ TRITONSERVER_InferenceResponseOutput(
   const ni::InferenceResponse::Output& output = outputs[index];
 
   *name = output.Name().c_str();
-  *datatype = DataTypeToTriton(output.DType());
+  *datatype = ni::DataTypeToTriton(output.DType());
 
   const std::vector<int64_t>& oshape = output.Shape();
   *shape = &oshape[0];
@@ -1920,7 +1920,7 @@ TRITONSERVER_ServerModelConfig(
 
   std::string model_config_json;
   RETURN_IF_STATUS_ERROR(
-      ModelConfigToJson(backend->Config(), config_version, &model_config_json));
+      ni::ModelConfigToJson(backend->Config(), config_version, &model_config_json));
 
   *model_config = reinterpret_cast<TRITONSERVER_Message*>(
       new ni::TritonServerMessage(std::move(model_config_json)));

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -1919,8 +1919,8 @@ TRITONSERVER_ServerModelConfig(
       lserver->GetInferenceBackend(model_name, model_version, &backend));
 
   std::string model_config_json;
-  RETURN_IF_STATUS_ERROR(
-      ni::ModelConfigToJson(backend->Config(), config_version, &model_config_json));
+  RETURN_IF_STATUS_ERROR(ni::ModelConfigToJson(
+      backend->Config(), config_version, &model_config_json));
 
   *model_config = reinterpret_cast<TRITONSERVER_Message*>(
       new ni::TritonServerMessage(std::move(model_config_json)));

--- a/src/core/tritonserver.h
+++ b/src/core/tritonserver.h
@@ -571,7 +571,7 @@ typedef void (*TRITONSERVER_InferenceTraceReleaseFn_t)(
 /// The release callback is called for both 'trace' and for any child
 /// traces spawned by 'trace'.
 ///
-/// \param trace Returns the new infernece trace object.
+/// \param trace Returns the new inference trace object.
 /// \param level The tracing level.
 /// \param parent_id The parent trace id for this trace. A value of 0
 /// indicates that there is not parent trace.

--- a/src/custom/dyna_sequence/dyna_sequence.cc
+++ b/src/custom/dyna_sequence/dyna_sequence.cc
@@ -68,7 +68,7 @@ namespace dyna_sequence {
 class Context : public CustomInstance {
  public:
   Context(
-      const std::string& instance_name, const ModelConfig& config,
+      const std::string& instance_name, const inference::ModelConfig& config,
       const int gpu_device);
   ~Context();
 
@@ -122,8 +122,8 @@ class Context : public CustomInstance {
 };
 
 Context::Context(
-    const std::string& instance_name, const ModelConfig& model_config,
-    const int gpu_device)
+    const std::string& instance_name,
+    const inference::ModelConfig& model_config, const int gpu_device)
     : CustomInstance(instance_name, model_config, gpu_device),
       execute_delay_ms_(0)
 {
@@ -155,7 +155,8 @@ Context::Init()
 
   auto& batcher = model_config_.sequence_batching();
 
-  std::unordered_map<std::string, const ModelSequenceBatching::ControlInput*>
+  std::unordered_map<
+      std::string, const inference::ModelSequenceBatching::ControlInput*>
       controls;
   for (const auto& ci : batcher.control_input()) {
     controls.insert({ci.name(), &ci});
@@ -174,7 +175,7 @@ Context::Init()
 
   // The CORRID input must be UINT64 type.
   if (controls.find("CORRID")->second->control(0).data_type() !=
-      DataType::TYPE_UINT64) {
+      inference::DataType::TYPE_UINT64) {
     return kCorrIDType;
   }
 
@@ -184,7 +185,7 @@ Context::Init()
       (model_config_.input(0).dims().size() != 1)) {
     return kInput;
   }
-  if (model_config_.input(0).data_type() != DataType::TYPE_INT32) {
+  if (model_config_.input(0).data_type() != inference::DataType::TYPE_INT32) {
     return kInputOutputDataType;
   }
   if (model_config_.input(0).name() != "INPUT") {
@@ -198,7 +199,7 @@ Context::Init()
       (model_config_.output(0).dims(0) != model_config_.input(0).dims(0))) {
     return kOutput;
   }
-  if (model_config_.output(0).data_type() != DataType::TYPE_INT32) {
+  if (model_config_.output(0).data_type() != inference::DataType::TYPE_INT32) {
     return kInputOutputDataType;
   }
   if (model_config_.output(0).name() != "OUTPUT") {
@@ -283,8 +284,10 @@ Context::Execute(
       continue;
     }
 
-    const size_t batch1_byte_size = GetDataTypeByteSize(TYPE_INT32);
-    const size_t batch1_corrid_byte_size = GetDataTypeByteSize(TYPE_UINT64);
+    const size_t batch1_byte_size =
+        GetDataTypeByteSize(inference::DataType::TYPE_INT32);
+    const size_t batch1_corrid_byte_size =
+        GetDataTypeByteSize(inference::DataType::TYPE_UINT64);
     int64_t input_element_cnt = 0;
 
     // Get the number of elements in the input tensor.
@@ -424,7 +427,7 @@ Context::Execute(
 int
 CustomInstance::Create(
     CustomInstance** instance, const std::string& name,
-    const ModelConfig& model_config, int gpu_device,
+    const inference::ModelConfig& model_config, int gpu_device,
     const CustomInitializeData* data)
 {
   dyna_sequence::Context* context =

--- a/src/custom/identity/identity.cc
+++ b/src/custom/identity/identity.cc
@@ -53,7 +53,7 @@ namespace identity {
 class Context : public CustomInstance {
  public:
   Context(
-      const std::string& instance_name, const ModelConfig& config,
+      const std::string& instance_name, const inference::ModelConfig& config,
       const int gpu_device);
   ~Context() = default;
 
@@ -79,7 +79,7 @@ class Context : public CustomInstance {
 
   struct CopyInfo {
     std::string input_name_;
-    DataType datatype_;
+    inference::DataType datatype_;
   };
 
 #ifdef TRITON_ENABLE_GPU
@@ -108,8 +108,8 @@ class Context : public CustomInstance {
 };
 
 Context::Context(
-    const std::string& instance_name, const ModelConfig& model_config,
-    const int gpu_device)
+    const std::string& instance_name,
+    const inference::ModelConfig& model_config, const int gpu_device)
     : CustomInstance(instance_name, model_config, gpu_device),
       execute_delay_ms_(0)
 {
@@ -235,7 +235,7 @@ Context::Execute(
       }
 
       const std::string& input_name = itr->second.input_name_;
-      const DataType datatype = itr->second.datatype_;
+      const inference::DataType datatype = itr->second.datatype_;
 
       std::vector<int64_t> shape;
       if (model_config_.max_batch_size() != 0) {
@@ -390,7 +390,7 @@ Context::Execute(
       }
 
       const std::string& input_name = itr->second.input_name_;
-      const DataType datatype = itr->second.datatype_;
+      const inference::DataType datatype = itr->second.datatype_;
 
       std::vector<int64_t> shape;
       if (model_config_.max_batch_size() != 0) {
@@ -461,7 +461,7 @@ Context::Execute(
 int
 CustomInstance::Create(
     CustomInstance** instance, const std::string& name,
-    const ModelConfig& model_config, int gpu_device,
+    const inference::ModelConfig& model_config, int gpu_device,
     const CustomInitializeData* data)
 {
   identity::Context* ctx =

--- a/src/custom/param/param.cc
+++ b/src/custom/param/param.cc
@@ -60,7 +60,7 @@ enum ErrorCodes {
 class Context : public CustomInstance {
  public:
   Context(
-      const std::string& instance_name, const ModelConfig& config,
+      const std::string& instance_name, const inference::ModelConfig& config,
       const int gpu_device, const size_t server_parameter_cnt,
       const char** server_parameters);
 
@@ -88,9 +88,9 @@ class Context : public CustomInstance {
 };
 
 Context::Context(
-    const std::string& instance_name, const ModelConfig& model_config,
-    const int gpu_device, const size_t server_parameter_cnt,
-    const char** server_parameters)
+    const std::string& instance_name,
+    const inference::ModelConfig& model_config, const int gpu_device,
+    const size_t server_parameter_cnt, const char** server_parameters)
     : CustomInstance(instance_name, model_config, gpu_device)
 {
   // Must make a copy of server_parameters since we don't own those
@@ -118,7 +118,7 @@ Context::Init()
   if (model_config_.input(0).dims(0) != 1) {
     return kInput;
   }
-  if (model_config_.input(0).data_type() != DataType::TYPE_INT32) {
+  if (model_config_.input(0).data_type() != inference::DataType::TYPE_INT32) {
     return kInput;
   }
 
@@ -134,7 +134,7 @@ Context::Init()
     return kOutput;
   }
 
-  if (model_config_.output(0).data_type() != DataType::TYPE_STRING) {
+  if (model_config_.output(0).data_type() != inference::DataType::TYPE_STRING) {
     return kOutput;
   }
 
@@ -189,7 +189,8 @@ Context::Execute(
     // If 'content' returns nullptr or if the content is not the
     // expected size, then something went wrong.
     if ((content == nullptr) ||
-        (content_byte_size != GetDataTypeByteSize(DataType::TYPE_INT32))) {
+        (content_byte_size !=
+         GetDataTypeByteSize(inference::DataType::TYPE_INT32))) {
       return kInputContents;
     }
 
@@ -250,7 +251,7 @@ Context::Execute(
 int
 CustomInstance::Create(
     CustomInstance** instance, const std::string& name,
-    const ModelConfig& model_config, int gpu_device,
+    const inference::ModelConfig& model_config, int gpu_device,
     const CustomInitializeData* data)
 {
   param::Context* context = new param::Context(

--- a/src/custom/sdk/custom_instance.cc
+++ b/src/custom/sdk/custom_instance.cc
@@ -29,8 +29,8 @@
 namespace nvidia { namespace inferenceserver { namespace custom {
 
 CustomInstance::CustomInstance(
-    const std::string& instance_name, const ModelConfig& model_config,
-    int gpu_device)
+    const std::string& instance_name,
+    const inference::ModelConfig& model_config, int gpu_device)
     : instance_name_(instance_name), model_config_(model_config),
       gpu_device_(gpu_device)
 {
@@ -44,7 +44,7 @@ int
 CustomInitialize(const CustomInitializeData* data, void** custom_instance)
 {
   // Convert the serialized model config to a ModelConfig object.
-  ModelConfig model_config;
+  inference::ModelConfig model_config;
   if (!model_config.ParseFromString(std::string(
           data->serialized_model_config, data->serialized_model_config_size))) {
     return ErrorCodes::InvalidModelConfig;

--- a/src/custom/sdk/custom_instance.h
+++ b/src/custom/sdk/custom_instance.h
@@ -58,7 +58,7 @@ class CustomInstance {
   /// \return Error code indicating success or the type of failure
   static int Create(
       CustomInstance** instance, const std::string& name,
-      const ModelConfig& model_config, int gpu_device,
+      const inference::ModelConfig& model_config, int gpu_device,
       const CustomInitializeData* data);
 
   virtual ~CustomInstance() = default;
@@ -114,8 +114,8 @@ class CustomInstance {
   /// \param gpu_device The GPU device ID
   /// \return Error code indicating success or the type of failure
   CustomInstance(
-      const std::string& instance_name, const ModelConfig& model_config,
-      int gpu_device);
+      const std::string& instance_name,
+      const inference::ModelConfig& model_config, int gpu_device);
 
   /// Register a custom error and error message.
   ///
@@ -130,7 +130,7 @@ class CustomInstance {
   const std::string instance_name_;
 
   /// The model configuration
-  const ModelConfig model_config_;
+  const inference::ModelConfig model_config_;
 
   /// The GPU device ID to execute on or CUSTOM_NO_GPU_DEVICE if should
   /// execute on CPU.

--- a/src/custom/sequence/sequence.cc
+++ b/src/custom/sequence/sequence.cc
@@ -62,7 +62,7 @@ namespace sequence {
 class Context : public CustomInstance {
  public:
   Context(
-      const std::string& instance_name, const ModelConfig& config,
+      const std::string& instance_name, const inference::ModelConfig& config,
       const int gpu_device);
   ~Context();
 
@@ -111,8 +111,8 @@ class Context : public CustomInstance {
 };
 
 Context::Context(
-    const std::string& instance_name, const ModelConfig& model_config,
-    const int gpu_device)
+    const std::string& instance_name,
+    const inference::ModelConfig& model_config, const int gpu_device)
     : CustomInstance(instance_name, model_config, gpu_device),
       execute_delay_ms_(0)
 {
@@ -160,7 +160,7 @@ Context::Init()
       (model_config_.input(0).dims().size() != 1)) {
     return kInput;
   }
-  if (model_config_.input(0).data_type() != DataType::TYPE_INT32) {
+  if (model_config_.input(0).data_type() != inference::DataType::TYPE_INT32) {
     return kInputOutputDataType;
   }
   if (model_config_.input(0).name() != "INPUT") {
@@ -174,7 +174,7 @@ Context::Init()
       (model_config_.output(0).dims(0) != model_config_.input(0).dims(0))) {
     return kOutput;
   }
-  if (model_config_.output(0).data_type() != DataType::TYPE_INT32) {
+  if (model_config_.output(0).data_type() != inference::DataType::TYPE_INT32) {
     return kInputOutputDataType;
   }
   if (model_config_.output(0).name() != "OUTPUT") {
@@ -260,7 +260,8 @@ Context::Execute(
       continue;
     }
 
-    const size_t batch1_byte_size = GetDataTypeByteSize(TYPE_INT32);
+    const size_t batch1_byte_size =
+        GetDataTypeByteSize(inference::DataType::TYPE_INT32);
     int64_t input_element_cnt = 0;
 
     // Get the number of elements in the input tensor.
@@ -361,7 +362,7 @@ Context::Execute(
 int
 CustomInstance::Create(
     CustomInstance** instance, const std::string& name,
-    const ModelConfig& model_config, int gpu_device,
+    const inference::ModelConfig& model_config, int gpu_device,
     const CustomInitializeData* data)
 {
   sequence::Context* context =

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -292,7 +292,7 @@ class CommonHandler : public GRPCServer::HandlerBase {
       const std::string& name,
       const std::shared_ptr<TRITONSERVER_Server>& tritonserver,
       const std::shared_ptr<SharedMemoryManager>& shm_manager,
-      GRPCInferenceService::AsyncService* service,
+      inference::GRPCInferenceService::AsyncService* service,
       grpc::ServerCompletionQueue* cq);
 
   // Descriptive name of of the handler.
@@ -312,7 +312,7 @@ class CommonHandler : public GRPCServer::HandlerBase {
 
   std::shared_ptr<SharedMemoryManager> shm_manager_;
 
-  GRPCInferenceService::AsyncService* service_;
+  inference::GRPCInferenceService::AsyncService* service_;
   grpc::ServerCompletionQueue* cq_;
   std::unique_ptr<std::thread> thread_;
 };
@@ -321,7 +321,7 @@ CommonHandler::CommonHandler(
     const std::string& name,
     const std::shared_ptr<TRITONSERVER_Server>& tritonserver,
     const std::shared_ptr<SharedMemoryManager>& shm_manager,
-    GRPCInferenceService::AsyncService* service,
+    inference::GRPCInferenceService::AsyncService* service,
     grpc::ServerCompletionQueue* cq)
     : name_(name), tritonserver_(tritonserver), shm_manager_(shm_manager),
       service_(service), cq_(cq)
@@ -385,16 +385,16 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterServerLive =
       [this](
-          grpc::ServerContext* ctx, ServerLiveRequest* request,
-          grpc::ServerAsyncResponseWriter<ServerLiveResponse>* responder,
+          grpc::ServerContext* ctx, inference::ServerLiveRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::ServerLiveResponse>* responder,
           void* tag) {
         this->service_->RequestServerLive(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
   auto OnExecuteServerLive = [this](
-                                 ServerLiveRequest& request,
-                                 ServerLiveResponse* response,
+                                 inference::ServerLiveRequest& request,
+                                 inference::ServerLiveResponse* response,
                                  grpc::Status* status) {
     bool live = false;
     TRITONSERVER_Error* err =
@@ -407,8 +407,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<ServerLiveResponse>, ServerLiveRequest,
-      ServerLiveResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ServerLiveResponse>, inference::ServerLiveRequest,
+      inference::ServerLiveResponse>(
       "ServerLive", 0, OnRegisterServerLive, OnExecuteServerLive);
 
   //
@@ -416,16 +416,16 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterServerReady =
       [this](
-          grpc::ServerContext* ctx, ServerReadyRequest* request,
-          grpc::ServerAsyncResponseWriter<ServerReadyResponse>* responder,
+          grpc::ServerContext* ctx, inference::ServerReadyRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::ServerReadyResponse>* responder,
           void* tag) {
         this->service_->RequestServerReady(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
   auto OnExecuteServerReady = [this](
-                                  ServerReadyRequest& request,
-                                  ServerReadyResponse* response,
+                                  inference::ServerReadyRequest& request,
+                                  inference::ServerReadyResponse* response,
                                   grpc::Status* status) {
     bool ready = false;
     TRITONSERVER_Error* err =
@@ -438,8 +438,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<ServerReadyResponse>, ServerReadyRequest,
-      ServerReadyResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ServerReadyResponse>, inference::ServerReadyRequest,
+      inference::ServerReadyResponse>(
       "ServerReady", 0, OnRegisterServerReady, OnExecuteServerReady);
 
   //
@@ -447,16 +447,16 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterModelReady =
       [this](
-          grpc::ServerContext* ctx, ModelReadyRequest* request,
-          grpc::ServerAsyncResponseWriter<ModelReadyResponse>* responder,
+          grpc::ServerContext* ctx, inference::ModelReadyRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::ModelReadyResponse>* responder,
           void* tag) {
         this->service_->RequestModelReady(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
   auto OnExecuteModelReady = [this](
-                                 ModelReadyRequest& request,
-                                 ModelReadyResponse* response,
+                                 inference::ModelReadyRequest& request,
+                                 inference::ModelReadyResponse* response,
                                  grpc::Status* status) {
     bool is_ready = false;
     int64_t requested_model_version;
@@ -475,8 +475,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<ModelReadyResponse>, ModelReadyRequest,
-      ModelReadyResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ModelReadyResponse>, inference::ModelReadyRequest,
+      inference::ModelReadyResponse>(
       "ModelReady", 0, OnRegisterModelReady, OnExecuteModelReady);
 
   //
@@ -484,16 +484,16 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterServerMetadata =
       [this](
-          grpc::ServerContext* ctx, ServerMetadataRequest* request,
-          grpc::ServerAsyncResponseWriter<ServerMetadataResponse>* responder,
+          grpc::ServerContext* ctx, inference::ServerMetadataRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::ServerMetadataResponse>* responder,
           void* tag) {
         this->service_->RequestServerMetadata(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
   auto OnExecuteServerMetadata = [this](
-                                     ServerMetadataRequest& request,
-                                     ServerMetadataResponse* response,
+                                     inference::ServerMetadataRequest& request,
+                                     inference::ServerMetadataResponse* response,
                                      grpc::Status* status) {
     TRITONSERVER_Message* server_metadata_message = nullptr;
     TRITONSERVER_Error* err = TRITONSERVER_ServerMetadata(
@@ -548,8 +548,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<ServerMetadataResponse>,
-      ServerMetadataRequest, ServerMetadataResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ServerMetadataResponse>,
+      inference::ServerMetadataRequest, inference::ServerMetadataResponse>(
       "ServerMetadata", 0, OnRegisterServerMetadata, OnExecuteServerMetadata);
 
   //
@@ -557,16 +557,16 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterModelMetadata =
       [this](
-          grpc::ServerContext* ctx, ModelMetadataRequest* request,
-          grpc::ServerAsyncResponseWriter<ModelMetadataResponse>* responder,
+          grpc::ServerContext* ctx, inference::ModelMetadataRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::ModelMetadataResponse>* responder,
           void* tag) {
         this->service_->RequestModelMetadata(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
   auto OnExecuteModelMetadata = [this](
-                                    ModelMetadataRequest& request,
-                                    ModelMetadataResponse* response,
+                                    inference::ModelMetadataRequest& request,
+                                    inference::ModelMetadataResponse* response,
                                     grpc::Status* status) {
     int64_t requested_model_version;
     auto err =
@@ -628,7 +628,7 @@ CommonHandler::SetUpAllRequests()
           err = inputs_json.IndexAsObject(idx, &io_json);
           GOTO_IF_ERR(err, earlyexit);
 
-          ModelMetadataResponse::TensorMetadata* io = response->add_inputs();
+          inference::ModelMetadataResponse::TensorMetadata* io = response->add_inputs();
 
           const char* name;
           size_t namelen;
@@ -669,7 +669,7 @@ CommonHandler::SetUpAllRequests()
           err = outputs_json.IndexAsObject(idx, &io_json);
           GOTO_IF_ERR(err, earlyexit);
 
-          ModelMetadataResponse::TensorMetadata* io = response->add_outputs();
+          inference::ModelMetadataResponse::TensorMetadata* io = response->add_outputs();
 
           const char* name;
           size_t namelen;
@@ -709,8 +709,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<ModelMetadataResponse>,
-      ModelMetadataRequest, ModelMetadataResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ModelMetadataResponse>,
+      inference::ModelMetadataRequest, inference::ModelMetadataResponse>(
       "ModelMetadata", 0, OnRegisterModelMetadata, OnExecuteModelMetadata);
 
   //
@@ -718,16 +718,16 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterModelConfig =
       [this](
-          grpc::ServerContext* ctx, ModelConfigRequest* request,
-          grpc::ServerAsyncResponseWriter<ModelConfigResponse>* responder,
+          grpc::ServerContext* ctx, inference::ModelConfigRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::ModelConfigResponse>* responder,
           void* tag) {
         this->service_->RequestModelConfig(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
   auto OnExecuteModelConfig = [this](
-                                  ModelConfigRequest& request,
-                                  ModelConfigResponse* response,
+                                  inference::ModelConfigRequest& request,
+                                  inference::ModelConfigResponse* response,
                                   grpc::Status* status) {
     int64_t requested_model_version;
     auto err =
@@ -755,8 +755,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<ModelConfigResponse>, ModelConfigRequest,
-      ModelConfigResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ModelConfigResponse>, inference::ModelConfigRequest,
+      inference::ModelConfigResponse>(
       "ModelConfig", 0, OnRegisterModelConfig, OnExecuteModelConfig);
 
   //
@@ -764,16 +764,16 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterModelStatistics =
       [this](
-          grpc::ServerContext* ctx, ModelStatisticsRequest* request,
-          grpc::ServerAsyncResponseWriter<ModelStatisticsResponse>* responder,
+          grpc::ServerContext* ctx, inference::ModelStatisticsRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::ModelStatisticsResponse>* responder,
           void* tag) {
         this->service_->RequestModelStatistics(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
   auto OnExecuteModelStatistics = [this](
-                                      ModelStatisticsRequest& request,
-                                      ModelStatisticsResponse* response,
+                                      inference::ModelStatisticsRequest& request,
+                                      inference::ModelStatisticsResponse* response,
                                       grpc::Status* status) {
 #ifdef TRITON_ENABLE_STATS
     TritonJson::Value model_stats_json;
@@ -1016,8 +1016,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<ModelStatisticsResponse>,
-      ModelStatisticsRequest, ModelStatisticsResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ModelStatisticsResponse>,
+      inference::ModelStatisticsRequest, inference::ModelStatisticsResponse>(
       "ModelStatistics", 0, OnRegisterModelStatistics,
       OnExecuteModelStatistics);
 
@@ -1027,8 +1027,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterSystemSharedMemoryStatus =
       [this](
-          grpc::ServerContext* ctx, SystemSharedMemoryStatusRequest* request,
-          grpc::ServerAsyncResponseWriter<SystemSharedMemoryStatusResponse>*
+          grpc::ServerContext* ctx, inference::SystemSharedMemoryStatusRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryStatusResponse>*
               responder,
           void* tag) {
         this->service_->RequestSystemSharedMemoryStatus(
@@ -1037,8 +1037,8 @@ CommonHandler::SetUpAllRequests()
 
   auto OnExecuteSystemSharedMemoryStatus =
       [this](
-          SystemSharedMemoryStatusRequest& request,
-          SystemSharedMemoryStatusResponse* response, grpc::Status* status) {
+          inference::SystemSharedMemoryStatusRequest& request,
+          inference::SystemSharedMemoryStatusResponse* response, grpc::Status* status) {
         TritonJson::Value shm_status_json(TritonJson::ValueType::ARRAY);
         TRITONSERVER_Error* err = shm_manager_->GetStatus(
             request.name(), TRITONSERVER_MEMORY_CPU, &shm_status_json);
@@ -1067,7 +1067,7 @@ CommonHandler::SetUpAllRequests()
           err = shm_region_json.MemberAsUInt("byte_size", &byte_size);
           GOTO_IF_ERR(err, earlyexit);
 
-          SystemSharedMemoryStatusResponse::RegionStatus region_status;
+          inference::SystemSharedMemoryStatusResponse::RegionStatus region_status;
           region_status.set_name(std::string(name, namelen));
           region_status.set_key(std::string(key, keylen));
           region_status.set_offset(offset);
@@ -1082,8 +1082,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<SystemSharedMemoryStatusResponse>,
-      SystemSharedMemoryStatusRequest, SystemSharedMemoryStatusResponse>(
+      grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryStatusResponse>,
+      inference::SystemSharedMemoryStatusRequest, inference::SystemSharedMemoryStatusResponse>(
       "SystemSharedMemoryStatus", 0, OnRegisterSystemSharedMemoryStatus,
       OnExecuteSystemSharedMemoryStatus);
 
@@ -1093,8 +1093,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterSystemSharedMemoryRegister =
       [this](
-          grpc::ServerContext* ctx, SystemSharedMemoryRegisterRequest* request,
-          grpc::ServerAsyncResponseWriter<SystemSharedMemoryRegisterResponse>*
+          grpc::ServerContext* ctx, inference::SystemSharedMemoryRegisterRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryRegisterResponse>*
               responder,
           void* tag) {
         this->service_->RequestSystemSharedMemoryRegister(
@@ -1103,8 +1103,8 @@ CommonHandler::SetUpAllRequests()
 
   auto OnExecuteSystemSharedMemoryRegister =
       [this](
-          SystemSharedMemoryRegisterRequest& request,
-          SystemSharedMemoryRegisterResponse* response, grpc::Status* status) {
+          inference::SystemSharedMemoryRegisterRequest& request,
+          inference::SystemSharedMemoryRegisterResponse* response, grpc::Status* status) {
         TRITONSERVER_Error* err = shm_manager_->RegisterSystemSharedMemory(
             request.name(), request.key(), request.offset(),
             request.byte_size());
@@ -1114,8 +1114,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<SystemSharedMemoryRegisterResponse>,
-      SystemSharedMemoryRegisterRequest, SystemSharedMemoryRegisterResponse>(
+      grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryRegisterResponse>,
+      inference::SystemSharedMemoryRegisterRequest, inference::SystemSharedMemoryRegisterResponse>(
       "SystemSharedMemoryRegister", 0, OnRegisterSystemSharedMemoryRegister,
       OnExecuteSystemSharedMemoryRegister);
 
@@ -1126,8 +1126,8 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterSystemSharedMemoryUnregister =
       [this](
           grpc::ServerContext* ctx,
-          SystemSharedMemoryUnregisterRequest* request,
-          grpc::ServerAsyncResponseWriter<SystemSharedMemoryUnregisterResponse>*
+          inference::SystemSharedMemoryUnregisterRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryUnregisterResponse>*
               responder,
           void* tag) {
         this->service_->RequestSystemSharedMemoryUnregister(
@@ -1136,8 +1136,8 @@ CommonHandler::SetUpAllRequests()
 
   auto OnExecuteSystemSharedMemoryUnregister =
       [this](
-          SystemSharedMemoryUnregisterRequest& request,
-          SystemSharedMemoryUnregisterResponse* response,
+          inference::SystemSharedMemoryUnregisterRequest& request,
+          inference::SystemSharedMemoryUnregisterResponse* response,
           grpc::Status* status) {
         TRITONSERVER_Error* err = nullptr;
         if (request.name().empty()) {
@@ -1152,9 +1152,9 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<SystemSharedMemoryUnregisterResponse>,
-      SystemSharedMemoryUnregisterRequest,
-      SystemSharedMemoryUnregisterResponse>(
+      grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryUnregisterResponse>,
+      inference::SystemSharedMemoryUnregisterRequest,
+      inference::SystemSharedMemoryUnregisterResponse>(
       "SystemSharedMemoryUnregister", 0, OnRegisterSystemSharedMemoryUnregister,
       OnExecuteSystemSharedMemoryUnregister);
 
@@ -1164,8 +1164,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterCudaSharedMemoryStatus =
       [this](
-          grpc::ServerContext* ctx, CudaSharedMemoryStatusRequest* request,
-          grpc::ServerAsyncResponseWriter<CudaSharedMemoryStatusResponse>*
+          grpc::ServerContext* ctx, inference::CudaSharedMemoryStatusRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryStatusResponse>*
               responder,
           void* tag) {
         this->service_->RequestCudaSharedMemoryStatus(
@@ -1173,8 +1173,8 @@ CommonHandler::SetUpAllRequests()
       };
   auto OnExecuteCudaSharedMemoryStatus =
       [this](
-          CudaSharedMemoryStatusRequest& request,
-          CudaSharedMemoryStatusResponse* response, grpc::Status* status) {
+          inference::CudaSharedMemoryStatusRequest& request,
+          inference::CudaSharedMemoryStatusResponse* response, grpc::Status* status) {
         TritonJson::Value shm_status_json(TritonJson::ValueType::ARRAY);
         TRITONSERVER_Error* err = shm_manager_->GetStatus(
             request.name(), TRITONSERVER_MEMORY_GPU, &shm_status_json);
@@ -1199,7 +1199,7 @@ CommonHandler::SetUpAllRequests()
           GOTO_IF_ERR(err, earlyexit);
 
 
-          CudaSharedMemoryStatusResponse::RegionStatus region_status;
+          inference::CudaSharedMemoryStatusResponse::RegionStatus region_status;
           region_status.set_name(std::string(name, namelen));
           region_status.set_device_id(device_id);
           region_status.set_byte_size(byte_size);
@@ -1211,8 +1211,8 @@ CommonHandler::SetUpAllRequests()
         TRITONSERVER_ErrorDelete(err);
       };
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<CudaSharedMemoryStatusResponse>,
-      CudaSharedMemoryStatusRequest, CudaSharedMemoryStatusResponse>(
+      grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryStatusResponse>,
+      inference::CudaSharedMemoryStatusRequest, inference::CudaSharedMemoryStatusResponse>(
       "CudaSharedMemoryStatus", 0, OnRegisterCudaSharedMemoryStatus,
       OnExecuteCudaSharedMemoryStatus);
 
@@ -1222,8 +1222,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterCudaSharedMemoryRegister =
       [this](
-          grpc::ServerContext* ctx, CudaSharedMemoryRegisterRequest* request,
-          grpc::ServerAsyncResponseWriter<CudaSharedMemoryRegisterResponse>*
+          grpc::ServerContext* ctx, inference::CudaSharedMemoryRegisterRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryRegisterResponse>*
               responder,
           void* tag) {
         this->service_->RequestCudaSharedMemoryRegister(
@@ -1232,8 +1232,8 @@ CommonHandler::SetUpAllRequests()
 
   auto OnExecuteCudaSharedMemoryRegister =
       [this](
-          CudaSharedMemoryRegisterRequest& request,
-          CudaSharedMemoryRegisterResponse* response, grpc::Status* status) {
+          inference::CudaSharedMemoryRegisterRequest& request,
+          inference::CudaSharedMemoryRegisterResponse* response, grpc::Status* status) {
         TRITONSERVER_Error* err = nullptr;
 #ifdef TRITON_ENABLE_GPU
         err = shm_manager_->RegisterCUDASharedMemory(
@@ -1255,8 +1255,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<CudaSharedMemoryRegisterResponse>,
-      CudaSharedMemoryRegisterRequest, CudaSharedMemoryRegisterResponse>(
+      grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryRegisterResponse>,
+      inference::CudaSharedMemoryRegisterRequest, inference::CudaSharedMemoryRegisterResponse>(
       "CudaSharedMemoryRegister", 0, OnRegisterCudaSharedMemoryRegister,
       OnExecuteCudaSharedMemoryRegister);
 
@@ -1265,8 +1265,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterCudaSharedMemoryUnregister =
       [this](
-          grpc::ServerContext* ctx, CudaSharedMemoryUnregisterRequest* request,
-          grpc::ServerAsyncResponseWriter<CudaSharedMemoryUnregisterResponse>*
+          grpc::ServerContext* ctx, inference::CudaSharedMemoryUnregisterRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryUnregisterResponse>*
               responder,
           void* tag) {
         this->service_->RequestCudaSharedMemoryUnregister(
@@ -1275,8 +1275,8 @@ CommonHandler::SetUpAllRequests()
 
   auto OnExecuteCudaSharedMemoryUnregister =
       [this](
-          CudaSharedMemoryUnregisterRequest& request,
-          CudaSharedMemoryUnregisterResponse* response, grpc::Status* status) {
+          inference::CudaSharedMemoryUnregisterRequest& request,
+          inference::CudaSharedMemoryUnregisterResponse* response, grpc::Status* status) {
         TRITONSERVER_Error* err = nullptr;
         if (request.name().empty()) {
           err = shm_manager_->UnregisterAll(TRITONSERVER_MEMORY_GPU);
@@ -1290,8 +1290,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<CudaSharedMemoryUnregisterResponse>,
-      CudaSharedMemoryUnregisterRequest, CudaSharedMemoryUnregisterResponse>(
+      grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryUnregisterResponse>,
+      inference::CudaSharedMemoryUnregisterRequest, inference::CudaSharedMemoryUnregisterResponse>(
       "CudaSharedMemoryUnregister", 0, OnRegisterCudaSharedMemoryUnregister,
       OnExecuteCudaSharedMemoryUnregister);
 
@@ -1300,16 +1300,16 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterRepositoryIndex =
       [this](
-          grpc::ServerContext* ctx, RepositoryIndexRequest* request,
-          grpc::ServerAsyncResponseWriter<RepositoryIndexResponse>* responder,
+          grpc::ServerContext* ctx, inference::RepositoryIndexRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::RepositoryIndexResponse>* responder,
           void* tag) {
         this->service_->RequestRepositoryIndex(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
   auto OnExecuteRepositoryIndex = [this](
-                                      RepositoryIndexRequest& request,
-                                      RepositoryIndexResponse* response,
+                                      inference::RepositoryIndexRequest& request,
+                                      inference::RepositoryIndexResponse* response,
                                       grpc::Status* status) {
     TRITONSERVER_Error* err = nullptr;
     if (request.repository_name().empty()) {
@@ -1385,8 +1385,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<RepositoryIndexResponse>,
-      RepositoryIndexRequest, RepositoryIndexResponse>(
+      grpc::ServerAsyncResponseWriter<inference::RepositoryIndexResponse>,
+      inference::RepositoryIndexRequest, inference::RepositoryIndexResponse>(
       "RepositoryIndex", 0, OnRegisterRepositoryIndex,
       OnExecuteRepositoryIndex);
 
@@ -1395,8 +1395,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterRepositoryModelLoad =
       [this](
-          grpc::ServerContext* ctx, RepositoryModelLoadRequest* request,
-          grpc::ServerAsyncResponseWriter<RepositoryModelLoadResponse>*
+          grpc::ServerContext* ctx, inference::RepositoryModelLoadRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::RepositoryModelLoadResponse>*
               responder,
           void* tag) {
         this->service_->RequestRepositoryModelLoad(
@@ -1404,8 +1404,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   auto OnExecuteRepositoryModelLoad = [this](
-                                          RepositoryModelLoadRequest& request,
-                                          RepositoryModelLoadResponse* response,
+                                          inference::RepositoryModelLoadRequest& request,
+                                          inference::RepositoryModelLoadResponse* response,
                                           grpc::Status* status) {
     TRITONSERVER_Error* err = nullptr;
     if (request.repository_name().empty()) {
@@ -1422,8 +1422,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<RepositoryModelLoadResponse>,
-      RepositoryModelLoadRequest, RepositoryModelLoadResponse>(
+      grpc::ServerAsyncResponseWriter<inference::RepositoryModelLoadResponse>,
+      inference::RepositoryModelLoadRequest, inference::RepositoryModelLoadResponse>(
       "RepositoryModelLoad", 0, OnRegisterRepositoryModelLoad,
       OnExecuteRepositoryModelLoad);
 
@@ -1432,8 +1432,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterRepositoryModelUnload =
       [this](
-          grpc::ServerContext* ctx, RepositoryModelUnloadRequest* request,
-          grpc::ServerAsyncResponseWriter<RepositoryModelUnloadResponse>*
+          grpc::ServerContext* ctx, inference::RepositoryModelUnloadRequest* request,
+          grpc::ServerAsyncResponseWriter<inference::RepositoryModelUnloadResponse>*
               responder,
           void* tag) {
         this->service_->RequestRepositoryModelUnload(
@@ -1442,8 +1442,8 @@ CommonHandler::SetUpAllRequests()
 
   auto OnExecuteRepositoryModelUnload =
       [this](
-          RepositoryModelUnloadRequest& request,
-          RepositoryModelUnloadResponse* response, grpc::Status* status) {
+          inference::RepositoryModelUnloadRequest& request,
+          inference::RepositoryModelUnloadResponse* response, grpc::Status* status) {
         TRITONSERVER_Error* err = nullptr;
         if (request.repository_name().empty()) {
           err = TRITONSERVER_ServerUnloadModel(
@@ -1459,8 +1459,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<RepositoryModelUnloadResponse>,
-      RepositoryModelUnloadRequest, RepositoryModelUnloadResponse>(
+      grpc::ServerAsyncResponseWriter<inference::RepositoryModelUnloadResponse>,
+      inference::RepositoryModelUnloadRequest, inference::RepositoryModelUnloadResponse>(
       "RepositoryModelUnload", 0, OnRegisterRepositoryModelUnload,
       OnExecuteRepositoryModelUnload);
 }
@@ -2058,7 +2058,7 @@ TRITONSERVER_Error*
 ResponseAllocatorHelper(
     TRITONSERVER_ResponseAllocator* allocator, const char* tensor_name,
     size_t byte_size, TRITONSERVER_MemoryType preferred_memory_type,
-    int64_t preferred_memory_type_id, ModelInferResponse* response,
+    int64_t preferred_memory_type_id, inference::ModelInferResponse* response,
     const ShmMapType& shm_map, void** buffer, void** buffer_userp,
     TRITONSERVER_MemoryType* actual_memory_type, int64_t* actual_memory_type_id)
 {
@@ -2069,7 +2069,7 @@ ResponseAllocatorHelper(
 
   // We add an output contents even if the 'byte_size' == 0 because we
   // expect to have a contents for every output.
-  ModelInferResponse::InferOutputTensor* output_tensor =
+  inference::ModelInferResponse::InferOutputTensor* output_tensor =
       response->add_outputs();
   output_tensor->set_name(tensor_name);
   std::string* raw_output = response->add_raw_output_contents();
@@ -2132,15 +2132,15 @@ InferResponseAlloc(
     void** buffer_userp, TRITONSERVER_MemoryType* actual_memory_type,
     int64_t* actual_memory_type_id)
 {
-  AllocPayload<ModelInferResponse>* payload =
-      reinterpret_cast<AllocPayload<ModelInferResponse>*>(userp);
+  AllocPayload<inference::ModelInferResponse>* payload =
+      reinterpret_cast<AllocPayload<inference::ModelInferResponse>*>(userp);
 
   // ModelInfer RPC expects exactly one response per request. Hence,
   // will be creating and using just one response object.
-  ModelInferResponse* response =
+  inference::ModelInferResponse* response =
       payload->response_queue_->GetNonDecoupledResponse();
   return ResponseAllocatorHelper<
-      AllocPayload<ModelInferResponse>::TensorShmMap>(
+      AllocPayload<inference::ModelInferResponse>::TensorShmMap>(
       allocator, tensor_name, byte_size, preferred_memory_type,
       preferred_memory_type_id, response, payload->shm_map_, buffer,
       buffer_userp, actual_memory_type, actual_memory_type_id);
@@ -2173,7 +2173,7 @@ ParseSharedMemoryParams(
     *has_shared_memory = true;
     const auto& infer_param = region_it->second;
     if (infer_param.parameter_choice_case() !=
-        InferParameter::ParameterChoiceCase::kStringParam) {
+        inference::InferParameter::ParameterChoiceCase::kStringParam) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
           std::string(
@@ -2198,7 +2198,7 @@ ParseSharedMemoryParams(
     }
     const auto& infer_param = offset_it->second;
     if (infer_param.parameter_choice_case() !=
-        InferParameter::ParameterChoiceCase::kInt64Param) {
+        inference::InferParameter::ParameterChoiceCase::kInt64Param) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
           std::string(
@@ -2223,7 +2223,7 @@ ParseSharedMemoryParams(
     }
     const auto& infer_param = bs_it->second;
     if (infer_param.parameter_choice_case() !=
-        InferParameter::ParameterChoiceCase::kInt64Param) {
+        inference::InferParameter::ParameterChoiceCase::kInt64Param) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
           std::string(
@@ -2252,7 +2252,7 @@ ParseSharedMemoryParams(
 
 TRITONSERVER_Error*
 ParseClassificationParams(
-    const ModelInferRequest::InferRequestedOutputTensor& output,
+    const inference::ModelInferRequest::InferRequestedOutputTensor& output,
     bool* has_classification, uint32_t* classification_count)
 {
   *has_classification = false;
@@ -2263,7 +2263,7 @@ ParseClassificationParams(
 
     const auto& param = class_it->second;
     if (param.parameter_choice_case() !=
-        InferParameter::ParameterChoiceCase::kInt64Param) {
+        inference::InferParameter::ParameterChoiceCase::kInt64Param) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
           "invalid value type for 'classification' parameter, expected "
@@ -2288,7 +2288,7 @@ TRITONSERVER_Error*
 InferAllocatorPayload(
     const std::shared_ptr<TRITONSERVER_Server>& tritonserver,
     const std::shared_ptr<SharedMemoryManager>& shm_manager,
-    const ModelInferRequest& request, std::list<std::string>&& serialized_data,
+    const inference::ModelInferRequest& request, std::list<std::string>&& serialized_data,
     std::shared_ptr<ResponseQueue<ResponseType>> response_queue,
     AllocPayload<ResponseType>* alloc_payload)
 {
@@ -2307,7 +2307,7 @@ InferAllocatorPayload(
     size_t byte_size;
     bool has_shared_memory;
     RETURN_IF_ERR(
-        ParseSharedMemoryParams<ModelInferRequest::InferRequestedOutputTensor>(
+        ParseSharedMemoryParams<inference::ModelInferRequest::InferRequestedOutputTensor>(
             io, &has_shared_memory, &region_name, &offset, &byte_size));
 
     bool has_classification;
@@ -2375,7 +2375,7 @@ TRITONSERVER_Error*
 InferGRPCToInput(
     const std::shared_ptr<TRITONSERVER_Server>& tritonserver,
     const std::shared_ptr<SharedMemoryManager>& shm_manager,
-    const ModelInferRequest& request, std::list<std::string>* serialized_data,
+    const inference::ModelInferRequest& request, std::list<std::string>* serialized_data,
     TRITONSERVER_InferenceRequest* inference_request)
 {
   // Verify that the batch-byte-size of each input matches the size of
@@ -2390,7 +2390,7 @@ InferGRPCToInput(
     std::string region_name;
     int64_t offset;
     bool has_shared_memory;
-    RETURN_IF_ERR(ParseSharedMemoryParams<ModelInferRequest::InferInputTensor>(
+    RETURN_IF_ERR(ParseSharedMemoryParams<inference::ModelInferRequest::InferInputTensor>(
         io, &has_shared_memory, &region_name, &offset, &byte_size));
 
     if (has_shared_memory) {
@@ -2598,7 +2598,7 @@ InferGRPCToInput(
 TRITONSERVER_Error*
 SetInferenceRequestMetadata(
     TRITONSERVER_InferenceRequest* inference_request,
-    const ModelInferRequest& request)
+    const inference::ModelInferRequest& request)
 {
   RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetId(
       inference_request, request.id().c_str()));
@@ -2608,7 +2608,7 @@ SetInferenceRequestMetadata(
     if (param.first.compare("sequence_id") == 0) {
       const auto& infer_param = param.second;
       if (infer_param.parameter_choice_case() !=
-          InferParameter::ParameterChoiceCase::kInt64Param) {
+          inference::InferParameter::ParameterChoiceCase::kInt64Param) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
             "invalid value type for 'sequence_id' parameter, expected "
@@ -2619,7 +2619,7 @@ SetInferenceRequestMetadata(
     } else if (param.first.compare("sequence_start") == 0) {
       const auto& infer_param = param.second;
       if (infer_param.parameter_choice_case() !=
-          InferParameter::ParameterChoiceCase::kBoolParam) {
+          inference::InferParameter::ParameterChoiceCase::kBoolParam) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
             "invalid value type for 'sequence_start' parameter, expected "
@@ -2631,7 +2631,7 @@ SetInferenceRequestMetadata(
     } else if (param.first.compare("sequence_end") == 0) {
       const auto& infer_param = param.second;
       if (infer_param.parameter_choice_case() !=
-          InferParameter::ParameterChoiceCase::kBoolParam) {
+          inference::InferParameter::ParameterChoiceCase::kBoolParam) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
             "invalid value type for 'sequence_end' parameter, expected "
@@ -2643,7 +2643,7 @@ SetInferenceRequestMetadata(
     } else if (param.first.compare("priority") == 0) {
       const auto& infer_param = param.second;
       if (infer_param.parameter_choice_case() !=
-          InferParameter::ParameterChoiceCase::kInt64Param) {
+          inference::InferParameter::ParameterChoiceCase::kInt64Param) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
             "invalid value type for 'priority' parameter, expected "
@@ -2655,7 +2655,7 @@ SetInferenceRequestMetadata(
     } else if (param.first.compare("timeout") == 0) {
       const auto& infer_param = param.second;
       if (infer_param.parameter_choice_case() !=
-          InferParameter::ParameterChoiceCase::kInt64Param) {
+          inference::InferParameter::ParameterChoiceCase::kInt64Param) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
             "invalid value type for 'timeout' parameter, expected "
@@ -2701,7 +2701,7 @@ template <typename ResponseType>
 TRITONSERVER_Error*
 InferResponseCompleteCommon(
     TRITONSERVER_Server* server, TRITONSERVER_InferenceResponse* iresponse,
-    ModelInferResponse& response,
+    inference::ModelInferResponse& response,
     const AllocPayload<ResponseType>& alloc_payload)
 {
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseError(iresponse));
@@ -2726,7 +2726,7 @@ InferResponseCompleteCommon(
     const void* vvalue;
     RETURN_IF_ERR(TRITONSERVER_InferenceResponseParameter(
         iresponse, pidx, &name, &type, &vvalue));
-    InferParameter& param = (*response.mutable_parameters())[name];
+    inference::InferParameter& param = (*response.mutable_parameters())[name];
     switch (type) {
       case TRITONSERVER_PARAMETER_BOOL:
         param.set_bool_param(*(reinterpret_cast<const bool*>(vvalue)));
@@ -2770,7 +2770,7 @@ InferResponseCompleteCommon(
     // There are usually very few outputs so fastest just to look for
     // the one we want... could create a map for cases where there are
     // a large number of outputs. Or rely on order to be same...
-    ModelInferResponse::InferOutputTensor* output = nullptr;
+    inference::ModelInferResponse::InferOutputTensor* output = nullptr;
     for (auto& io : *(response.mutable_outputs())) {
       if (io.name() == name) {
         output = &io;
@@ -2882,16 +2882,16 @@ InferResponseCompleteCommon(
 //
 class ModelInferHandler
     : public InferHandler<
-          GRPCInferenceService::AsyncService,
-          grpc::ServerAsyncResponseWriter<ModelInferResponse>,
-          ModelInferRequest, ModelInferResponse> {
+          inference::GRPCInferenceService::AsyncService,
+          grpc::ServerAsyncResponseWriter<inference::ModelInferResponse>,
+          inference::ModelInferRequest, inference::ModelInferResponse> {
  public:
   ModelInferHandler(
       const std::string& name,
       const std::shared_ptr<TRITONSERVER_Server>& tritonserver,
       TraceManager* trace_manager,
       const std::shared_ptr<SharedMemoryManager>& shm_manager,
-      GRPCInferenceService::AsyncService* service,
+      inference::GRPCInferenceService::AsyncService* service,
       grpc::ServerCompletionQueue* cq, size_t max_state_bucket_count)
       : InferHandler(name, tritonserver, service, cq, max_state_bucket_count),
         trace_manager_(trace_manager), shm_manager_(shm_manager)
@@ -2977,7 +2977,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     finished = true;
   }
 
-  const ModelInferRequest& request = state->request_;
+  const inference::ModelInferRequest& request = state->request_;
   auto response_queue = state->response_queue_;
 
   if (state->step_ == Steps::START) {
@@ -3035,7 +3035,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           tritonserver_, shm_manager_, request, &serialized_data, irequest);
     }
     if (err == nullptr) {
-      err = InferAllocatorPayload<ModelInferResponse>(
+      err = InferAllocatorPayload<inference::ModelInferResponse>(
           tritonserver_, shm_manager_, request, std::move(serialized_data),
           response_queue, &state->alloc_payload_);
     }
@@ -3073,7 +3073,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       GrpcStatusUtil::Create(&status, err);
       TRITONSERVER_ErrorDelete(err);
 
-      ModelInferResponse error_response;
+      inference::ModelInferResponse error_response;
 
 #ifdef TRITON_ENABLE_TRACING
       if ((state->trace_manager_ != nullptr) && (state->trace_id_ != 0)) {
@@ -3123,7 +3123,7 @@ ModelInferHandler::InferResponseComplete(
   // This callback is expected to be called exactly once for each request.
   // Will use the single response object in the response list to hold the
   // information.
-  ModelInferResponse* response = state->response_queue_->GetResponseAt(0);
+  inference::ModelInferResponse* response = state->response_queue_->GetResponseAt(0);
   bool response_created = false;
   if (response == nullptr) {
     LOG_ERROR << "expected allocator to have created a response object";
@@ -3131,7 +3131,7 @@ ModelInferHandler::InferResponseComplete(
         TRITONSERVER_ERROR_INTERNAL,
         "No response object found in the callback");
     response_created = true;
-    response = new ModelInferResponse();
+    response = new inference::ModelInferResponse();
   }
 
   if (state->cb_count_ != 1) {
@@ -3144,7 +3144,7 @@ ModelInferHandler::InferResponseComplete(
     err = TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INTERNAL, "received an unexpected null response");
   } else {
-    err = InferResponseCompleteCommon<ModelInferResponse>(
+    err = InferResponseCompleteCommon<inference::ModelInferResponse>(
         state->tritonserver_, iresponse, *response, state->alloc_payload_);
   }
 
@@ -3180,8 +3180,8 @@ ModelInferHandler::InferResponseComplete(
 TRITONSERVER_Error*
 StreamInferResponseStart(TRITONSERVER_ResponseAllocator* allocator, void* userp)
 {
-  AllocPayload<ModelStreamInferResponse>* payload =
-      reinterpret_cast<AllocPayload<ModelStreamInferResponse>*>(userp);
+  AllocPayload<inference::ModelStreamInferResponse>* payload =
+      reinterpret_cast<AllocPayload<inference::ModelStreamInferResponse>*>(userp);
 
   // Move to the next response object
   payload->response_queue_->AllocateResponse();
@@ -3197,8 +3197,8 @@ StreamInferResponseAlloc(
     void** buffer_userp, TRITONSERVER_MemoryType* actual_memory_type,
     int64_t* actual_memory_type_id)
 {
-  AllocPayload<ModelStreamInferResponse>* payload =
-      reinterpret_cast<AllocPayload<ModelStreamInferResponse>*>(userp);
+  AllocPayload<inference::ModelStreamInferResponse>* payload =
+      reinterpret_cast<AllocPayload<inference::ModelStreamInferResponse>*>(userp);
 
   auto response = payload->response_queue_->GetLastAllocatedResponse();
 
@@ -3209,7 +3209,7 @@ StreamInferResponseAlloc(
   }
 
   return ResponseAllocatorHelper<
-      AllocPayload<ModelStreamInferResponse>::TensorShmMap>(
+      AllocPayload<inference::ModelStreamInferResponse>::TensorShmMap>(
       allocator, tensor_name, byte_size, preferred_memory_type,
       preferred_memory_type_id, response->mutable_infer_response(),
       payload->shm_map_, buffer, buffer_userp, actual_memory_type,
@@ -3221,17 +3221,17 @@ StreamInferResponseAlloc(
 //
 class ModelStreamInferHandler
     : public InferHandler<
-          GRPCInferenceService::AsyncService,
+          inference::GRPCInferenceService::AsyncService,
           grpc::ServerAsyncReaderWriter<
-              ModelStreamInferResponse, ModelInferRequest>,
-          ModelInferRequest, ModelStreamInferResponse> {
+              inference::ModelStreamInferResponse, inference::ModelInferRequest>,
+          inference::ModelInferRequest, inference::ModelStreamInferResponse> {
  public:
   ModelStreamInferHandler(
       const std::string& name,
       const std::shared_ptr<TRITONSERVER_Server>& tritonserver,
       TraceManager* trace_manager,
       const std::shared_ptr<SharedMemoryManager>& shm_manager,
-      GRPCInferenceService::AsyncService* service,
+      inference::GRPCInferenceService::AsyncService* service,
       grpc::ServerCompletionQueue* cq, size_t max_state_bucket_count)
       : InferHandler(name, tritonserver, service, cq, max_state_bucket_count),
         trace_manager_(trace_manager), shm_manager_(shm_manager)
@@ -3328,7 +3328,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
 
   } else if (state->step_ == Steps::READ) {
     TRITONSERVER_Error* err = nullptr;
-    const ModelInferRequest& request = state->request_;
+    const inference::ModelInferRequest& request = state->request_;
 #ifdef TRITON_ENABLE_TRACING
     if ((state->trace_manager_ != nullptr) && (state->trace_id_ != 0)) {
       state->trace_manager_->CaptureTimestamp(
@@ -3413,7 +3413,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           tritonserver_, shm_manager_, request, &serialized_data, irequest);
     }
     if (err == nullptr) {
-      err = InferAllocatorPayload<ModelStreamInferResponse>(
+      err = InferAllocatorPayload<inference::ModelStreamInferResponse>(
           tritonserver_, shm_manager_, request, std::move(serialized_data),
           response_queue_, &state->alloc_payload_);
     }
@@ -3443,7 +3443,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // WRITEREADY or WRITTEN. If there was an error then enqueue the
     // error response and show it to be ready for writing.
     if (err != nullptr) {
-      ModelStreamInferResponse* response;
+      inference::ModelStreamInferResponse* response;
       if (state->is_decoupled_) {
         state->response_queue_->AllocateResponse();
         response = state->response_queue_->GetLastAllocatedResponse();
@@ -3699,9 +3699,9 @@ ModelStreamInferHandler::StreamInferResponseComplete(
 
     TRITONSERVER_Error* err = nullptr;
     if (iresponse != nullptr) {
-      ModelInferResponse& infer_response =
+      inference::ModelInferResponse& infer_response =
           *(response->mutable_infer_response());
-      err = InferResponseCompleteCommon<ModelStreamInferResponse>(
+      err = InferResponseCompleteCommon<inference::ModelStreamInferResponse>(
           state->tritonserver_, iresponse, infer_response,
           state->alloc_payload_);
     }

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -386,7 +386,8 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterServerLive =
       [this](
           grpc::ServerContext* ctx, inference::ServerLiveRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::ServerLiveResponse>* responder,
+          grpc::ServerAsyncResponseWriter<inference::ServerLiveResponse>*
+              responder,
           void* tag) {
         this->service_->RequestServerLive(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -407,8 +408,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::ServerLiveResponse>, inference::ServerLiveRequest,
-      inference::ServerLiveResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ServerLiveResponse>,
+      inference::ServerLiveRequest, inference::ServerLiveResponse>(
       "ServerLive", 0, OnRegisterServerLive, OnExecuteServerLive);
 
   //
@@ -417,7 +418,8 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterServerReady =
       [this](
           grpc::ServerContext* ctx, inference::ServerReadyRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::ServerReadyResponse>* responder,
+          grpc::ServerAsyncResponseWriter<inference::ServerReadyResponse>*
+              responder,
           void* tag) {
         this->service_->RequestServerReady(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -438,8 +440,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::ServerReadyResponse>, inference::ServerReadyRequest,
-      inference::ServerReadyResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ServerReadyResponse>,
+      inference::ServerReadyRequest, inference::ServerReadyResponse>(
       "ServerReady", 0, OnRegisterServerReady, OnExecuteServerReady);
 
   //
@@ -448,7 +450,8 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterModelReady =
       [this](
           grpc::ServerContext* ctx, inference::ModelReadyRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::ModelReadyResponse>* responder,
+          grpc::ServerAsyncResponseWriter<inference::ModelReadyResponse>*
+              responder,
           void* tag) {
         this->service_->RequestModelReady(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -475,8 +478,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::ModelReadyResponse>, inference::ModelReadyRequest,
-      inference::ModelReadyResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ModelReadyResponse>,
+      inference::ModelReadyRequest, inference::ModelReadyResponse>(
       "ModelReady", 0, OnRegisterModelReady, OnExecuteModelReady);
 
   //
@@ -485,67 +488,68 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterServerMetadata =
       [this](
           grpc::ServerContext* ctx, inference::ServerMetadataRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::ServerMetadataResponse>* responder,
+          grpc::ServerAsyncResponseWriter<inference::ServerMetadataResponse>*
+              responder,
           void* tag) {
         this->service_->RequestServerMetadata(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
-  auto OnExecuteServerMetadata = [this](
-                                     inference::ServerMetadataRequest& request,
-                                     inference::ServerMetadataResponse* response,
-                                     grpc::Status* status) {
-    TRITONSERVER_Message* server_metadata_message = nullptr;
-    TRITONSERVER_Error* err = TRITONSERVER_ServerMetadata(
-        tritonserver_.get(), &server_metadata_message);
-    GOTO_IF_ERR(err, earlyexit);
-
-    const char* buffer;
-    size_t byte_size;
-    err = TRITONSERVER_MessageSerializeToJson(
-        server_metadata_message, &buffer, &byte_size);
-    GOTO_IF_ERR(err, earlyexit);
-
-    {
-      TritonJson::Value server_metadata_json;
-      err = server_metadata_json.Parse(buffer, byte_size);
-      GOTO_IF_ERR(err, earlyexit);
-
-      const char* name;
-      size_t namelen;
-      err = server_metadata_json.MemberAsString("name", &name, &namelen);
-      GOTO_IF_ERR(err, earlyexit);
-
-      const char* version;
-      size_t versionlen;
-      err =
-          server_metadata_json.MemberAsString("version", &version, &versionlen);
-      GOTO_IF_ERR(err, earlyexit);
-
-      response->set_name(std::string(name, namelen));
-      response->set_version(std::string(version, versionlen));
-
-      if (server_metadata_json.Find("extensions")) {
-        TritonJson::Value extensions_json;
-        err =
-            server_metadata_json.MemberAsArray("extensions", &extensions_json);
+  auto OnExecuteServerMetadata =
+      [this](
+          inference::ServerMetadataRequest& request,
+          inference::ServerMetadataResponse* response, grpc::Status* status) {
+        TRITONSERVER_Message* server_metadata_message = nullptr;
+        TRITONSERVER_Error* err = TRITONSERVER_ServerMetadata(
+            tritonserver_.get(), &server_metadata_message);
         GOTO_IF_ERR(err, earlyexit);
 
-        for (size_t idx = 0; idx < extensions_json.ArraySize(); ++idx) {
-          const char* ext;
-          size_t extlen;
-          err = extensions_json.IndexAsString(idx, &ext, &extlen);
-          GOTO_IF_ERR(err, earlyexit);
-          response->add_extensions(std::string(ext, extlen));
-        }
-      }
-      TRITONSERVER_MessageDelete(server_metadata_message);
-    }
+        const char* buffer;
+        size_t byte_size;
+        err = TRITONSERVER_MessageSerializeToJson(
+            server_metadata_message, &buffer, &byte_size);
+        GOTO_IF_ERR(err, earlyexit);
 
-  earlyexit:
-    GrpcStatusUtil::Create(status, err);
-    TRITONSERVER_ErrorDelete(err);
-  };
+        {
+          TritonJson::Value server_metadata_json;
+          err = server_metadata_json.Parse(buffer, byte_size);
+          GOTO_IF_ERR(err, earlyexit);
+
+          const char* name;
+          size_t namelen;
+          err = server_metadata_json.MemberAsString("name", &name, &namelen);
+          GOTO_IF_ERR(err, earlyexit);
+
+          const char* version;
+          size_t versionlen;
+          err = server_metadata_json.MemberAsString(
+              "version", &version, &versionlen);
+          GOTO_IF_ERR(err, earlyexit);
+
+          response->set_name(std::string(name, namelen));
+          response->set_version(std::string(version, versionlen));
+
+          if (server_metadata_json.Find("extensions")) {
+            TritonJson::Value extensions_json;
+            err = server_metadata_json.MemberAsArray(
+                "extensions", &extensions_json);
+            GOTO_IF_ERR(err, earlyexit);
+
+            for (size_t idx = 0; idx < extensions_json.ArraySize(); ++idx) {
+              const char* ext;
+              size_t extlen;
+              err = extensions_json.IndexAsString(idx, &ext, &extlen);
+              GOTO_IF_ERR(err, earlyexit);
+              response->add_extensions(std::string(ext, extlen));
+            }
+          }
+          TRITONSERVER_MessageDelete(server_metadata_message);
+        }
+
+      earlyexit:
+        GrpcStatusUtil::Create(status, err);
+        TRITONSERVER_ErrorDelete(err);
+      };
 
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ServerMetadataResponse>,
@@ -558,7 +562,8 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterModelMetadata =
       [this](
           grpc::ServerContext* ctx, inference::ModelMetadataRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::ModelMetadataResponse>* responder,
+          grpc::ServerAsyncResponseWriter<inference::ModelMetadataResponse>*
+              responder,
           void* tag) {
         this->service_->RequestModelMetadata(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -628,7 +633,8 @@ CommonHandler::SetUpAllRequests()
           err = inputs_json.IndexAsObject(idx, &io_json);
           GOTO_IF_ERR(err, earlyexit);
 
-          inference::ModelMetadataResponse::TensorMetadata* io = response->add_inputs();
+          inference::ModelMetadataResponse::TensorMetadata* io =
+              response->add_inputs();
 
           const char* name;
           size_t namelen;
@@ -669,7 +675,8 @@ CommonHandler::SetUpAllRequests()
           err = outputs_json.IndexAsObject(idx, &io_json);
           GOTO_IF_ERR(err, earlyexit);
 
-          inference::ModelMetadataResponse::TensorMetadata* io = response->add_outputs();
+          inference::ModelMetadataResponse::TensorMetadata* io =
+              response->add_outputs();
 
           const char* name;
           size_t namelen;
@@ -719,7 +726,8 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterModelConfig =
       [this](
           grpc::ServerContext* ctx, inference::ModelConfigRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::ModelConfigResponse>* responder,
+          grpc::ServerAsyncResponseWriter<inference::ModelConfigResponse>*
+              responder,
           void* tag) {
         this->service_->RequestModelConfig(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -755,8 +763,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::ModelConfigResponse>, inference::ModelConfigRequest,
-      inference::ModelConfigResponse>(
+      grpc::ServerAsyncResponseWriter<inference::ModelConfigResponse>,
+      inference::ModelConfigRequest, inference::ModelConfigResponse>(
       "ModelConfig", 0, OnRegisterModelConfig, OnExecuteModelConfig);
 
   //
@@ -765,255 +773,260 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterModelStatistics =
       [this](
           grpc::ServerContext* ctx, inference::ModelStatisticsRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::ModelStatisticsResponse>* responder,
+          grpc::ServerAsyncResponseWriter<inference::ModelStatisticsResponse>*
+              responder,
           void* tag) {
         this->service_->RequestModelStatistics(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
-  auto OnExecuteModelStatistics = [this](
-                                      inference::ModelStatisticsRequest& request,
-                                      inference::ModelStatisticsResponse* response,
-                                      grpc::Status* status) {
+  auto OnExecuteModelStatistics =
+      [this](
+          inference::ModelStatisticsRequest& request,
+          inference::ModelStatisticsResponse* response, grpc::Status* status) {
 #ifdef TRITON_ENABLE_STATS
-    TritonJson::Value model_stats_json;
+        TritonJson::Value model_stats_json;
 
-    int64_t requested_model_version;
-    auto err =
-        GetModelVersionFromString(request.version(), &requested_model_version);
-    GOTO_IF_ERR(err, earlyexit);
-
-    {
-      TRITONSERVER_Message* model_stats_message = nullptr;
-      err = TRITONSERVER_ServerModelStatistics(
-          tritonserver_.get(), request.name().c_str(), requested_model_version,
-          &model_stats_message);
-      GOTO_IF_ERR(err, earlyexit);
-
-      const char* buffer;
-      size_t byte_size;
-      err = TRITONSERVER_MessageSerializeToJson(
-          model_stats_message, &buffer, &byte_size);
-      GOTO_IF_ERR(err, earlyexit);
-
-      err = model_stats_json.Parse(buffer, byte_size);
-      GOTO_IF_ERR(err, earlyexit);
-
-      TRITONSERVER_MessageDelete(model_stats_message);
-    }
-
-    if (model_stats_json.Find("model_stats")) {
-      TritonJson::Value stats_json;
-      err = model_stats_json.MemberAsArray("model_stats", &stats_json);
-      GOTO_IF_ERR(err, earlyexit);
-
-      for (size_t idx = 0; idx < stats_json.ArraySize(); ++idx) {
-        TritonJson::Value model_stat;
-        err = stats_json.IndexAsObject(idx, &model_stat);
-        GOTO_IF_ERR(err, earlyexit);
-
-        auto statistics = response->add_model_stats();
-
-        const char* name;
-        size_t namelen;
-        err = model_stat.MemberAsString("name", &name, &namelen);
-        GOTO_IF_ERR(err, earlyexit);
-
-        const char* version;
-        size_t versionlen;
-        err = model_stat.MemberAsString("version", &version, &versionlen);
-        GOTO_IF_ERR(err, earlyexit);
-
-        statistics->set_name(std::string(name, namelen));
-        statistics->set_version(std::string(version, versionlen));
-
-        uint64_t ucnt;
-        err = model_stat.MemberAsUInt("last_inference", &ucnt);
-        GOTO_IF_ERR(err, earlyexit);
-        statistics->set_last_inference(ucnt);
-
-        err = model_stat.MemberAsUInt("inference_count", &ucnt);
-        GOTO_IF_ERR(err, earlyexit);
-        statistics->set_inference_count(ucnt);
-
-        err = model_stat.MemberAsUInt("execution_count", &ucnt);
-        GOTO_IF_ERR(err, earlyexit);
-        statistics->set_execution_count(ucnt);
-
-        TritonJson::Value infer_stats_json;
-        err = model_stat.MemberAsObject("inference_stats", &infer_stats_json);
+        int64_t requested_model_version;
+        auto err = GetModelVersionFromString(
+            request.version(), &requested_model_version);
         GOTO_IF_ERR(err, earlyexit);
 
         {
-          TritonJson::Value success_json;
-          err = infer_stats_json.MemberAsObject("success", &success_json);
+          TRITONSERVER_Message* model_stats_message = nullptr;
+          err = TRITONSERVER_ServerModelStatistics(
+              tritonserver_.get(), request.name().c_str(),
+              requested_model_version, &model_stats_message);
           GOTO_IF_ERR(err, earlyexit);
 
-          err = success_json.MemberAsUInt("count", &ucnt);
+          const char* buffer;
+          size_t byte_size;
+          err = TRITONSERVER_MessageSerializeToJson(
+              model_stats_message, &buffer, &byte_size);
           GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()->mutable_success()->set_count(
-              ucnt);
-          err = success_json.MemberAsUInt("ns", &ucnt);
+
+          err = model_stats_json.Parse(buffer, byte_size);
           GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()->mutable_success()->set_ns(
-              ucnt);
+
+          TRITONSERVER_MessageDelete(model_stats_message);
         }
 
-        {
-          TritonJson::Value fail_json;
-          err = infer_stats_json.MemberAsObject("fail", &fail_json);
+        if (model_stats_json.Find("model_stats")) {
+          TritonJson::Value stats_json;
+          err = model_stats_json.MemberAsArray("model_stats", &stats_json);
           GOTO_IF_ERR(err, earlyexit);
 
-          err = fail_json.MemberAsUInt("count", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()->mutable_fail()->set_count(
-              ucnt);
-          err = fail_json.MemberAsUInt("ns", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()->mutable_fail()->set_ns(ucnt);
-        }
+          for (size_t idx = 0; idx < stats_json.ArraySize(); ++idx) {
+            TritonJson::Value model_stat;
+            err = stats_json.IndexAsObject(idx, &model_stat);
+            GOTO_IF_ERR(err, earlyexit);
 
-        {
-          TritonJson::Value queue_json;
-          err = infer_stats_json.MemberAsObject("queue", &queue_json);
-          GOTO_IF_ERR(err, earlyexit);
+            auto statistics = response->add_model_stats();
 
-          err = queue_json.MemberAsUInt("count", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()->mutable_queue()->set_count(
-              ucnt);
-          err = queue_json.MemberAsUInt("ns", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()->mutable_queue()->set_ns(ucnt);
-        }
+            const char* name;
+            size_t namelen;
+            err = model_stat.MemberAsString("name", &name, &namelen);
+            GOTO_IF_ERR(err, earlyexit);
 
-        {
-          TritonJson::Value compute_input_json;
-          err = infer_stats_json.MemberAsObject(
-              "compute_input", &compute_input_json);
-          GOTO_IF_ERR(err, earlyexit);
+            const char* version;
+            size_t versionlen;
+            err = model_stat.MemberAsString("version", &version, &versionlen);
+            GOTO_IF_ERR(err, earlyexit);
 
-          err = compute_input_json.MemberAsUInt("count", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()
-              ->mutable_compute_input()
-              ->set_count(ucnt);
-          err = compute_input_json.MemberAsUInt("ns", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()
-              ->mutable_compute_input()
-              ->set_ns(ucnt);
-        }
+            statistics->set_name(std::string(name, namelen));
+            statistics->set_version(std::string(version, versionlen));
 
-        {
-          TritonJson::Value compute_infer_json;
-          err = infer_stats_json.MemberAsObject(
-              "compute_infer", &compute_infer_json);
-          GOTO_IF_ERR(err, earlyexit);
+            uint64_t ucnt;
+            err = model_stat.MemberAsUInt("last_inference", &ucnt);
+            GOTO_IF_ERR(err, earlyexit);
+            statistics->set_last_inference(ucnt);
 
-          err = compute_infer_json.MemberAsUInt("count", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()
-              ->mutable_compute_infer()
-              ->set_count(ucnt);
-          err = compute_infer_json.MemberAsUInt("ns", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()
-              ->mutable_compute_infer()
-              ->set_ns(ucnt);
-        }
+            err = model_stat.MemberAsUInt("inference_count", &ucnt);
+            GOTO_IF_ERR(err, earlyexit);
+            statistics->set_inference_count(ucnt);
 
-        {
-          TritonJson::Value compute_output_json;
-          err = infer_stats_json.MemberAsObject(
-              "compute_output", &compute_output_json);
-          GOTO_IF_ERR(err, earlyexit);
+            err = model_stat.MemberAsUInt("execution_count", &ucnt);
+            GOTO_IF_ERR(err, earlyexit);
+            statistics->set_execution_count(ucnt);
 
-          err = compute_output_json.MemberAsUInt("count", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()
-              ->mutable_compute_output()
-              ->set_count(ucnt);
-          err = compute_output_json.MemberAsUInt("ns", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()
-              ->mutable_compute_output()
-              ->set_ns(ucnt);
-        }
-
-
-        TritonJson::Value batches_json;
-        err = model_stat.MemberAsArray("batch_stats", &batches_json);
-        GOTO_IF_ERR(err, earlyexit);
-
-        for (size_t idx = 0; idx < batches_json.ArraySize(); ++idx) {
-          TritonJson::Value batch_stat;
-          err = batches_json.IndexAsObject(idx, &batch_stat);
-          GOTO_IF_ERR(err, earlyexit);
-
-          auto batch_statistics = statistics->add_batch_stats();
-
-          uint64_t ucnt;
-          err = batch_stat.MemberAsUInt("batch_size", &ucnt);
-          GOTO_IF_ERR(err, earlyexit);
-          batch_statistics->set_batch_size(ucnt);
-
-          {
-            TritonJson::Value compute_input_json;
+            TritonJson::Value infer_stats_json;
             err =
-                batch_stat.MemberAsObject("compute_input", &compute_input_json);
+                model_stat.MemberAsObject("inference_stats", &infer_stats_json);
             GOTO_IF_ERR(err, earlyexit);
 
-            err = compute_input_json.MemberAsUInt("count", &ucnt);
-            GOTO_IF_ERR(err, earlyexit);
-            batch_statistics->mutable_compute_input()->set_count(ucnt);
-            err = compute_input_json.MemberAsUInt("ns", &ucnt);
-            GOTO_IF_ERR(err, earlyexit);
-            batch_statistics->mutable_compute_input()->set_ns(ucnt);
-          }
+            {
+              TritonJson::Value success_json;
+              err = infer_stats_json.MemberAsObject("success", &success_json);
+              GOTO_IF_ERR(err, earlyexit);
 
-          {
-            TritonJson::Value compute_infer_json;
-            err =
-                batch_stat.MemberAsObject("compute_infer", &compute_infer_json);
+              err = success_json.MemberAsUInt("count", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()
+                  ->mutable_success()
+                  ->set_count(ucnt);
+              err = success_json.MemberAsUInt("ns", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()->mutable_success()->set_ns(
+                  ucnt);
+            }
+
+            {
+              TritonJson::Value fail_json;
+              err = infer_stats_json.MemberAsObject("fail", &fail_json);
+              GOTO_IF_ERR(err, earlyexit);
+
+              err = fail_json.MemberAsUInt("count", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()->mutable_fail()->set_count(
+                  ucnt);
+              err = fail_json.MemberAsUInt("ns", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()->mutable_fail()->set_ns(
+                  ucnt);
+            }
+
+            {
+              TritonJson::Value queue_json;
+              err = infer_stats_json.MemberAsObject("queue", &queue_json);
+              GOTO_IF_ERR(err, earlyexit);
+
+              err = queue_json.MemberAsUInt("count", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()->mutable_queue()->set_count(
+                  ucnt);
+              err = queue_json.MemberAsUInt("ns", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()->mutable_queue()->set_ns(
+                  ucnt);
+            }
+
+            {
+              TritonJson::Value compute_input_json;
+              err = infer_stats_json.MemberAsObject(
+                  "compute_input", &compute_input_json);
+              GOTO_IF_ERR(err, earlyexit);
+
+              err = compute_input_json.MemberAsUInt("count", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()
+                  ->mutable_compute_input()
+                  ->set_count(ucnt);
+              err = compute_input_json.MemberAsUInt("ns", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()
+                  ->mutable_compute_input()
+                  ->set_ns(ucnt);
+            }
+
+            {
+              TritonJson::Value compute_infer_json;
+              err = infer_stats_json.MemberAsObject(
+                  "compute_infer", &compute_infer_json);
+              GOTO_IF_ERR(err, earlyexit);
+
+              err = compute_infer_json.MemberAsUInt("count", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()
+                  ->mutable_compute_infer()
+                  ->set_count(ucnt);
+              err = compute_infer_json.MemberAsUInt("ns", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()
+                  ->mutable_compute_infer()
+                  ->set_ns(ucnt);
+            }
+
+            {
+              TritonJson::Value compute_output_json;
+              err = infer_stats_json.MemberAsObject(
+                  "compute_output", &compute_output_json);
+              GOTO_IF_ERR(err, earlyexit);
+
+              err = compute_output_json.MemberAsUInt("count", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()
+                  ->mutable_compute_output()
+                  ->set_count(ucnt);
+              err = compute_output_json.MemberAsUInt("ns", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              statistics->mutable_inference_stats()
+                  ->mutable_compute_output()
+                  ->set_ns(ucnt);
+            }
+
+
+            TritonJson::Value batches_json;
+            err = model_stat.MemberAsArray("batch_stats", &batches_json);
             GOTO_IF_ERR(err, earlyexit);
 
-            err = compute_infer_json.MemberAsUInt("count", &ucnt);
-            GOTO_IF_ERR(err, earlyexit);
-            batch_statistics->mutable_compute_infer()->set_count(ucnt);
-            err = compute_infer_json.MemberAsUInt("ns", &ucnt);
-            GOTO_IF_ERR(err, earlyexit);
-            batch_statistics->mutable_compute_infer()->set_ns(ucnt);
-          }
+            for (size_t idx = 0; idx < batches_json.ArraySize(); ++idx) {
+              TritonJson::Value batch_stat;
+              err = batches_json.IndexAsObject(idx, &batch_stat);
+              GOTO_IF_ERR(err, earlyexit);
 
-          {
-            TritonJson::Value compute_output_json;
-            err = batch_stat.MemberAsObject(
-                "compute_output", &compute_output_json);
-            GOTO_IF_ERR(err, earlyexit);
+              auto batch_statistics = statistics->add_batch_stats();
 
-            err = compute_output_json.MemberAsUInt("count", &ucnt);
-            GOTO_IF_ERR(err, earlyexit);
-            batch_statistics->mutable_compute_output()->set_count(ucnt);
-            err = compute_output_json.MemberAsUInt("ns", &ucnt);
-            GOTO_IF_ERR(err, earlyexit);
-            batch_statistics->mutable_compute_output()->set_ns(ucnt);
+              uint64_t ucnt;
+              err = batch_stat.MemberAsUInt("batch_size", &ucnt);
+              GOTO_IF_ERR(err, earlyexit);
+              batch_statistics->set_batch_size(ucnt);
+
+              {
+                TritonJson::Value compute_input_json;
+                err = batch_stat.MemberAsObject(
+                    "compute_input", &compute_input_json);
+                GOTO_IF_ERR(err, earlyexit);
+
+                err = compute_input_json.MemberAsUInt("count", &ucnt);
+                GOTO_IF_ERR(err, earlyexit);
+                batch_statistics->mutable_compute_input()->set_count(ucnt);
+                err = compute_input_json.MemberAsUInt("ns", &ucnt);
+                GOTO_IF_ERR(err, earlyexit);
+                batch_statistics->mutable_compute_input()->set_ns(ucnt);
+              }
+
+              {
+                TritonJson::Value compute_infer_json;
+                err = batch_stat.MemberAsObject(
+                    "compute_infer", &compute_infer_json);
+                GOTO_IF_ERR(err, earlyexit);
+
+                err = compute_infer_json.MemberAsUInt("count", &ucnt);
+                GOTO_IF_ERR(err, earlyexit);
+                batch_statistics->mutable_compute_infer()->set_count(ucnt);
+                err = compute_infer_json.MemberAsUInt("ns", &ucnt);
+                GOTO_IF_ERR(err, earlyexit);
+                batch_statistics->mutable_compute_infer()->set_ns(ucnt);
+              }
+
+              {
+                TritonJson::Value compute_output_json;
+                err = batch_stat.MemberAsObject(
+                    "compute_output", &compute_output_json);
+                GOTO_IF_ERR(err, earlyexit);
+
+                err = compute_output_json.MemberAsUInt("count", &ucnt);
+                GOTO_IF_ERR(err, earlyexit);
+                batch_statistics->mutable_compute_output()->set_count(ucnt);
+                err = compute_output_json.MemberAsUInt("ns", &ucnt);
+                GOTO_IF_ERR(err, earlyexit);
+                batch_statistics->mutable_compute_output()->set_ns(ucnt);
+              }
+            }
           }
         }
-      }
-    }
 
-  earlyexit:
-    GrpcStatusUtil::Create(status, err);
-    TRITONSERVER_ErrorDelete(err);
+      earlyexit:
+        GrpcStatusUtil::Create(status, err);
+        TRITONSERVER_ErrorDelete(err);
 #else
-    auto err = TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_UNAVAILABLE,
-        "the server does not suppport model statistics");
-    GrpcStatusUtil::Create(status, err);
-    TRITONSERVER_ErrorDelete(err);
+        auto err = TRITONSERVER_ErrorNew(
+            TRITONSERVER_ERROR_UNAVAILABLE,
+            "the server does not suppport model statistics");
+        GrpcStatusUtil::Create(status, err);
+        TRITONSERVER_ErrorDelete(err);
 #endif
-  };
+      };
 
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ModelStatisticsResponse>,
@@ -1027,9 +1040,10 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterSystemSharedMemoryStatus =
       [this](
-          grpc::ServerContext* ctx, inference::SystemSharedMemoryStatusRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryStatusResponse>*
-              responder,
+          grpc::ServerContext* ctx,
+          inference::SystemSharedMemoryStatusRequest* request,
+          grpc::ServerAsyncResponseWriter<
+              inference::SystemSharedMemoryStatusResponse>* responder,
           void* tag) {
         this->service_->RequestSystemSharedMemoryStatus(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -1038,7 +1052,8 @@ CommonHandler::SetUpAllRequests()
   auto OnExecuteSystemSharedMemoryStatus =
       [this](
           inference::SystemSharedMemoryStatusRequest& request,
-          inference::SystemSharedMemoryStatusResponse* response, grpc::Status* status) {
+          inference::SystemSharedMemoryStatusResponse* response,
+          grpc::Status* status) {
         TritonJson::Value shm_status_json(TritonJson::ValueType::ARRAY);
         TRITONSERVER_Error* err = shm_manager_->GetStatus(
             request.name(), TRITONSERVER_MEMORY_CPU, &shm_status_json);
@@ -1067,7 +1082,8 @@ CommonHandler::SetUpAllRequests()
           err = shm_region_json.MemberAsUInt("byte_size", &byte_size);
           GOTO_IF_ERR(err, earlyexit);
 
-          inference::SystemSharedMemoryStatusResponse::RegionStatus region_status;
+          inference::SystemSharedMemoryStatusResponse::RegionStatus
+              region_status;
           region_status.set_name(std::string(name, namelen));
           region_status.set_key(std::string(key, keylen));
           region_status.set_offset(offset);
@@ -1082,8 +1098,10 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryStatusResponse>,
-      inference::SystemSharedMemoryStatusRequest, inference::SystemSharedMemoryStatusResponse>(
+      grpc::ServerAsyncResponseWriter<
+          inference::SystemSharedMemoryStatusResponse>,
+      inference::SystemSharedMemoryStatusRequest,
+      inference::SystemSharedMemoryStatusResponse>(
       "SystemSharedMemoryStatus", 0, OnRegisterSystemSharedMemoryStatus,
       OnExecuteSystemSharedMemoryStatus);
 
@@ -1093,9 +1111,10 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterSystemSharedMemoryRegister =
       [this](
-          grpc::ServerContext* ctx, inference::SystemSharedMemoryRegisterRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryRegisterResponse>*
-              responder,
+          grpc::ServerContext* ctx,
+          inference::SystemSharedMemoryRegisterRequest* request,
+          grpc::ServerAsyncResponseWriter<
+              inference::SystemSharedMemoryRegisterResponse>* responder,
           void* tag) {
         this->service_->RequestSystemSharedMemoryRegister(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -1104,7 +1123,8 @@ CommonHandler::SetUpAllRequests()
   auto OnExecuteSystemSharedMemoryRegister =
       [this](
           inference::SystemSharedMemoryRegisterRequest& request,
-          inference::SystemSharedMemoryRegisterResponse* response, grpc::Status* status) {
+          inference::SystemSharedMemoryRegisterResponse* response,
+          grpc::Status* status) {
         TRITONSERVER_Error* err = shm_manager_->RegisterSystemSharedMemory(
             request.name(), request.key(), request.offset(),
             request.byte_size());
@@ -1114,8 +1134,10 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryRegisterResponse>,
-      inference::SystemSharedMemoryRegisterRequest, inference::SystemSharedMemoryRegisterResponse>(
+      grpc::ServerAsyncResponseWriter<
+          inference::SystemSharedMemoryRegisterResponse>,
+      inference::SystemSharedMemoryRegisterRequest,
+      inference::SystemSharedMemoryRegisterResponse>(
       "SystemSharedMemoryRegister", 0, OnRegisterSystemSharedMemoryRegister,
       OnExecuteSystemSharedMemoryRegister);
 
@@ -1127,8 +1149,8 @@ CommonHandler::SetUpAllRequests()
       [this](
           grpc::ServerContext* ctx,
           inference::SystemSharedMemoryUnregisterRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryUnregisterResponse>*
-              responder,
+          grpc::ServerAsyncResponseWriter<
+              inference::SystemSharedMemoryUnregisterResponse>* responder,
           void* tag) {
         this->service_->RequestSystemSharedMemoryUnregister(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -1152,7 +1174,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::SystemSharedMemoryUnregisterResponse>,
+      grpc::ServerAsyncResponseWriter<
+          inference::SystemSharedMemoryUnregisterResponse>,
       inference::SystemSharedMemoryUnregisterRequest,
       inference::SystemSharedMemoryUnregisterResponse>(
       "SystemSharedMemoryUnregister", 0, OnRegisterSystemSharedMemoryUnregister,
@@ -1164,9 +1187,10 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterCudaSharedMemoryStatus =
       [this](
-          grpc::ServerContext* ctx, inference::CudaSharedMemoryStatusRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryStatusResponse>*
-              responder,
+          grpc::ServerContext* ctx,
+          inference::CudaSharedMemoryStatusRequest* request,
+          grpc::ServerAsyncResponseWriter<
+              inference::CudaSharedMemoryStatusResponse>* responder,
           void* tag) {
         this->service_->RequestCudaSharedMemoryStatus(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -1174,7 +1198,8 @@ CommonHandler::SetUpAllRequests()
   auto OnExecuteCudaSharedMemoryStatus =
       [this](
           inference::CudaSharedMemoryStatusRequest& request,
-          inference::CudaSharedMemoryStatusResponse* response, grpc::Status* status) {
+          inference::CudaSharedMemoryStatusResponse* response,
+          grpc::Status* status) {
         TritonJson::Value shm_status_json(TritonJson::ValueType::ARRAY);
         TRITONSERVER_Error* err = shm_manager_->GetStatus(
             request.name(), TRITONSERVER_MEMORY_GPU, &shm_status_json);
@@ -1211,8 +1236,10 @@ CommonHandler::SetUpAllRequests()
         TRITONSERVER_ErrorDelete(err);
       };
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryStatusResponse>,
-      inference::CudaSharedMemoryStatusRequest, inference::CudaSharedMemoryStatusResponse>(
+      grpc::ServerAsyncResponseWriter<
+          inference::CudaSharedMemoryStatusResponse>,
+      inference::CudaSharedMemoryStatusRequest,
+      inference::CudaSharedMemoryStatusResponse>(
       "CudaSharedMemoryStatus", 0, OnRegisterCudaSharedMemoryStatus,
       OnExecuteCudaSharedMemoryStatus);
 
@@ -1222,9 +1249,10 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterCudaSharedMemoryRegister =
       [this](
-          grpc::ServerContext* ctx, inference::CudaSharedMemoryRegisterRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryRegisterResponse>*
-              responder,
+          grpc::ServerContext* ctx,
+          inference::CudaSharedMemoryRegisterRequest* request,
+          grpc::ServerAsyncResponseWriter<
+              inference::CudaSharedMemoryRegisterResponse>* responder,
           void* tag) {
         this->service_->RequestCudaSharedMemoryRegister(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -1233,7 +1261,8 @@ CommonHandler::SetUpAllRequests()
   auto OnExecuteCudaSharedMemoryRegister =
       [this](
           inference::CudaSharedMemoryRegisterRequest& request,
-          inference::CudaSharedMemoryRegisterResponse* response, grpc::Status* status) {
+          inference::CudaSharedMemoryRegisterResponse* response,
+          grpc::Status* status) {
         TRITONSERVER_Error* err = nullptr;
 #ifdef TRITON_ENABLE_GPU
         err = shm_manager_->RegisterCUDASharedMemory(
@@ -1255,8 +1284,10 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryRegisterResponse>,
-      inference::CudaSharedMemoryRegisterRequest, inference::CudaSharedMemoryRegisterResponse>(
+      grpc::ServerAsyncResponseWriter<
+          inference::CudaSharedMemoryRegisterResponse>,
+      inference::CudaSharedMemoryRegisterRequest,
+      inference::CudaSharedMemoryRegisterResponse>(
       "CudaSharedMemoryRegister", 0, OnRegisterCudaSharedMemoryRegister,
       OnExecuteCudaSharedMemoryRegister);
 
@@ -1265,9 +1296,10 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterCudaSharedMemoryUnregister =
       [this](
-          grpc::ServerContext* ctx, inference::CudaSharedMemoryUnregisterRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryUnregisterResponse>*
-              responder,
+          grpc::ServerContext* ctx,
+          inference::CudaSharedMemoryUnregisterRequest* request,
+          grpc::ServerAsyncResponseWriter<
+              inference::CudaSharedMemoryUnregisterResponse>* responder,
           void* tag) {
         this->service_->RequestCudaSharedMemoryUnregister(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -1276,7 +1308,8 @@ CommonHandler::SetUpAllRequests()
   auto OnExecuteCudaSharedMemoryUnregister =
       [this](
           inference::CudaSharedMemoryUnregisterRequest& request,
-          inference::CudaSharedMemoryUnregisterResponse* response, grpc::Status* status) {
+          inference::CudaSharedMemoryUnregisterResponse* response,
+          grpc::Status* status) {
         TRITONSERVER_Error* err = nullptr;
         if (request.name().empty()) {
           err = shm_manager_->UnregisterAll(TRITONSERVER_MEMORY_GPU);
@@ -1290,8 +1323,10 @@ CommonHandler::SetUpAllRequests()
       };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<inference::CudaSharedMemoryUnregisterResponse>,
-      inference::CudaSharedMemoryUnregisterRequest, inference::CudaSharedMemoryUnregisterResponse>(
+      grpc::ServerAsyncResponseWriter<
+          inference::CudaSharedMemoryUnregisterResponse>,
+      inference::CudaSharedMemoryUnregisterRequest,
+      inference::CudaSharedMemoryUnregisterResponse>(
       "CudaSharedMemoryUnregister", 0, OnRegisterCudaSharedMemoryUnregister,
       OnExecuteCudaSharedMemoryUnregister);
 
@@ -1301,88 +1336,89 @@ CommonHandler::SetUpAllRequests()
   auto OnRegisterRepositoryIndex =
       [this](
           grpc::ServerContext* ctx, inference::RepositoryIndexRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::RepositoryIndexResponse>* responder,
+          grpc::ServerAsyncResponseWriter<inference::RepositoryIndexResponse>*
+              responder,
           void* tag) {
         this->service_->RequestRepositoryIndex(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
-  auto OnExecuteRepositoryIndex = [this](
-                                      inference::RepositoryIndexRequest& request,
-                                      inference::RepositoryIndexResponse* response,
-                                      grpc::Status* status) {
-    TRITONSERVER_Error* err = nullptr;
-    if (request.repository_name().empty()) {
-      uint32_t flags = 0;
-      if (request.ready()) {
-        flags |= TRITONSERVER_INDEX_FLAG_READY;
-      }
+  auto OnExecuteRepositoryIndex =
+      [this](
+          inference::RepositoryIndexRequest& request,
+          inference::RepositoryIndexResponse* response, grpc::Status* status) {
+        TRITONSERVER_Error* err = nullptr;
+        if (request.repository_name().empty()) {
+          uint32_t flags = 0;
+          if (request.ready()) {
+            flags |= TRITONSERVER_INDEX_FLAG_READY;
+          }
 
-      TRITONSERVER_Message* model_index_message = nullptr;
-      err = TRITONSERVER_ServerModelIndex(
-          tritonserver_.get(), flags, &model_index_message);
-      GOTO_IF_ERR(err, earlyexit);
-
-      const char* buffer;
-      size_t byte_size;
-      err = TRITONSERVER_MessageSerializeToJson(
-          model_index_message, &buffer, &byte_size);
-      GOTO_IF_ERR(err, earlyexit);
-
-      TritonJson::Value model_index_json;
-      err = model_index_json.Parse(buffer, byte_size);
-      GOTO_IF_ERR(err, earlyexit);
-
-      err = model_index_json.AssertType(TritonJson::ValueType::ARRAY);
-      GOTO_IF_ERR(err, earlyexit);
-
-      for (size_t idx = 0; idx < model_index_json.ArraySize(); ++idx) {
-        TritonJson::Value index_json;
-        err = model_index_json.IndexAsObject(idx, &index_json);
-        GOTO_IF_ERR(err, earlyexit);
-
-        auto model_index = response->add_models();
-
-        const char* name;
-        size_t namelen;
-        err = index_json.MemberAsString("name", &name, &namelen);
-        GOTO_IF_ERR(err, earlyexit);
-        model_index->set_name(std::string(name, namelen));
-
-        if (index_json.Find("version")) {
-          const char* version;
-          size_t versionlen;
-          err = index_json.MemberAsString("version", &version, &versionlen);
+          TRITONSERVER_Message* model_index_message = nullptr;
+          err = TRITONSERVER_ServerModelIndex(
+              tritonserver_.get(), flags, &model_index_message);
           GOTO_IF_ERR(err, earlyexit);
-          model_index->set_version(std::string(version, versionlen));
-        }
-        if (index_json.Find("state")) {
-          const char* state;
-          size_t statelen;
-          err = index_json.MemberAsString("state", &state, &statelen);
-          GOTO_IF_ERR(err, earlyexit);
-          model_index->set_state(std::string(state, statelen));
-        }
-        if (index_json.Find("reason")) {
-          const char* reason;
-          size_t reasonlen;
-          err = index_json.MemberAsString("reason", &reason, &reasonlen);
-          GOTO_IF_ERR(err, earlyexit);
-          model_index->set_reason(std::string(reason, reasonlen));
-        }
-      }
 
-      TRITONSERVER_MessageDelete(model_index_message);
-    } else {
-      err = TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_UNSUPPORTED,
-          "'repository_name' specification is not supported");
-    }
+          const char* buffer;
+          size_t byte_size;
+          err = TRITONSERVER_MessageSerializeToJson(
+              model_index_message, &buffer, &byte_size);
+          GOTO_IF_ERR(err, earlyexit);
 
-  earlyexit:
-    GrpcStatusUtil::Create(status, err);
-    TRITONSERVER_ErrorDelete(err);
-  };
+          TritonJson::Value model_index_json;
+          err = model_index_json.Parse(buffer, byte_size);
+          GOTO_IF_ERR(err, earlyexit);
+
+          err = model_index_json.AssertType(TritonJson::ValueType::ARRAY);
+          GOTO_IF_ERR(err, earlyexit);
+
+          for (size_t idx = 0; idx < model_index_json.ArraySize(); ++idx) {
+            TritonJson::Value index_json;
+            err = model_index_json.IndexAsObject(idx, &index_json);
+            GOTO_IF_ERR(err, earlyexit);
+
+            auto model_index = response->add_models();
+
+            const char* name;
+            size_t namelen;
+            err = index_json.MemberAsString("name", &name, &namelen);
+            GOTO_IF_ERR(err, earlyexit);
+            model_index->set_name(std::string(name, namelen));
+
+            if (index_json.Find("version")) {
+              const char* version;
+              size_t versionlen;
+              err = index_json.MemberAsString("version", &version, &versionlen);
+              GOTO_IF_ERR(err, earlyexit);
+              model_index->set_version(std::string(version, versionlen));
+            }
+            if (index_json.Find("state")) {
+              const char* state;
+              size_t statelen;
+              err = index_json.MemberAsString("state", &state, &statelen);
+              GOTO_IF_ERR(err, earlyexit);
+              model_index->set_state(std::string(state, statelen));
+            }
+            if (index_json.Find("reason")) {
+              const char* reason;
+              size_t reasonlen;
+              err = index_json.MemberAsString("reason", &reason, &reasonlen);
+              GOTO_IF_ERR(err, earlyexit);
+              model_index->set_reason(std::string(reason, reasonlen));
+            }
+          }
+
+          TRITONSERVER_MessageDelete(model_index_message);
+        } else {
+          err = TRITONSERVER_ErrorNew(
+              TRITONSERVER_ERROR_UNSUPPORTED,
+              "'repository_name' specification is not supported");
+        }
+
+      earlyexit:
+        GrpcStatusUtil::Create(status, err);
+        TRITONSERVER_ErrorDelete(err);
+      };
 
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::RepositoryIndexResponse>,
@@ -1395,35 +1431,38 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterRepositoryModelLoad =
       [this](
-          grpc::ServerContext* ctx, inference::RepositoryModelLoadRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::RepositoryModelLoadResponse>*
-              responder,
+          grpc::ServerContext* ctx,
+          inference::RepositoryModelLoadRequest* request,
+          grpc::ServerAsyncResponseWriter<
+              inference::RepositoryModelLoadResponse>* responder,
           void* tag) {
         this->service_->RequestRepositoryModelLoad(
             ctx, request, responder, this->cq_, this->cq_, tag);
       };
 
-  auto OnExecuteRepositoryModelLoad = [this](
-                                          inference::RepositoryModelLoadRequest& request,
-                                          inference::RepositoryModelLoadResponse* response,
-                                          grpc::Status* status) {
-    TRITONSERVER_Error* err = nullptr;
-    if (request.repository_name().empty()) {
-      err = TRITONSERVER_ServerLoadModel(
-          tritonserver_.get(), request.model_name().c_str());
-    } else {
-      err = TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_UNSUPPORTED,
-          "'repository_name' specification is not supported");
-    }
+  auto OnExecuteRepositoryModelLoad =
+      [this](
+          inference::RepositoryModelLoadRequest& request,
+          inference::RepositoryModelLoadResponse* response,
+          grpc::Status* status) {
+        TRITONSERVER_Error* err = nullptr;
+        if (request.repository_name().empty()) {
+          err = TRITONSERVER_ServerLoadModel(
+              tritonserver_.get(), request.model_name().c_str());
+        } else {
+          err = TRITONSERVER_ErrorNew(
+              TRITONSERVER_ERROR_UNSUPPORTED,
+              "'repository_name' specification is not supported");
+        }
 
-    GrpcStatusUtil::Create(status, err);
-    TRITONSERVER_ErrorDelete(err);
-  };
+        GrpcStatusUtil::Create(status, err);
+        TRITONSERVER_ErrorDelete(err);
+      };
 
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::RepositoryModelLoadResponse>,
-      inference::RepositoryModelLoadRequest, inference::RepositoryModelLoadResponse>(
+      inference::RepositoryModelLoadRequest,
+      inference::RepositoryModelLoadResponse>(
       "RepositoryModelLoad", 0, OnRegisterRepositoryModelLoad,
       OnExecuteRepositoryModelLoad);
 
@@ -1432,9 +1471,10 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterRepositoryModelUnload =
       [this](
-          grpc::ServerContext* ctx, inference::RepositoryModelUnloadRequest* request,
-          grpc::ServerAsyncResponseWriter<inference::RepositoryModelUnloadResponse>*
-              responder,
+          grpc::ServerContext* ctx,
+          inference::RepositoryModelUnloadRequest* request,
+          grpc::ServerAsyncResponseWriter<
+              inference::RepositoryModelUnloadResponse>* responder,
           void* tag) {
         this->service_->RequestRepositoryModelUnload(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -1443,7 +1483,8 @@ CommonHandler::SetUpAllRequests()
   auto OnExecuteRepositoryModelUnload =
       [this](
           inference::RepositoryModelUnloadRequest& request,
-          inference::RepositoryModelUnloadResponse* response, grpc::Status* status) {
+          inference::RepositoryModelUnloadResponse* response,
+          grpc::Status* status) {
         TRITONSERVER_Error* err = nullptr;
         if (request.repository_name().empty()) {
           err = TRITONSERVER_ServerUnloadModel(
@@ -1460,7 +1501,8 @@ CommonHandler::SetUpAllRequests()
 
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::RepositoryModelUnloadResponse>,
-      inference::RepositoryModelUnloadRequest, inference::RepositoryModelUnloadResponse>(
+      inference::RepositoryModelUnloadRequest,
+      inference::RepositoryModelUnloadResponse>(
       "RepositoryModelUnload", 0, OnRegisterRepositoryModelUnload,
       OnExecuteRepositoryModelUnload);
 }
@@ -2288,7 +2330,8 @@ TRITONSERVER_Error*
 InferAllocatorPayload(
     const std::shared_ptr<TRITONSERVER_Server>& tritonserver,
     const std::shared_ptr<SharedMemoryManager>& shm_manager,
-    const inference::ModelInferRequest& request, std::list<std::string>&& serialized_data,
+    const inference::ModelInferRequest& request,
+    std::list<std::string>&& serialized_data,
     std::shared_ptr<ResponseQueue<ResponseType>> response_queue,
     AllocPayload<ResponseType>* alloc_payload)
 {
@@ -2306,9 +2349,9 @@ InferAllocatorPayload(
     int64_t offset;
     size_t byte_size;
     bool has_shared_memory;
-    RETURN_IF_ERR(
-        ParseSharedMemoryParams<inference::ModelInferRequest::InferRequestedOutputTensor>(
-            io, &has_shared_memory, &region_name, &offset, &byte_size));
+    RETURN_IF_ERR(ParseSharedMemoryParams<
+                  inference::ModelInferRequest::InferRequestedOutputTensor>(
+        io, &has_shared_memory, &region_name, &offset, &byte_size));
 
     bool has_classification;
     uint32_t classification_count;
@@ -2375,7 +2418,8 @@ TRITONSERVER_Error*
 InferGRPCToInput(
     const std::shared_ptr<TRITONSERVER_Server>& tritonserver,
     const std::shared_ptr<SharedMemoryManager>& shm_manager,
-    const inference::ModelInferRequest& request, std::list<std::string>* serialized_data,
+    const inference::ModelInferRequest& request,
+    std::list<std::string>* serialized_data,
     TRITONSERVER_InferenceRequest* inference_request)
 {
   // Verify that the batch-byte-size of each input matches the size of
@@ -2390,8 +2434,9 @@ InferGRPCToInput(
     std::string region_name;
     int64_t offset;
     bool has_shared_memory;
-    RETURN_IF_ERR(ParseSharedMemoryParams<inference::ModelInferRequest::InferInputTensor>(
-        io, &has_shared_memory, &region_name, &offset, &byte_size));
+    RETURN_IF_ERR(
+        ParseSharedMemoryParams<inference::ModelInferRequest::InferInputTensor>(
+            io, &has_shared_memory, &region_name, &offset, &byte_size));
 
     if (has_shared_memory) {
       if (io.has_contents()) {
@@ -3123,7 +3168,8 @@ ModelInferHandler::InferResponseComplete(
   // This callback is expected to be called exactly once for each request.
   // Will use the single response object in the response list to hold the
   // information.
-  inference::ModelInferResponse* response = state->response_queue_->GetResponseAt(0);
+  inference::ModelInferResponse* response =
+      state->response_queue_->GetResponseAt(0);
   bool response_created = false;
   if (response == nullptr) {
     LOG_ERROR << "expected allocator to have created a response object";
@@ -3181,7 +3227,8 @@ TRITONSERVER_Error*
 StreamInferResponseStart(TRITONSERVER_ResponseAllocator* allocator, void* userp)
 {
   AllocPayload<inference::ModelStreamInferResponse>* payload =
-      reinterpret_cast<AllocPayload<inference::ModelStreamInferResponse>*>(userp);
+      reinterpret_cast<AllocPayload<inference::ModelStreamInferResponse>*>(
+          userp);
 
   // Move to the next response object
   payload->response_queue_->AllocateResponse();
@@ -3198,7 +3245,8 @@ StreamInferResponseAlloc(
     int64_t* actual_memory_type_id)
 {
   AllocPayload<inference::ModelStreamInferResponse>* payload =
-      reinterpret_cast<AllocPayload<inference::ModelStreamInferResponse>*>(userp);
+      reinterpret_cast<AllocPayload<inference::ModelStreamInferResponse>*>(
+          userp);
 
   auto response = payload->response_queue_->GetLastAllocatedResponse();
 
@@ -3223,7 +3271,8 @@ class ModelStreamInferHandler
     : public InferHandler<
           inference::GRPCInferenceService::AsyncService,
           grpc::ServerAsyncReaderWriter<
-              inference::ModelStreamInferResponse, inference::ModelInferRequest>,
+              inference::ModelStreamInferResponse,
+              inference::ModelInferRequest>,
           inference::ModelInferRequest, inference::ModelStreamInferResponse> {
  public:
   ModelStreamInferHandler(

--- a/src/servers/grpc_server.h
+++ b/src/servers/grpc_server.h
@@ -99,7 +99,7 @@ class GRPCServer {
   std::unique_ptr<HandlerBase> model_infer_handler_;
   std::unique_ptr<HandlerBase> model_stream_infer_handler_;
 
-  GRPCInferenceService::AsyncService service_;
+  inference::GRPCInferenceService::AsyncService service_;
   bool running_;
 };
 


### PR DESCRIPTION
The GRPC protobuf implements the KFserving open inferencing protocols so we don't want to tie it to Triton with a package. Also use same package for the model configuration protobuf since that is used in a GRPC protocol extension.