### PR TITLE
flag to find curl package without using cmake config

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TRITON_EXTRA_LIB_PATHS "" CACHE PATH "Extra library paths for Triton Server 
 # Client
 set(TRITON_CLIENT_CMAKE_DIR "" CACHE PATH "Path to Triton client library cmake configuration")
 option(TRITON_CLIENT_SKIP_EXAMPLES "Skip building client examples" OFF)
+option(TRITON_CURL_WITHOUT_CONFIG "Find curl package without using cmake config" OFF)
 
 option(TRITON_ENABLE_LOGGING "Include logging support in server" ON)
 option(TRITON_ENABLE_STATS "Include statistics collections in server" ON)
@@ -442,6 +443,7 @@ ExternalProject_Add(client
     ${_CMAKE_TRITON_DIR}
     -DTRITON_ENABLE_METRICS:BOOL=OFF
     -DTRITON_CLIENT_SKIP_EXAMPLES:BOOL=${TRITON_CLIENT_SKIP_EXAMPLES}
+    -DTRITON_CURL_WITHOUT_CONFIG:BOOL=${TRITON_CURL_WITHOUT_CONFIG}
     -DTRITON_ENABLE_HTTP:BOOL=${TRITON_ENABLE_HTTP}
     -DTRITON_ENABLE_GRPC:BOOL=${TRITON_ENABLE_GRPC}
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/src/clients/c++/library/CMakeLists.txt
+++ b/src/clients/c++/library/CMakeLists.txt
@@ -153,7 +153,11 @@ if(${TRITON_ENABLE_HTTP})
   #
   # libhttpclient.so and libhttpclient_static.a
   #
-  find_package(CURL CONFIG REQUIRED)
+  if(${TRITON_CURL_WITHOUT_CONFIG})
+    find_package(CURL REQUIRED)
+  else()
+    find_package(CURL CONFIG REQUIRED)
+  endif() # TRITON_CURL_WITHOUT_CONFIG
   message(STATUS "Using curl ${CURL_VERSION}")
   add_definitions(-DCURL_STATICLIB)
 

--- a/src/clients/c++/library/cmake/TRITONConfig.cmake.in
+++ b/src/clients/c++/library/cmake/TRITONConfig.cmake.in
@@ -36,7 +36,11 @@ if(NOT GRPC_FOUND AND NOT gRPC_FOUND)
 endif()
 
 if(NOT CURL_FOUND)
-  find_package(CURL CONFIG REQUIRED)
+  if(${TRITON_CURL_WITHOUT_CONFIG})
+    find_package(CURL REQUIRED)
+  else()
+    find_package(CURL CONFIG REQUIRED)
+  endif() # TRITON_CURL_WITHOUT_CONFIG
 endif()
 
 if(NOT Threads_FOUND)


### PR DESCRIPTION
This PR addresses #1428.

The originally proposed solution, essentially `s/find_package(CURL CONFIG REQUIRED)/find_package(CURL REQUIRED)/`, did not retain the expected default behavior. When running the build according to https://docs.nvidia.com/deeplearning/triton-inference-server/master-user-guide/docs/build.html, CMake found the system curl, even though a newer curl was installed in the build directory.

Instead, the approach of #1846 is followed to introduce a configuration option `TRITON_CURL_WITHOUT_CONFIG`. This option is disabled by default, so the expected build behavior is preserved. This is safer, as the option should only be selected by users who know that they also need to point to the correct files/directories with `-DCURL_LIBRARY` and `-DCURL_INCLUDE_DIR`.

This change was tested in r20.07 and then rebased to master to avoid merge conflicts.