### PR TITLE
Improve the TFTRT optimization path

### DIFF
--- a/src/backends/tensorflow/tensorflow_backend_tf.cc
+++ b/src/backends/tensorflow/tensorflow_backend_tf.cc
@@ -24,7 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "trtis/tensorflow_backend_tf.h"
+#include "triton/tensorflow_backend_tf.h"
 
 #include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/cc/saved_model/tag_constants.h"
@@ -40,6 +40,7 @@
 #include "tensorflow/core/grappler/utils.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/tstring.h"
 #include "tensorflow/core/protobuf/meta_graph.pb.h"
 #include "tensorflow/core/protobuf/rewriter_config.pb.h"
 #include "tensorflow/core/public/session.h"
@@ -418,14 +419,14 @@ TensorImpl::Init()
 const std::string&
 TensorImpl::String(size_t idx) const
 {
-  auto flat = tftensor_.flat<std::string>();
+  auto flat = tftensor_.flat<tensorflow::tstring>();
   return flat(idx);
 }
 
 void
 TensorImpl::SetString(size_t idx, const std::string& str)
 {
-  auto flat = tftensor_.flat<std::string>();
+  auto flat = tftensor_.flat<tensorflow::tstring>();
   flat(idx) = str;
 }
 

--- a/src/backends/tensorflow/tensorflow_backend_tf.cc
+++ b/src/backends/tensorflow/tensorflow_backend_tf.cc
@@ -262,13 +262,16 @@ NewSessionOptions(
 
   // TF-TRT optimization. Parameters that are not specified in 'tftrt_config'
   // are specified based on:
-  // https://github.com/tensorflow/tensorflow/blob/r1.13/tensorflow/contrib/tensorrt/test/test_tftrt.py#L238
+  // https://github.com/tensorflow/tensorflow/blob/v1.15.2/tensorflow/python/compiler/tensorrt/trt_convert.py#L241
   if (tftrt_config != nullptr) {
     auto opt_config = session_options->config.mutable_graph_options()
                           ->mutable_rewrite_options();
     opt_config->set_meta_optimizer_iterations(tensorflow::RewriterConfig::ONE);
     opt_config->add_optimizers("constfold");
     opt_config->add_optimizers("layout");
+    // Layout optimizer may add Const nodes followed by Reshape nodes,
+    // thus we need to run constant folding again.
+    opt_config->add_optimizers("constfold");
     auto trt_optimizer = opt_config->add_custom_optimizers();
     trt_optimizer->set_name("TensorRTOptimizer");
 
@@ -283,6 +286,9 @@ NewSessionOptions(
         tftrt_config->max_workspace_size_bytes_);
     (*trt_parameter_map)["max_cached_engines"].set_i(
         tftrt_config->max_cached_engines_);
+    auto custom_optimizer = opt_config->add_custom_optimizers();
+    // Add a constfold optimizer to cleanup the unused Const nodes.
+    custom_optimizer->set_name("constfold");
   }
 
   if (auto_mixed_precision) {
@@ -405,8 +411,7 @@ TensorImpl::Init()
     cudaPointerAttributes attributes;
     cudaError_t err = cudaPointerGetAttributes(&attributes, nonstring_base_);
     gpu_tensor_ =
-        ((err == cudaSuccess) &&
-         (attributes.memoryType == cudaMemoryTypeDevice));
+        ((err == cudaSuccess) && (attributes.type == cudaMemoryTypeDevice));
   }
 }
 


### PR DESCRIPTION
Not running CI as the changes to this file will not show impact right away...
I am not authenticated to push to the tensorflow repository. Filing here to collect reviews.

~However, there is still the matter of some ops not getting recognized as TF-TRT Candidates for optimization purposes, but are included when the network is converted outside triton. I am waiting for TFTRT team response to understand the same.~

These changes fix the problem. I was missing one of the libraries in container. These changes improve the performance of optimized TRTEngine by **25%** as seen on `resent_v1_50_savedmodel`.

### Before

> 2020-08-05 00:21:41.520011: I tensorflow/compiler/tf2tensorrt/segment/segment.cc:486] There are 16 ops of 9 different types in the graph that are not converted to TensorRT: Softmax, Squeeze, Mean, DataFormatDimMap, Add, NoOp, Placeholder, Pad, DataFormatVecPermute, (For more information see https://docs.nvidia.com/deeplearning/frameworks/tf-trt-user-guide/index.html#supported-ops).
> tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc:633] Number of TensorRT candidate segments: 8

### After (Identical behaviour with outside triton)

> 2020-08-07 18:25:20.833243: I tensorflow/compiler/tf2tensorrt/segment/segment.cc:486] There are 4 ops of 3 different types in the graph that are not converted to TensorRT: Softmax, NoOp, Placeholder, (For more information see https://docs.nvidia.com/deeplearning/frameworks/tf-trt-user-guide/index.html#supported-ops).
> 2020-08-07 18:25:20.854810: I tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc:647] Number of TensorRT candidate segments: 1

