### PR TITLE
Advance GRPC to 1.25.0

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 ExternalProject_Add(grpc-repo
   PREFIX grpc-repo
   GIT_REPOSITORY "https://github.com/grpc/grpc.git"
-  GIT_TAG "v1.24.0"
+  GIT_TAG "v1.25.0"
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/grpc-repo/src/grpc"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
Need to advance the grpc version to 1.25.0 as [`rules_proto_grpc`](https://github.com/rules-proto-grpc/rules_proto_grpc), used for generating `*.pb.cc` and `*pb.h` files inside bazel build system doesn't have a release supporting GRPC 1.24.0.  