### PR TITLE
Expose sequence information to Backend APIs

### DIFF
--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -528,6 +528,33 @@ TRITONBACKEND_RequestCorrelationId(TRITONBACKEND_Request* request, uint64_t* id)
 }
 
 TRITONSERVER_Error*
+TRITONBACKEND_RequestStartsSequence(
+    TRITONBACKEND_Request* request, bool* starts_seq)
+{
+  InferenceRequest* tr = reinterpret_cast<InferenceRequest*>(request);
+  *starts_seq = tr->Flags() & TRITONSERVER_REQUEST_FLAG_SEQUENCE_START;
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
+TRITONBACKEND_RequestEndsSequence(
+    TRITONBACKEND_Request* request, bool* ends_seq)
+{
+  InferenceRequest* tr = reinterpret_cast<InferenceRequest*>(request);
+  *ends_seq = tr->Flags() & TRITONSERVER_REQUEST_FLAG_SEQUENCE_END;
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
+TRITONBACKEND_RequestBatchSize(
+    TRITONBACKEND_Request* request, uint32_t* batch_size)
+{
+  InferenceRequest* tr = reinterpret_cast<InferenceRequest*>(request);
+  *batch_size = tr->BatchSize();
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
 TRITONBACKEND_RequestInputCount(TRITONBACKEND_Request* request, uint32_t* count)
 {
   InferenceRequest* tr = reinterpret_cast<InferenceRequest*>(request);

--- a/src/backends/backend/tritonbackend.h
+++ b/src/backends/backend/tritonbackend.h
@@ -198,6 +198,30 @@ TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestId(
 TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestCorrelationId(
     TRITONBACKEND_Request* request, uint64_t* id);
 
+/// Check whether the request marks the start of a new sequence.
+///
+/// \param request The inference request.
+/// \param starts_seq Returns whether or not the request starts a new sequence.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestStartsSequence(
+    TRITONBACKEND_Request* request, bool* starts_seq);
+
+/// Check whether the request marks the end of a sequence.
+///
+/// \param request The inference request.
+/// \param ends_seq Returns whether or not the request ends a sequence.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestEndsSequence(
+    TRITONBACKEND_Request* request, bool* ends_seq);
+
+/// Get the batch size of the request.
+///
+/// \param request The inference request.
+/// \param batch_size Returns the batch size.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONBACKEND_EXPORT TRITONSERVER_Error* TRITONBACKEND_RequestBatchSize(
+    TRITONBACKEND_Request* request, uint32_t* batch_size);
+
 /// Get the number of input tensors specified in the request.
 ///
 /// \param request The inference request.


### PR DESCRIPTION
Some of the backends might need this information about requests for their proper handling. 
Kaldi custom backend needs this information.