### PR TITLE
Fix undefined protobuf symbols in the client shared library

### DIFF
--- a/qa/L0_client/grpc_test.cc
+++ b/qa/L0_client/grpc_test.cc
@@ -32,6 +32,8 @@ int
 main(int argc, char* argv[])
 {
   std::unique_ptr<nvic::InferenceServerGrpcClient> client;
+  // Add a symbol from protobufs to verify correct linking
+  inference::ModelConfigResponse model_config;
   nvic::InferenceServerGrpcClient::Create(&client, "localhost:8001");
   bool live;
   client->IsServerLive(&live);

--- a/src/clients/c++/library/libgrpcclient.ldscript
+++ b/src/clients/c++/library/libgrpcclient.ldscript
@@ -26,7 +26,8 @@
 {
   global:
     extern "C++" {
-      nvidia::inferenceserver*
+      nvidia::inferenceserver*;
+      inference*;
     };
   local: *;
 };


### PR DESCRIPTION
Fix the ldscript to make symbols starting with `inference::` global.